### PR TITLE
Feature/chg event timezone

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -29,7 +29,7 @@ module.exports = function (eleventyConfig) {
         ...defaultDateOptions,
         ...opts,
       };
-      return DateTime.fromISO(dateString).toFormat(format, resolvedOptions);
+      return DateTime.fromISO(dateString).setZone("America/New_York").toFormat(format, resolvedOptions);
     }
   );
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -19,14 +19,10 @@ module.exports = function (eleventyConfig) {
 
   eleventyConfig.addLayoutAlias('post', 'layouts/post.njk');
 
-  const defaultDateOptions = {
-    zone: 'edt',
-  };
   eleventyConfig.addFilter(
     'dateForDisplay',
     (dateString, format = 'fff', opts = {}) => {
       const resolvedOptions = {
-        ...defaultDateOptions,
         ...opts,
       };
       return DateTime.fromISO(dateString).setZone("America/New_York").toFormat(format, resolvedOptions);


### PR DESCRIPTION
## Linked Issue
Addresses issue #61 

## Description
In eleventy.js:
* Change timezone to EST/EDT in the dateForDisplay filter
* Remove defaultDateOptions variable declaration
* Remove defaultDateOptions variable reference from dateForDisplay filter

## Methodology

Explicitly set the timezone to EST/EDT for all users instead of defaulting to UTC which is the time zone that Netlify's server is set to.


