### PR TITLE
Fixes "VC GitHub" link on homepage

### DIFF
--- a/src/github.njk
+++ b/src/github.njk
@@ -5,6 +5,7 @@ hero: 'svg/undraw_version_control_9bpv.svg'
 homePageBlocks:
   type: small
   key: VC GitHub
+  url: https://github.com/Virtual-Coffee
   order: 4
 eleventyNavigation:
   key: GitHub

--- a/src/index.njk
+++ b/src/index.njk
@@ -35,7 +35,7 @@ eleventyNavigation:
 
     <div class="smallhomepageblocks mb-5">
       {% for pageBlock in collections.homePageBlocksSmall %}
-        <a href="{{pageBlock.url}}" class="smallhomepageblocks-item">
+        <a href="{{ pageBlock.data.eleventyNavigation.url if pageBlock.data.permalink == false else pageBlock.url }}" class="smallhomepageblocks-item">
           <div class="smallhomepageblocks-hero">
             {% include pageBlock.data.hero %}
           </div>

--- a/src/index.njk
+++ b/src/index.njk
@@ -35,7 +35,7 @@ eleventyNavigation:
 
     <div class="smallhomepageblocks mb-5">
       {% for pageBlock in collections.homePageBlocksSmall %}
-        <a href="{{ pageBlock.data.eleventyNavigation.url if pageBlock.data.permalink == false else pageBlock.url }}" class="smallhomepageblocks-item">
+        <a href="{{ pageBlock.data.homePageBlocks.url if pageBlock.data.homePageBlocks.url else pageBlock.url }}" class="smallhomepageblocks-item">
           <div class="smallhomepageblocks-hero">
             {% include pageBlock.data.hero %}
           </div>


### PR DESCRIPTION
## Linked Issue

Closes #140.

## Description

As discussed in the issue ticket, we fix the incorrect link for the GitHub repository in the "Get Involved" section. We do this by checking if `permalink: false` (not the same thing as `not permalink`), and if so, we instead use the `eleventyNavigation.url`. Testing locally, we've resolved the problem!

## Methodology

One issue I'll bring up: do we want to rely on all members of  `collections.homePageBlocksSmall` having an accompanying `data.eleventyNavigation.url` field? I initially chose this method so that I wouldn't modify `github.njk`; however, if we think that there will be future small homepage blocks that aren't parsed by the navigation module, I can instead revise this PR and add some special field to our collection. Let me know what you think!

