### PR TITLE
Fix 'build-preview' command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "npx grunt start",
     "build": "ELEVENTY_ENV=production npx grunt release-prep",
     "serve": "npx grunt connect:server",
-    "build-preview": "npm build && npm serve"
+    "build-preview": "npm run build && npm run serve"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Linked Issue

Fixes #95 

## Description

I adjusted the `build-preview` script slightly:

```diff
-  "build-preview": "npm build && npm serve"
+  "build-preview": "npm run build && npm run serve"
```

## Methodology

As referred to in the issue I raised, the terminal warns the user:

```plain text
`npm build` called with no arguments. Did you mean to `npm run-script build`?
```

Per [npm's documentation](https://docs.npmjs.com/cli/v6/commands/npm-run-script), `npm run` (which is an alias for `npm run-script`) runs a command from the package's `"scripts"` object. In this case, entering `npm run build-preview` in the terminal was calling the two commands `npm build` and `npm serve`, which the CLI cannot interpret because they're both missing the `run` command. This merge will fix that.
