### PR TITLE
Update typescript definition for `directory import`

### DIFF
--- a/netlify/functions/data-members.ts
+++ b/netlify/functions/data-members.ts
@@ -156,7 +156,7 @@ async function getMemberGithubData(
 }
 
 function loadDirectory(path: string) {
-	const dict: Record<string, MemberObject> = importDir({
+	const dict = importDir<MemberObject>({
 		directoryPath: join(process.cwd(), 'members', path),
 	});
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,30 +1,56 @@
 declare module 'directory-import' {
-	function importDir(parameters: {
+	type ImportDirParams = {
 		/**
 		 * Relative path to directory
+		 * @default './'
 		 */
 		directoryPath?: string;
-		/**
-		 * Import files synchronously, or asynchronously
-		 */
-		importMethod?: string;
+
 		/**
 		 * If false — files in subdirectories will not be imported
+		 * @default true
 		 */
 		includeSubdirectories?: boolean;
 		/**
 		 * Webpack support.
+		 * @default false
 		 */
 		webpack?: boolean;
 		/**
 		 * Indicates how many files to import. 0 - to disable the limit
+		 * @default 0
 		 */
 		limit?: number;
 		/**
 		 * Exclude files paths.
+		 * @default undefined
 		 */
 		exclude?: RegExp;
-	}): any;
+	};
+
+	type WithImportAsync = {
+		/**
+		 * Import files synchronously, or asynchronously
+		 * @default 'sync'
+		 */
+		importMethod?: 'async';
+	};
+
+	type WithImportSync = {
+		/**
+		 * Import files synchronously, or asynchronously
+		 * @default 'sync'
+		 */
+		importMethod?: 'sync';
+	};
+
+	function importDir<T>(
+		parameters: ImportDirParams & WithImportSync,
+	): Record<string, T>;
+
+	function importDir<T>(
+		parameters: ImportDirParams & WithImportAsync,
+	): Promise<Record<string, T>>;
 
 	export = importDir;
 }


### PR DESCRIPTION
From Typescript Tuesdays episode 9!

In order to improve the custom type definition of the `directory-import` library (see #610), we added some JSDoc improvements, and used type overloading to allow for different shapes of return values (instead of just saying `any`)