### PR TITLE
Added LinkedIn account to Member Bio

### DIFF
--- a/src/_data/members/members/rek990.js
+++ b/src/_data/members/members/rek990.js
@@ -16,7 +16,7 @@ module.exports = {
   //
   // can take  one of each type except website - you can add as many `website` accounts as you wish
   accounts: [
-    // { type: 'linkedin', username: 'yourlinkedinUserName' },
+    { type: 'linkedin', username: 'rebecca-key' },
     // { type: 'dev', username: 'yourUserName' },
     // { type: 'codenewbie', username: 'yourUserName' },
     // { type: 'twitter', username: 'yourUserName' },


### PR DESCRIPTION
## Linked Issue

#13

## Description

This PR reflects the addition of my (Rebecca Key) LinkedIn profile page to my Member Bio on virtualcoffee.io/members/. This was accomplished by replacing `yourlinkedinUserName` with `rebecca-key` within the `accounts` array. My LinkedIn profile successfully rendered when testing the Member page locally.

## Methodology

My LinkedIn account was added such that my profile is more readily accessible within the community.

