### PR TITLE
Bug: update URLs on About Virtual Coffee page

### DIFF
--- a/src/about.md
+++ b/src/about.md
@@ -50,4 +50,4 @@ We welcome and support developers at all stages to create a more empathetic tech
 
 To become a member of Virtual Coffee, all you need to do is <a href="/events">attend a Tuesday or Thursday Coffee</a> and submit the form you'll receive at coffee. We absolutely love the closeness of this community and know it’s one of the many things that sets us apart. This closeness starts with those coffees.
 
-You can find out more about our community and what we offer in our <a href="/https://virtualcoffee.io/member-resources/">Member Resources section</a>.
+You can find out more about our community and what we offer in our <a href="/resources/virtual-coffee">Member Resources section</a>.


### PR DESCRIPTION
## Linked Issue

No linked issue. Spotted the broken URL and set up the PR. No issue recorded with this issue.

## Description

Fixed the broken URL on the [About Virtual Coffee](https://virtualcoffee.io/about/) page, that links to the [Virtual Coffee Member Resources](https://virtualcoffee.io/resources/virtual-coffee/) page. 

The tag `<a href="/https://virtualcoffee.io/member-resources/">Member Resources section</a>` is currently redirecting to `https://virtualcoffee.io/https://virtualcoffee.io/member-resources/`. 

https://github.com/Virtual-Coffee/virtualcoffee.io/blob/4994d308bfe29b02c839aa77183da77127b1d3b1/src/about.md#L55

Changed it to redirect to `https://virtualcoffee.io/resources/virtual-coffee/`, the real [Virtual Coffee Member Resources](https://virtualcoffee.io/resources/virtual-coffee/) page. 

https://github.com/Virtual-Coffee/virtualcoffee.io/blob/4f1611f7f065570ea6789120c89c4147929f7e33/src/about.md#L53

## Methodology 

![Cat typing on a computer](https://media.giphy.com/media/unQ3IJU2RG7DO/giphy.gif)