### PR TITLE
Accessibility edits to smaller supporter avatars (issue #433)

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -189,7 +189,7 @@ eleventyNavigation:
 				>
 					<img
 						src="{{supporter.avatarUrl_80}}"
-						alt="{{supporter.name or support.logo}}"
+						alt="{{supporter.name or supporter.login}}"
 						width="240"
 						height="240"
 						loading="lazy"


### PR DESCRIPTION
## Linked Issue

#433 Improve accessibility of the smaller Supporters avatars. Closes #433 

## Description

### Fixes:  

Removes `title="..."` from `<a>`
Changes `alt` on profile image to `alt="{{supporter.name or supporter.login}}"` (remove " profile image")
Adds`aria-hidden="true"` to the `svg` element

@danieltott opened the issue, please close the issue if the PR looks good to you.

## Methodology

For keyboard users and users of assistive technology to navigate through the sponsors area better and that screen readers can read back the images better to disabled users who use screen readers.

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)
