### PR TITLE
Adding end of challenge message for sep 2021 file

### DIFF
--- a/src/monthlychallenges/sept-2021/index.njk
+++ b/src/monthlychallenges/sept-2021/index.njk
@@ -6,6 +6,9 @@ date: 2021-09-01
 tags: monthlychallenges 
 ---
 
+<div class="alert alert-success">
+  This monthly challenge is complete. Congratulations! Please join us for the <a href="/monthlychallenges/oct-2021/">next challenge</a>!
+</div>
 
 <h1>
   <small>Monthly Challenge for September, 2021:</small>


### PR DESCRIPTION
## Linked Issue

- #346 

## Description
Adding the end of challenge message to the September 2021 monthly challenge page.

## Methodology
This message will appear at the top of the page where users can click on the next challenge link to go to the new monthly challenge page. 

