### PR TITLE
Feature/member anchor link

### DIFF
--- a/src/assets/scss/_base.scss
+++ b/src/assets/scss/_base.scss
@@ -252,16 +252,23 @@ ul {
 	font-size: 1.1em;
 	opacity: 0;
 	transition: opacity 0.2s ease-in-out;
+	display: inline-block;
+	text-align: center;
+
+	@media (any-hover: none) {
+		opacity: 0.75;
+	}
 }
 
 .header-anchor-wrapper {
 	position: relative;
 	display: grid;
-	grid-template-columns: 1em 1fr;
+	grid-template-columns: 1.5em 1fr;
+	margin-left: -1.5em;
 	align-items: baseline;
-	margin-left: -1em;
 
-	&:hover .header-anchor {
+	&:hover .header-anchor,
+	&:focus-within .header-anchor {
 		opacity: 1;
 	}
 }

--- a/src/assets/scss/_base.scss
+++ b/src/assets/scss/_base.scss
@@ -1,5 +1,6 @@
 html {
 	font-size: 18px;
+	scroll-padding-top: 100px;
 }
 
 a:focus {

--- a/src/monthlychallenges/nov-2021/index.njk
+++ b/src/monthlychallenges/nov-2021/index.njk
@@ -41,8 +41,14 @@ tags: monthlychallenges
 <h2 class="mt-5">Our Posts:</h2>
 
 {% for person in sortedList %}
+<div class="header-anchor-wrapper header-anchor-wrapper-h3">
+	<h3 id="{{ person.name | slugify }}" tabindex="-1">{{ person.name }}</h3>
+	<a class="header-anchor" href="#{{person.name | slugify}}"
+		><span class="sr-only">Permalink to {{person.name}}'s posts</span>
+		<span aria-hidden="true">#</span></a
+	>
+</div>
 
-<h3>{{person.name}}</h3>
 <ul>
 	{% for post in person.posts %}
 	<li>


### PR DESCRIPTION
Thanks to @nickytonline for the idea:

### Changes:
- Add anchor links to member names on the 2021 NaNoWriMo monthly challenge for direct linking action!
- Add `scroll-padding-top` to avoid the fixed-header overlap
- Fixed bug on header anchors where they remained hidden on focus
- Fixed bug on header anchors where they were invisible when no hover-capable devices present