### PR TITLE
Make sure to use http if missing on website url

### DIFF
--- a/src/_includes/macros/members.njk
+++ b/src/_includes/macros/members.njk
@@ -2,6 +2,14 @@
   <div class="membercards">
     {% for username in membersList %}
       {% set member = memberData[username | lower] %}
+      {% set memberSite = '' %}
+        {% if member.websiteUrl %}
+
+          {% set memberSite = member.websiteUrl %}
+          {% if memberSite | truncate(4,true,'') != 'http' %}
+            {% set memberSite = 'https://' + memberSite %}
+          {% endif %}
+        {% endif %}
       <div class="membercard" id="member_{{username}}">
         <div class="membercard-img">
           <img src="{{member.avatarUrl}}" alt="{{member.name}} profile image">
@@ -10,8 +18,8 @@
         <div class="membercard-header">
 
             <h5 class="membercard-name">
-              {% if member.websiteUrl %}
-                <a href="{{member.websiteUrl}}" target="_blank" rel="noopener noreferrer">{{member.name}}</a>
+              {% if memberSite %}
+                <a href="{{memberSite}}" target="_blank" rel="noopener noreferrer">{{member.name}}</a>
               {% else %}
                 <a href="{{member.url}}" target="_blank" rel="noopener noreferrer">{{member.name}}</a>
               {% endif %}
@@ -36,9 +44,9 @@
           {% if member.bioHTML %}
             <div class="text-muted">{{member.bioHTML | safe}}</div>
           {% endif %}
-          {% if member.websiteUrl %}
+          {% if memberSite %}
             <div class="text-truncate">
-              <a href="{{member.websiteUrl}}" target="_blank" rel="noopener noreferrer">{{member.websiteUrl | replace('https://','') | replace('http://','')}}</a>
+              <a href="{{memberSite}}" target="_blank" rel="noopener noreferrer">{{memberSite | replace('https://','') | replace('http://','')}}</a>
             </div>
           {% endif %}
         </div>


### PR DESCRIPTION
If membersite was missing https on github info (`virtualcoffee.io` vs `https://virtualcoffee.io`) the link would be broken. This takes care of that.