### PR TITLE
Vscode settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-	"recommendations": ["esbenp.prettier-vscode"]
+	"recommendations": ["esbenp.prettier-vscode", "ronnidc.nunjucks"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,11 +10,13 @@
 	"[javascript]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode"
 	},
-	// JSON with Comments
 	"[jsonc]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode"
 	},
 	"[json]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"[nunjucks]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode"
 	}
 }


### PR DESCRIPTION
## Linked Issue

#411 

## Description

Adds a simple, minimalist `.vscode` directory with settings.json and extensions.json to make writing code more delightful ❤️ 

### `.vscode/extensions.json`
Prompts VSCode user to install prettier extension if not already installed: 
```json
{
	"recommendations": ["esbenp.prettier-vscode"]
}
```

### `.vscode/settings.json`

  - EDIT: Removed formatOnSave from settings as [Nick indicated it should be a user option](https://github.com/Virtual-Coffee/virtualcoffee.io/issues/411#issuecomment-942697660).
  - Brings syntax highlighting to `.njk` files
  - Ensures prettier is the default formatter onSave, since it *is* the default formatter on commit, anyways.

```json
{
	"files.associations": {
		"*.html": "html",
		"*.njk": "html",
		"*.js": "javascript"
	},
	"[html]": {
		"editor.defaultFormatter": "esbenp.prettier-vscode"
	},
	"[javascript]": {
		"editor.defaultFormatter": "esbenp.prettier-vscode"
	},
	"[jsonc]": {
		"editor.defaultFormatter": "esbenp.prettier-vscode"
	},
	"[json]": {
		"editor.defaultFormatter": "esbenp.prettier-vscode"
	}
}
```