### PR TITLE
Change the layout of event cards to highlight the date in the card header and the 'Details & RSVP' in a button

### DIFF
--- a/src/events.njk
+++ b/src/events.njk
@@ -29,11 +29,13 @@ description: See our upcoming events!
     {% for event in events | head(20) %}
 
     <div class="card mb-4">
+      <a href="{{ event.url }}" class="card-header" target="_blank" rel="noopener noreferrer">{{ event.start_time | dateForDisplay }}</a>
       <div class="card-body">
         <h5 class="card-title">{{event.name}}</h5>
-        <h6 class="card-subtitle mb-2 text-muted">{{ event.start_time | dateForDisplay }}</h6>
+        {% if event.description %}
         <p class="card-text">{{ event.description | striptags(true) }}</p>
-        <a href="{{ event.url }}" class="card-link" target="_blank" rel="noopener noreferrer">Details and RSVP</a>
+        {% endif %}
+        <a href="{{ event.url }}" class="btn-sm btn btn-secondary" target="_blank" rel="noopener noreferrer">Details and RSVP</a>
       </div>
     </div>
     {% endfor %}


### PR DESCRIPTION
##  Linked Issue
Enhancement addresses issue #62

## Description

All changes were to events.njk

Enhancement changes the layout of event cards as outlined in the issue:
* Move date to card header
* Add btn, btn-sm, and btn-secondary classes to the 'Details and RSVP' link to change the display to look like a button.
* Add conditional logic to display event description only when it exists

## Methodology

Previously the date was not highlighted, but it should be because it is usually the main difference from card to card.  The new layout makes the date more prominent.
