### PR TITLE
adds profile information

### DIFF
--- a/src/_data/members/members/paceaux.js
+++ b/src/_data/members/members/paceaux.js
@@ -1,0 +1,15 @@
+module.exports = {
+	// GitHub username (required)
+	github: 'paceaux',
+	name: 'Frank M. Taylor',
+	mainUrl: 'https://blog.frankmtaylor.com',
+	bio: `Forward-facing developer. I love clean code and Node, subtle jokes and linguist folks, playing guitar and Oxford commas.
+	He/him
+	`,
+	accounts: [
+		{ type: 'linkedin', username: 'paceaux' },
+		{ type: 'dev', username: 'paceaux' },
+		{ type: 'twitter', username: 'paceaux' },
+		{ type: 'website', url: 'https://frankmtaylor.com/', title: 'Portfolio' },
+	],
+};


### PR DESCRIPTION
## Linked Issue

Adds profile, according to instructions in [issue 13](https://github.com/Virtual-Coffee/virtualcoffee.io/issues/13)


## Description
Howdy. I'd like to add my profile to the members page. This is a single file, added to `src/_data/members/members`


## Methodology

I've been active in the slack community for maybe a year now. I figure it's time to commit to it. 


## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)
