### PR TITLE
[WIP] Feature: automate update-member-data.js script

### DIFF
--- a/.github/workflows/update-member-data.yml
+++ b/.github/workflows/update-member-data.yml
@@ -31,9 +31,13 @@ jobs:
 
       - name: Update members data
         run: yarn update-member-data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push changes in members data
         run: |
           git add src/_data/members/memberData.json
           git commit -m "GA: Update members data"
           git push 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-member-data.yml
+++ b/.github/workflows/update-member-data.yml
@@ -1,0 +1,39 @@
+name: Update Members Data
+
+# Trigger the action only when a pull_request is made to the main branch
+# when changes are commited to the members files
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+    - 'src/_data/members/members.json'
+    - 'src/_data/members/core.json'
+    - 'src/_data/members/teams.json'
+
+  # Also run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  update-member-data:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the merged source code
+      - uses: actions/checkout@v2
+
+      # Setup node v 14.x with npm and yarn
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "14.x"
+
+      - name: Install packages
+        run: yarn install
+
+      - name: Update members data
+        run: yarn update-member-data
+
+      - name: Push changes in members data
+        run: |
+          git add src/_data/members/memberData.json
+          git commit -m "GA: Update members data"
+          git push 

--- a/.github/workflows/update-member-data.yml
+++ b/.github/workflows/update-member-data.yml
@@ -53,7 +53,9 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-
+          
+          git pull
+          
           git add src/_data/members/memberData.json
           git commit -m "chore: update membersData.json after merging $PR_ID"
           git push origin main

--- a/.github/workflows/update-member-data.yml
+++ b/.github/workflows/update-member-data.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.ref }}
+          fetch-depth: 0
 
       # Setup node v 14.x with npm and yarn
       - uses: actions/setup-node@v1

--- a/.github/workflows/update-member-data.yml
+++ b/.github/workflows/update-member-data.yml
@@ -50,10 +50,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Push changes in members data
+        env:
+          PR_ID:  {{github.event.pull_request.title}} #{{github.event.pull_request.number}}
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
 
           git add src/_data/members/memberData.json
-          git commit -m "GA: Update members data"
-          git push origin ${{ github.head_ref }}
+          git commit -m "chore: update membersData.json after merging $PR_ID"
+          git push origin main

--- a/.github/workflows/update-member-data.yml
+++ b/.github/workflows/update-member-data.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       # Checkout the merged source code from PR
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       # Setup node v 14.x with npm and yarn
       - uses: actions/setup-node@v1

--- a/.github/workflows/update-member-data.yml
+++ b/.github/workflows/update-member-data.yml
@@ -27,15 +27,34 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "14.x"
+      
+      # Cache yarn node_modules (save 40 seconds)
+      # as seen in https://github.com/actions/cache/blob/main/examples.md#node---yarn
+      - run: echo "::set-output name=dir::$(yarn cache dir)"
+        id: yarn-cache-dir-path
 
+      - name: Use yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      
+      # Yarn install but prioritize the cache with --prefer-offline
       - name: Install packages
-        run: yarn install
+        run: yarn install --prefer-offline
 
       - name: Update members data
         run: yarn update-member-data
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+      
+      - run: |
+          echo "${{ github.base_ref }}"
+          echo "${{ github.head_ref }}"
+          echo "${{ github.ref }}"
+          echo "${{ github.event.pull_request.head.sha }}"
+      
       - name: Push changes in members data
         run: |
           git config user.name github-actions

--- a/.github/workflows/update-member-data.yml
+++ b/.github/workflows/update-member-data.yml
@@ -18,8 +18,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Checkout the merged source code
+      # Checkout the merged source code from PR
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # Setup node v 14.x with npm and yarn
       - uses: actions/setup-node@v1
@@ -36,8 +38,8 @@ jobs:
 
       - name: Push changes in members data
         run: |
-          git config --global user.email "bogcov@gmail.com"
-          git config --global user.name "GitHub Actions"
+          git config user.name github-actions
+          git config user.email github-actions@github.com
 
           git add src/_data/members/memberData.json
           git commit -m "GA: Update members data"

