### PR TITLE
KLD: Updated membercard from max-width to set width

### DIFF
--- a/src/assets/scss/_members.scss
+++ b/src/assets/scss/_members.scss
@@ -13,9 +13,10 @@
 
 .membercard {
   margin-bottom: map-get($spacers, 5);
+  width: 100%;
 
   @include media-breakpoint-up(md) {
-    max-width: 48%;
+    width: 50%;
   }
 }
 


### PR DESCRIPTION
## Linked Issue
 #41 - Layout issue with members with smaller github profile photos

## Description

Updated src/assets/css/scss/ _members.scss
- Changed max-width to width:50% for desktop
- Added width: 100% to mobile as a precaution, though not needed.

## Methodology

With a fixed width, a membercard will take up the full desired width instead of determining its width by its contents. This allows for the image to be a standard size and the social media to go all the way to the right edge.

