### PR TITLE
Correct blog website URL if needed

### DIFF
--- a/src/_data/members.js
+++ b/src/_data/members.js
@@ -25,6 +25,10 @@ module.exports = async function () {
         }
       );
 
+      if(response.blog && !response.blog.startsWith('http')){
+        response.blog = 'https://' + response.blog
+      }
+
       members.push(response);
     } catch (e) {
       console.warn(`Unable to read ${file}, skipping and moving on!`);

--- a/src/_data/members.js
+++ b/src/_data/members.js
@@ -26,7 +26,7 @@ module.exports = async function () {
       );
 
       if(response.blog && !response.blog.startsWith('http')){
-        response.blog = 'https://' + response.blog
+        response.blog = 'http://' + response.blog
       }
 
       members.push(response);


### PR DESCRIPTION
## Linked Issue
#32 

## Description

I added an if statement that checks whether or not the blog starts with `http` and if it doesn't add the `https://` to correct the path and allow the users blog to be accessed. 
 
## Methodology
This change was made due to some blog url's not being entered in correctly. This change should fix that. 

