### PR TITLE
Feature/add challenge stretch

### DIFF
--- a/src/monthlychallenges/nov-2021/index.11tydata.js
+++ b/src/monthlychallenges/nov-2021/index.11tydata.js
@@ -77,7 +77,13 @@ module.exports = async function () {
 		}, {}),
 	).sort((a, b) => a.name.localeCompare(b.name));
 
+	const goals = [20000, 50000, 100000, 150000, 200000];
+	const completedGoals = goals.filter((g) => g <= totalCount);
+	const currentGoal = goals.find((g) => g > totalCount);
+
 	return {
+		completedGoals,
+		currentGoal,
 		sortedList,
 		list: tableRows,
 		totals: {

--- a/src/monthlychallenges/nov-2021/index.11tydata.js
+++ b/src/monthlychallenges/nov-2021/index.11tydata.js
@@ -77,7 +77,7 @@ module.exports = async function () {
 		}, {}),
 	).sort((a, b) => a.name.localeCompare(b.name));
 
-	const goals = [20000, 50000, 100000, 150000, 200000];
+	const goals = [50000, 100000, 125000, 150000, 175000, 200000];
 	const completedGoals = goals.filter((g) => g <= totalCount);
 	const currentGoal = goals.find((g) => g > totalCount);
 

--- a/src/monthlychallenges/nov-2021/index.njk
+++ b/src/monthlychallenges/nov-2021/index.njk
@@ -21,18 +21,35 @@ tags: monthlychallenges
 
 <p class="lead">Get those blog posts up!</p>
 
+{% if completedGoals.length %}
+
+<h2><small>Current status:</small></h2>
+
+<ul>
+	{% for goal in completedGoals %}
+	<li class="lead">{{goal | toLocaleString}} goal completed!!!</li>
+	{% endfor %}
+</ul>
+
+<div class="h3">
+	Stretch Goal {{completedGoals.length}}: {{totals.totalCount | toLocaleString}}
+	out of {{currentGoal | toLocaleString}} words
+</div>
+{% else %}
 <h2>
-	Current status: {{totals.totalCount | toLocaleString}} out of 50,000 words
+	Current status: {{totals.totalCount | toLocaleString}} out of {{currentGoal |
+	toLocaleString}} words
 </h2>
+{% endif %}
 
 <div class="progress my-4" style="height: 3em">
 	<div
 		class="progress-bar progress-bar progress-bar-striped"
 		role="progressbar"
-		style="width: {{(totals.totalCount/50000)*100}}%"
+		style="width: {{(totals.totalCount/currentGoal)*100}}%"
 		aria-valuenow="totals.totalCount"
 		aria-valuemin="0"
-		aria-valuemax="50000"
+		aria-valuemax="{{currentGoal}}"
 	>
 		{{totals.totalCount | toLocaleString}} Words
 	</div>


### PR DESCRIPTION
It seems like we're almost certainly going to hit our goal of 50,000 words this month 🤯

So we need a way to display stretch goals!

Screenshot of what it'll look like (imagine original goal was 20,000 words):

![image](https://user-images.githubusercontent.com/360261/141355665-1bc6bea3-9c0c-4b17-95ec-0d76c2c188f4.png)

Here's after hitting a couple goals:

![image](https://user-images.githubusercontent.com/360261/141355997-05b32406-9a28-49b8-9eb8-0db2d3529718.png)

I added the following goals, we can always add more or less steps:

- 50,000 (original)
- 100,000
- 125,000
- 150,000
- 200,000