--- a/.github/workflows/update-member-data.yml
+++ b/.github/workflows/update-member-data.yml
@@ -51,7 +51,7 @@ jobs:
       
       - name: Push changes in members data
         env:
-          PR_ID:  {{github.event.pull_request.title}} #{{github.event.pull_request.number}}
+          PR_ID:  ${{github.event.pull_request.title}} \#${{github.event.pull_request.number}}
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/.github/workflows/update-member-data.yml
+++ b/.github/workflows/update-member-data.yml
@@ -43,4 +43,4 @@ jobs:
 
           git add src/_data/members/memberData.json
           git commit -m "GA: Update members data"
-          git push origin ${{ github.base_ref }}
+          git push origin ${{ github.ref }}

--- a/.github/workflows/update-member-data.yml
+++ b/.github/workflows/update-member-data.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       # Checkout the merged source code from PR
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
 
       # Setup node v 14.x with npm and yarn
       - uses: actions/setup-node@v1

--- a/.github/workflows/update-member-data.yml
+++ b/.github/workflows/update-member-data.yml
@@ -36,8 +36,9 @@ jobs:
 
       - name: Push changes in members data
         run: |
+          git config --global user.email "bogcov@gmail.com"
+          git config --global user.name "GitHub Actions"
+
           git add src/_data/members/memberData.json
           git commit -m "GA: Update members data"
           git push 
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-member-data.yml
+++ b/.github/workflows/update-member-data.yml
@@ -43,4 +43,4 @@ jobs:
 
           git add src/_data/members/memberData.json
           git commit -m "GA: Update members data"
-          git push origin HEAD:${{ github.event.pull_request.head.sha }}
+          git push origin ${{ github.base_ref }}

--- a/.github/workflows/update-member-data.yml
+++ b/.github/workflows/update-member-data.yml
@@ -49,12 +49,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
-      - run: |
-          echo "${{ github.base_ref }}"
-          echo "${{ github.head_ref }}"
-          echo "${{ github.ref }}"
-          echo "${{ github.event.pull_request.head.sha }}"
-      
       - name: Push changes in members data
         run: |
           git config user.name github-actions
@@ -62,4 +56,4 @@ jobs:
 
           git add src/_data/members/memberData.json
           git commit -m "GA: Update members data"
-          git push origin ${{ github.ref }}
+          git push origin ${{ github.head_ref }}

--- a/.github/workflows/update-member-data.yml
+++ b/.github/workflows/update-member-data.yml
@@ -43,4 +43,4 @@ jobs:
 
           git add src/_data/members/memberData.json
           git commit -m "GA: Update members data"
-          git push 
+          git push origin HEAD:${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Linked Issue

Issue #208 about automating the update of members data. 

## Description

As suggested by @rhdeck, the workflow does the following:

- Gets triggered on PRs on main, when changes are done to the member files
https://github.com/Virtual-Coffee/virtualcoffee.io/blob/5d51a10103485b4c2938c4d59d0fa386edea1dc7/.github/workflows/update-member-data.yml#L5-L11

- Yarn install & cache `node_modules`. Saves about 40s, but the cache gets deleted if is not accessed for 7 days 
https://github.com/Virtual-Coffee/virtualcoffee.io/blob/5d51a10103485b4c2938c4d59d0fa386edea1dc7/.github/workflows/update-member-data.yml#L31-L45

- Runs `scripts/update-member-data.js` with the `secrets.GITHUB_TOKEN` token and commits `memberData.json` 
https://github.com/Virtual-Coffee/virtualcoffee.io/blob/5d51a10103485b4c2938c4d59d0fa386edea1dc7/.github/workflows/update-member-data.yml#L47-L59

## WIP TODOs

At the moment, the checkout/push refs are messed up. Trying to find the right refs to checkout the PR branch (so the `members.js` changes are checked out) and to push back the `membersData.json` changes into the PR

Relevant GitHub Actions context variables: `github.base_ref`, `github.head_ref`, `github.ref` as in https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context

To be looked into: `pull_request` refs as in https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request