### PR TITLE
delete extra li and href to fix Voyagger link

### DIFF
--- a/src/monthlychallenges/oct-2021/index.njk
+++ b/src/monthlychallenges/oct-2021/index.njk
@@ -128,7 +128,7 @@ tags: monthlychallenges
 <li><h3><a href="https://github.com/forem/forem">Forem</a></h3>
 <p> Forem is open source software for building communities</p>
 <p><strong>Maintainer</strong>: Nick Taylor</p></li>
-<li><h3><a href="li><a href="https://github.com/avneesh0612/voyagger">Voyagger</a></h3>
+<li><h3><a href="https://github.com/avneesh0612/voyagger">Voyagger</a></h3>
 <p> A hassle-free delivery service. These tough times have made us all aware of the importance of our loved ones and through this app, users can bring a smile to their family and friends' faces by sending them their favorite delicacy, medicines, or a simple heartfelt gift.</p>
 <p><strong>Maintainer</strong>: Abderrahim Ben</p></li>
 <li><h3><a href="https://github.com/open-sauced/open-sauced">Open Sauced</a></h3>


### PR DESCRIPTION
## Linked Issue

Closes #413 

## Description

Small repeat ```a``` and ```li``` tag caused a broken link. 

<img width="1206" alt="Screen Shot 2021-10-05 at 10 56 00 AM" src="https://user-images.githubusercontent.com/25398021/136078928-36f34b2a-d758-4a2d-b9d6-53cd995d1327.png">


## Methodology

Deleted extra code, tested changes on localhost, and matched other links in that section. 

