### PR TITLE
Reword membership profile template for clarity

### DIFF
--- a/src/_data/members/core/bekahhw.js
+++ b/src/_data/members/core/bekahhw.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'bekahhw',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'bekah-hawrot-weigel' },
 		{ type: 'dev', username: 'bekahhw' },
 		{ type: 'codenewbie', username: 'bekahhw' },
 		{ type: 'twitter', username: 'bekahhw' },
 		{ type: 'twitch', username: 'bekahhw' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		{ type: 'polywork', username: 'bekahhw' },
 		// { type: 'hashnode', username: 'yourUserName' },
 		{

--- a/src/_data/members/core/danieltott.js
+++ b/src/_data/members/core/danieltott.js
@@ -1,21 +1,31 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'danieltott',
 	//
-	// everything below here is optional.
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name: if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Dan Ott',
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	//
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	mainUrl: 'https://www.dtott.com',
-	// bio - accepts markdown.
+	//
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	bio: `Independent front-end designer and developer, father, #ADHD person, and Clevelander.
 
   He/him`,
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	//
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
+		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		{ type: 'dev', username: 'danieltott' },
+		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'danieltott' },
+		// { type: 'twitch', username: 'yourUserName' },
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		{ type: 'polywork', username: 'danieltott' },
+		// { type: 'medium', username: 'yourUserName' },
+		// { type: 'hashnode', username: 'yourUserName' },
+		// { type: 'website', url: 'https://virtualcoffee.io', title: 'Title of link' },
 	],
 };

--- a/src/_data/members/core/saramccombs.js
+++ b/src/_data/members/core/saramccombs.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'saramccombs',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/core/tkshill.js
+++ b/src/_data/members/core/tkshill.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'tkshill',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/AlexVCS.js
+++ b/src/_data/members/members/AlexVCS.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'AlexVCS',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/AmyShackles.js
+++ b/src/_data/members/members/AmyShackles.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'AmyShackles',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/BogDAAAMN.js
+++ b/src/_data/members/members/BogDAAAMN.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'BogDAAAMN',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/CassidyMountjoy.js
+++ b/src/_data/members/members/CassidyMountjoy.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'CassidyMountjoy',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Cassidy Mountjoy',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	mainUrl: 'https://cassidymountjoy.com/',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	bio: `Entrepreneur and database developer [@Blockpoint](https://blockpointdb.com/), avid surfer and enjoyer of the outdoors`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'cassidymountjoy' },
 		{ type: 'dev', username: 'cassidymountjoy' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'CptnMountjoy' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/Cerchie.js
+++ b/src/_data/members/members/Cerchie.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'Cerchie',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/ChadStewart.js
+++ b/src/_data/members/members/ChadStewart.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'ChadStewart',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/ClJarvis.js
+++ b/src/_data/members/members/ClJarvis.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'ClJarvis',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		{ type: 'dev', username: 'jarvisscript' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'JarvisScript' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		{ type: 'polywork', username: 'chrisjarvis' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/CuriousCurmudgeon.js
+++ b/src/_data/members/members/CuriousCurmudgeon.js
@@ -1,28 +1,27 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'CuriousCurmudgeon',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Brian Meeker',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	mainUrl: 'https://brianmeeker.me/',
 	//
-	// bio - accepts markdown. Please keep your bio to a reasonable length, refer to
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples. Please keep your bio to a reasonable length, refer to
 	// [members page](https://virtualcoffee.io/members/) for examples
 	bio: `Ceremonial Director of Engineering | Full Stack Engineer | Lover of Systems`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'brianmeeker' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'CuriousCurmudge' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/Dana94.js
+++ b/src/_data/members/members/Dana94.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'Dana94',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/LSanchez17.js
+++ b/src/_data/members/members/LSanchez17.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'LSanchez17',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/LeoUCon.js
+++ b/src/_data/members/members/LeoUCon.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'LeoUCon',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/LincolnFleet.js
+++ b/src/_data/members/members/LincolnFleet.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'LincolnFleet',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/Lor1138.js
+++ b/src/_data/members/members/Lor1138.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'Lor1138',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/MattyMc.js
+++ b/src/_data/members/members/MattyMc.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'MattyMc',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'mattmcinnis' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'MattLovesMath' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/SuzeShardlow.js
+++ b/src/_data/members/members/SuzeShardlow.js
@@ -1,28 +1,27 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'SuzeShardlow',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	mainUrl: 'https://suze.dev',
 	//
-	// bio - accepts markdown. Please keep your bio to a reasonable length, refer to
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples. Please keep your bio to a reasonable length, refer to
 	// [members page](https://virtualcoffee.io/members/) for examples
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'SuzeShardlow' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'SuzeShardlow' },
 		{ type: 'twitch', username: 'SuzeShardlow' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		{ type: 'polywork', username: 'Suze' },
 		{ type: 'medium', username: '@SuzeShardlow' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/YolandaHaynes.js
+++ b/src/_data/members/members/YolandaHaynes.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'YolandaHaynes',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'yolanda-haynes' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: '_YolandaHaynes' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		{ type: 'polywork', username: 'yhaynes' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/ZenMnky.js
+++ b/src/_data/members/members/ZenMnky.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'ZenMnky',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/_EXAMPLE.js
+++ b/src/_data/members/members/_EXAMPLE.js
@@ -1,28 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'yourGitHubUserName',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown. Please keep your bio to a reasonable length, refer to
-	// [members page](https://virtualcoffee.io/members/) for examples
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/abbeyperini.js
+++ b/src/_data/members/members/abbeyperini.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'abbeyperini',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	mainUrl: 'https://abbeyperini.dev',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	bio: `A full-stack web developer, crafter, blogger, fiber artist, cosplayer, yoga teacher, and gamer with years of recruiting industry experience.`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'abigail-perini' },
 		{ type: 'dev', username: 'abbeyperini' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'abbeyperini' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		{ type: 'polywork', username: 'abbeyperini' },
 		{ type: 'medium', username: 'abbeyperini' },
 		{ type: 'hashnode', username: 'abbeyperini' },

--- a/src/_data/members/members/abuna1985.js
+++ b/src/_data/members/members/abuna1985.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'abuna1985',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/adiati98.js
+++ b/src/_data/members/members/adiati98.js
@@ -1,36 +1,31 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'adiati98',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	name: 'Ayu Adiati',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
 	mainUrl: 'https://adiati.com',
-	// bio - accepts markdown.
+	//
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
-		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		{ type: 'linkedin', username: 'adiatiayu' },
-		// { type: 'dev', username: 'yourUserName' },
 		{ type: 'dev', username: 'adiatiayu' },
-		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'codenewbie', username: 'adiatiayu' },
-		// { type: 'twitter', username: 'yourUserName' },
 		{ type: 'twitter', username: 'AdiatiAyu' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		{ type: 'polywork', username: 'adiatiayu' },
 		// { type: 'medium', username: 'yourUserName' },
-		// { type: 'hashnode', username: 'yourUserName' },
 		{ type: 'hashnode', username: 'ayuadiati' },
 		// { type: 'website', url: 'https://virtualcoffee.io', title: 'Title of link' },
 	],

--- a/src/_data/members/members/ajoseaishat.js
+++ b/src/_data/members/members/ajoseaishat.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'ajoseaishat',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/alvarosanchez.js
+++ b/src/_data/members/members/alvarosanchez.js
@@ -1,29 +1,28 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'raykotab',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Álvaro Sánchez Taboada',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown. Please keep your bio to a reasonable length, refer to
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples. Please keep your bio to a reasonable length, refer to
 	// [members page](https://virtualcoffee.io/members/) for examples
-	bio: `junior front-end, bass player, learning, 
+	bio: `junior front-end, bass player, learning,
 	 communicating and bike riding.`,
-
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	//
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'taboada7' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/andreamartz.js
+++ b/src/_data/members/members/andreamartz.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'andreamartz',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Andrea Martz',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://andreamartz.dev/',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	bio: `Full-stack dev | Avid learner | Passionate about education and equity & using tech to make it happen`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'andreamartz' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'amartzcoder' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/arvinf07.js
+++ b/src/_data/members/members/arvinf07.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'arvinf07',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'arvin-fernandez' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'arvinf07arvin' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		{ type: 'medium', username: 'arvinf07' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/aureliefomum.js
+++ b/src/_data/members/members/aureliefomum.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'aureliefomum',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/aurelieverrot.js
+++ b/src/_data/members/members/aurelieverrot.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'aurelieverrot',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/avinashupadhya99.js
+++ b/src/_data/members/members/avinashupadhya99.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'avinashupadhya99',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Avinash Upadhyaya',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	bio: `DevOps Engineer who loves most things Cloud Native. Love tinkering with new tech and meeting new folks!`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'avinash-upadhyaya' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'avinash_ukr' },
 		{ type: 'twitch', username: 'avinashupadhyaya' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		{ type: 'polywork', username: 'avinashupadhya99' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/awildstone.js
+++ b/src/_data/members/members/awildstone.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'awildstone',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/barbaralaw.js
+++ b/src/_data/members/members/barbaralaw.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'barbaralaw',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/bjorkypie.js
+++ b/src/_data/members/members/bjorkypie.js
@@ -1,28 +1,27 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'bjorkypie',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Madeline Hassett',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown. Please keep your bio to a reasonable length, refer to
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples. Please keep your bio to a reasonable length, refer to
 	// [members page](https://virtualcoffee.io/members/) for examples
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'madelinehassett' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		{ type: 'polywork', username: 'madeline_h' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/bmeverett.js
+++ b/src/_data/members/members/bmeverett.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'bmeverett',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/brandonbrown4792.js
+++ b/src/_data/members/members/brandonbrown4792.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'brandonbrown4792',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/c0der4t.js
+++ b/src/_data/members/members/c0der4t.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'c0der4t',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/cafloyd.js
+++ b/src/_data/members/members/cafloyd.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'cafloyd',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/calendee.js
+++ b/src/_data/members/members/calendee.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'calendee',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/cassiel257.js
+++ b/src/_data/members/members/cassiel257.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'cassiel257',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Tiffany Udoh',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'tiffanyudoh' },
 		{ type: 'dev', username: 'cassiel257' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		{ type: 'polywork', username: 'tiffany_u' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/chaos986.js
+++ b/src/_data/members/members/chaos986.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'chaos986',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/chrismjohnston.js
+++ b/src/_data/members/members/chrismjohnston.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'chrismjohnston',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/clandau.js
+++ b/src/_data/members/members/clandau.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'clandau',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/crisbnp.js
+++ b/src/_data/members/members/crisbnp.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'crisbnp',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/crislanarafael.js
+++ b/src/_data/members/members/crislanarafael.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'crislanarafael',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	mainUrl: 'https://crislanarafael.com',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'crislana-rafael' },
 		{ type: 'dev', username: 'crislanarafael' },
 		{ type: 'codenewbie', username: 'crislanarafael' },
 		{ type: 'twitter', username: 'CrislanaRafael' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		{ type: 'polywork', username: 'crislana_rafael' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/danielcobo.js
+++ b/src/_data/members/members/danielcobo.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'danielcobo',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/danieljanderson.js
+++ b/src/_data/members/members/danieljanderson.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'danieljanderson',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'danieljamesanderson' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/danieluhl.js
+++ b/src/_data/members/members/danieluhl.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'danieluhl',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/davidalpert.js
+++ b/src/_data/members/members/davidalpert.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'davidalpert',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/debrakayeelliott.js
+++ b/src/_data/members/members/debrakayeelliott.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'debrakayeelliott',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/doleraj.js
+++ b/src/_data/members/members/doleraj.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'doleraj',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/dominicduffin1.js
+++ b/src/_data/members/members/dominicduffin1.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'dominicduffin1',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/eclectic-coding.js
+++ b/src/_data/members/members/eclectic-coding.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'eclectic-coding',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/ehilst515.js
+++ b/src/_data/members/members/ehilst515.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'ehilst515',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/fatima-ola.js
+++ b/src/_data/members/members/fatima-ola.js
@@ -1,28 +1,27 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'fatima-ola',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Fatima Olasunkanmi-Ojo',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	mainUrl: 'https://fatimaolasunkanmi.netlify.app/',
 	//
-	// bio - accepts markdown. Please keep your bio to a reasonable length, refer to
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples. Please keep your bio to a reasonable length, refer to
 	// [members page](https://virtualcoffee.io/members/) for examples
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'fatima-olasunkanmi-ojo' },
 		//{ type: 'dev', username: 'yourUserName' },
 		//{ type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'fatima_ola1' },
 		//{ type: 'twitch', username: 'yourUserName' },
-		//{ type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		//{ type: 'polywork', username: 'yourUserName' },
 		{ type: 'medium', username: 'fatima-ola' },
 		{ type: 'hashnode', username: 'fatima-ola' },

--- a/src/_data/members/members/gantman.js
+++ b/src/_data/members/members/gantman.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'gantman',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/gervanna.js
+++ b/src/_data/members/members/gervanna.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'gervanna',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/healeyb.js
+++ b/src/_data/members/members/healeyb.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'healeyb',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/jamesrascal.js
+++ b/src/_data/members/members/jamesrascal.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'jamesrascal',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/jdwilkin4.js
+++ b/src/_data/members/members/jdwilkin4.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'jdwilkin4',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'jessica-wilkins-developer' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'codergirl1991' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/jenkens-dev.js
+++ b/src/_data/members/members/jenkens-dev.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'jenkens-dev',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'jenkens' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/jonathanyeong.js
+++ b/src/_data/members/members/jonathanyeong.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'jonathanyeong',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/juliaseid.js
+++ b/src/_data/members/members/juliaseid.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'juliaseid',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/kfairris.js
+++ b/src/_data/members/members/kfairris.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'kfairris',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/kldickenson.js
+++ b/src/_data/members/members/kldickenson.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'kldickenson',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/lennox-codes.js
+++ b/src/_data/members/members/lennox-codes.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'lennox-codes',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/loganom.js
+++ b/src/_data/members/members/loganom.js
@@ -1,28 +1,28 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'loganom',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Logan McCamon',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: '',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	bio: `Team Lead | Software Engineer with a data driven mindset and a passion for problem solving
-    
+
     He/Him`,
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	//
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'logan-mccamon' },
 		{ type: 'dev', username: 'loganom' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'LoganMcCamon' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/lohityarra.js
+++ b/src/_data/members/members/lohityarra.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'lohityarra',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Lohit Yarra',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'lohityarra' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/lsparlin.js
+++ b/src/_data/members/members/lsparlin.js
@@ -1,21 +1,30 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'lsparlin',
-
 	//
-	// everything below here is optional.
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Lewis Sparlin',
-
-	// bio - accepts markdown.
+	//
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
+	//
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	bio: `Full Stack Developer 💻
   Rails | Javascript | Lifetime learner | Loves ☕️
   `,
+	//
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
-		{ type: 'dev', username: 'lsparlin' },
-		{ type: 'twitter', username: 'lewis_sparlin' },
-		{ type: 'polywork', username: 'lsparlin' },
 		{ type: 'linkedin', username: 'lewis-sparlin-b0b7786a' },
+		{ type: 'dev', username: 'lsparlin' },
+		// { type: 'codenewbie', username: 'yourUserName' },
+		{ type: 'twitter', username: 'lewis_sparlin' },
+		// { type: 'twitch', username: 'yourUserName' },
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
+		{ type: 'polywork', username: 'lsparlin' },
+		// { type: 'medium', username: 'yourUserName' },
+		// { type: 'hashnode', username: 'yourUserName' },
 		{ type: 'website', url: 'https://lewismsparlin.com' },
 	],
 };

--- a/src/_data/members/members/magsol.js
+++ b/src/_data/members/members/magsol.js
@@ -1,28 +1,27 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'magsol',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Shannon Quinn',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	mainUrl: 'https://magsol.github.io',
 	//
-	// bio - accepts markdown. Please keep your bio to a reasonable length, refer to
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples. Please keep your bio to a reasonable length, refer to
 	// [members page](https://virtualcoffee.io/members/) for examples
 	bio: 'Academic, Data Scientist, Runner, Donut-eater',
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'shannonpquinn' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'SpectralFilter' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/matthew-dean.js
+++ b/src/_data/members/members/matthew-dean.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'matthew-dean',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/maylenepoulsen.js
+++ b/src/_data/members/members/maylenepoulsen.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'maylenepoulsen',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/mccurcio.js
+++ b/src/_data/members/members/mccurcio.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'mccurcio',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Matthew Curcio',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	bio: `Scientist, Biochemist & Educator`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'mattcurcio' },
 		{ type: 'dev', username: 'mccurcio' },
 		{ type: 'codenewbie', username: 'mccurcio' },
 		{ type: 'twitter', username: '@oaxacamatt1' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/meg-gutshall.js
+++ b/src/_data/members/members/meg-gutshall.js
@@ -1,20 +1,19 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'meg-gutshall',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Meg Gutshall',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'meghan-gutshall' },
 		{ type: 'dev', username: 'meg_gutshall' },
@@ -25,6 +24,10 @@ module.exports = {
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },
-		{ type: 'website', url: 'https://meghangutshall.com/blog/', title: 'My Digital Garden' },
+		{
+			type: 'website',
+			url: 'https://meghangutshall.com/blog/',
+			title: 'My Digital Garden',
+		},
 	],
 };

--- a/src/_data/members/members/mikerogers0.js
+++ b/src/_data/members/members/mikerogers0.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'mikerogers0',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/mikerogers0.js
+++ b/src/_data/members/members/mikerogers0.js
@@ -16,14 +16,18 @@ module.exports = {
 	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
-		// { type: 'dev', username: 'yourUserName' },
+		{ type: 'dev', username: 'mikerogers0' },
 		// { type: 'codenewbie', username: 'yourUserName' },
-		// { type: 'twitter', username: 'yourUserName' },
+		{ type: 'twitter', username: 'MikeRogers0' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
+		{ type: 'youtube', customUrl: 'https://www.youtube.com/c/MikeRogers0' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },
-		// { type: 'website', url: 'https://virtualcoffee.io', title: 'Title of link' },
+		{
+			type: 'website',
+			url: 'https://mikerogers.io/',
+			title: 'Ruby Developer | Mike Rogers',
+		},
 	],
 };

--- a/src/_data/members/members/mrsantons.js
+++ b/src/_data/members/members/mrsantons.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'mrsantons',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/mtfoley.js
+++ b/src/_data/members/members/mtfoley.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'mtfoley',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Matthew Foley',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		{ type: 'dev', username: 'mtfoley' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'MatthewTFoley' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		{ type: 'polywork', username: 'mtfoley' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/needcaffeine.js
+++ b/src/_data/members/members/needcaffeine.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'needcaffeine',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/nerajno.js
+++ b/src/_data/members/members/nerajno.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'nerajno',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'nerando-johnson' },
 		{ type: 'dev', username: 'nerajno' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'Nerajno' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/nickytonline.js
+++ b/src/_data/members/members/nickytonline.js
@@ -1,20 +1,19 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'nickytonline',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Nick Taylor',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	mainUrl: 'https://iamdeveloper.com',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourUserName' },
 		{ type: 'dev', username: 'nickytonline' },

--- a/src/_data/members/members/nicoolel.js
+++ b/src/_data/members/members/nicoolel.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'nicoolel',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'nicolelee-11' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'NicoleLeeDev' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/norafergany.js
+++ b/src/_data/members/members/norafergany.js
@@ -1,28 +1,27 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'norafergany',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown. Please keep your bio to a reasonable length, refer to
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples. Please keep your bio to a reasonable length, refer to
 	// [members page](https://virtualcoffee.io/members/) for examples
 	bio: `Full Stack Developer`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'norafergany' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'norafergany' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/ntinosng.js
+++ b/src/_data/members/members/ntinosng.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'ntinosng',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/pedaars.js
+++ b/src/_data/members/members/pedaars.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'pedaars',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/redapy.js
+++ b/src/_data/members/members/redapy.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'redapy',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/regromrob.js
+++ b/src/_data/members/members/regromrob.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'regromrob',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Regina Robinson',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'reginaromae' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/rek990.js
+++ b/src/_data/members/members/rek990.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'rek990',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'rebecca-key' },
 		{ type: 'dev', username: 'rek990' },
 		{ type: 'codenewbie', username: 'rek990' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/rreiso.js
+++ b/src/_data/members/members/rreiso.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'RReiso',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Ruta R',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	bio: `Ruby on Rails developer`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'ruta-reisoglu' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'rreisoh' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/s-blais.js
+++ b/src/_data/members/members/s-blais.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 's-blais',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/sadiejay.js
+++ b/src/_data/members/members/sadiejay.js
@@ -1,17 +1,16 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'sadiejay',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	bio: `I'm a freelance writer with a background in front-end web development and digital communication. 😄 Pronouns: she / her.`,
 	//   bio: `# Hi there, I'm Sadie ✨
 
@@ -28,14 +27,14 @@ module.exports = {
 	// - 🔲 Securing freelance, contract or part-time work
 	// - 🔲 Remote jobs only please!`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/secondl1ght.js
+++ b/src/_data/members/members/secondl1ght.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'secondl1ght',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	mainUrl: 'https://secondl1ght.site',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		{ type: 'dev', username: 'secondl1ght' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'secondl1ght' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		{ type: 'polywork', username: 'secondl1ght' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/sethburtonhall.js
+++ b/src/_data/members/members/sethburtonhall.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'sethburtonhall',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/shaylalewis.js
+++ b/src/_data/members/members/shaylalewis.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'shaylalewis',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Shayla',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/shelleymcq.js
+++ b/src/_data/members/members/shelleymcq.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'shelleymcq',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Shelley McHardy',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/shiftyp.js
+++ b/src/_data/members/members/shiftyp.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'shiftyp',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/simonprickett.js
+++ b/src/_data/members/members/simonprickett.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'simonprickett',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/sirohub.js
+++ b/src/_data/members/members/sirohub.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'sirohub',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/spike.js
+++ b/src/_data/members/members/spike.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'superspike7',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Spike Vinz Cruz',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'spikevinz' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'sspikeyy' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/surajrpanchal.js
+++ b/src/_data/members/members/surajrpanchal.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'surajrpanchal',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/tamihughes.js
+++ b/src/_data/members/members/tamihughes.js
@@ -1,28 +1,27 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'tamsauce',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Tami Hughes',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown. Please keep your bio to a reasonable length, refer to
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples. Please keep your bio to a reasonable length, refer to
 	// [members page](https://virtualcoffee.io/members/) for examples
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'tamsauce' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'tamsaucce' },
 		{ type: 'twitch', username: 'tamsauce' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		{ type: 'polywork', username: 'tamsauce' },
 		// { type: 'medium', username: 'yourUserName' },
 		{ type: 'hashnode', username: 'tamsauce' },

--- a/src/_data/members/members/teezzan.js
+++ b/src/_data/members/members/teezzan.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'teezzan',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	name: 'Taiwo Yusuf',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'yusuf-hassan' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'TaiwoHY' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		{ type: 'polywork', username: 'taiwohy' },
 		// { type: 'medium', username: 'yourUserName' },
 		{ type: 'hashnode', username: 'TaiwoHY' },

--- a/src/_data/members/members/thacherhussain.js
+++ b/src/_data/members/members/thacherhussain.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'thacherhussain',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		{ type: 'twitter', username: 'thacherhussain' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/toddlibby.js
+++ b/src/_data/members/members/toddlibby.js
@@ -21,7 +21,7 @@ module.exports = {
 		{ type: 'codenewbie', username: 'colabottles' },
 		{ type: 'twitter', username: 'toddlibby' },
 		{ type: 'twitch', username: 'toddlibby' },
-		{ type: 'youtube', channelId: 'FrontEndNerdery' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/FrontEndNerdery' }
+		{ type: 'youtube', customUrl: 'https://www.youtube.com/c/FrontEndNerdery' },
 		{ type: 'polywork', username: 'colabottles' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/toddlibby.js
+++ b/src/_data/members/members/toddlibby.js
@@ -1,21 +1,20 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'colabottles',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown. Please keep your bio to a reasonable length, refer to
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples. Please keep your bio to a reasonable length, refer to
 	// [members page](https://virtualcoffee.io/members/) for examples
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		{ type: 'linkedin', username: 'todd-libby' },
 		{ type: 'dev', username: 'colabottles' },

--- a/src/_data/members/members/tombousquet.js
+++ b/src/_data/members/members/tombousquet.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'tombousquet',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/tomcudd.js
+++ b/src/_data/members/members/tomcudd.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'tomcudd',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/torianne02.js
+++ b/src/_data/members/members/torianne02.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'torianne02',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/vanessacor.js
+++ b/src/_data/members/members/vanessacor.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'vanessacor',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },

--- a/src/_data/members/members/zooglon.js
+++ b/src/_data/members/members/zooglon.js
@@ -1,27 +1,26 @@
 module.exports = {
-	// github username: required
+	// GitHub username (required)
 	github: 'zooglon',
 	//
-	// everything below here is optional. by default, we pull most profile data from your github profile.
-	// you can override that data here, as well as provide some additional account links below
+	// Everything below here is optional. By default, we pull most profile data from your GitHub profile. You can override that data here, as well as provide some additional account links below.
 	//
-	// name - if not defined here, will default to your Name on github if defined, if not, then your username
+	// Name - If not defined here, it will default to your display name on GitHub. If that's not defined, then your GitHub username.
 	// name: 'Your Name',
 	//
-	// mainUrl: the url your name links to on the members page. defaults to your github profile
+	// Main URL - If not defined here, it will default to the website displayed on your GitHub profile. If that's not defined, then a link to your GitHub profile will be displayed.
 	// mainUrl: 'https://virtualcoffee.io',
 	//
-	// bio - accepts markdown.
+	// Bio - Accepts [markdown](https://spec.commonmark.org/0.30/). Please keep your bio to a reasonable length. Refer to our [members page](https://virtualcoffee.io/members/) for examples.
 	// bio: `This is _my_ **bio** and [here is a link](https://virtualcoffee.io)`,
 	//
-	// can take  one of each type except website - you can add as many `website` accounts as you wish
+	// Links - You can add one of each type, except website - you can add as many `website` accounts as you wish.
 	accounts: [
 		// { type: 'linkedin', username: 'yourlinkedinUserName' },
 		// { type: 'dev', username: 'yourUserName' },
 		// { type: 'codenewbie', username: 'yourUserName' },
 		// { type: 'twitter', username: 'yourUserName' },
 		// { type: 'twitch', username: 'yourUserName' },
-		// { type: 'youtube', channelId: 'yourChannelId' }, // or { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' }
+		// { type: 'youtube', channelId: 'yourChannelId' }, OR { type: 'youtube', customUrl: 'https://www.youtube.com/c/yourCustomUrl' },
 		// { type: 'polywork', username: 'yourUserName' },
 		// { type: 'medium', username: 'yourUserName' },
 		// { type: 'hashnode', username: 'yourUserName' },


### PR DESCRIPTION
## Linked Issue

Closes #462 

## Description

Reword `_EXAMPLE.js` for clarity.

## Methodology

When updating my own profile, I was confused as to why my website link was appearing as the `mainUrl` value when the template said it would default to my GitHub profile link.

After looking into it further, I realized it defaults to _the website listed on the user's GitHub profile_. If that's missing, _**then**_ `mainUrl` becomes a link to the user's GitHub profile.
