### PR TITLE
chore: updating github action for prettier formatting

### DIFF
--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '16.x'
-      - run: yarn format
+      - run: yarn run format
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -1,11 +1,8 @@
+name: Formatting PR with Prettier
 on:
-  push:
-    branches:
-      - main
   pull_request_target:
-    types: [opened, synchronize, reopened]
-
-name: Format
+    branches:
+      - 'main'
 
 jobs:
   format:

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -1,20 +1,22 @@
-name: Format
+name: Formatting codebase
+
 on:
   pull_request:
     branches: [main]
+
 jobs:
-  format:
+  prettier:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
-      - uses: actions/setup-node@v2
+          fetch-depth: 0
+
+      - name: Using Prettier for codebase
+        uses: creyD/prettier_action@v4.2
         with:
-          node-version: '16.x'
-      - run: yarn format
-      - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Apply formatting changes
-          branch: ${{ github.head_ref }}
+          prettier_options: npx prettier --write --ignore-unknown \"**/*\"
+          only_changed: True

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -5,18 +5,20 @@ on:
       - 'main'
 
 jobs:
-  format:
+  prettier:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
       - uses: actions/setup-node@v2
         with:
           node-version: '16.x'
-      - run: yarn run format
-      - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+      - run: yarn format
+      - name: Using Prettier to format code
+        uses: creyD/prettier_action@v4.2
         with:
           commit_message: Apply formatting changes
           branch: ${{ github.head_ref }}

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -1,10 +1,12 @@
-name: Format
 on:
   push:
     branches:
       - main
   pull_request_target:
     types: [opened, synchronize, reopened]
+
+name: Format
+
 jobs:
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -1,7 +1,10 @@
 name: Format
 on:
-  pull_request:
-    branches: [main]
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 jobs:
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -1,4 +1,4 @@
-name: Formatting PR with Prettier
+name: Format
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -1,24 +1,20 @@
-name: Formatting PR with Prettier
+name: Format
 on:
-  pull_request_target:
-    branches:
-      - 'main'
-
+  pull_request:
+    branches: [main]
 jobs:
-  prettier:
+  format:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
       - uses: actions/setup-node@v2
         with:
           node-version: '16.x'
       - run: yarn format
-      - name: Using Prettier to format code
-        uses: creyD/prettier_action@v4.2
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Apply formatting changes
           branch: ${{ github.head_ref }}

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -1,4 +1,4 @@
-name: Format
+name: Formatting PR with Prettier
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
## Linked Issue

#700 

## Context for the PR
Over a year ago, there was already a pull request to add the formatting for PR
https://github.com/Virtual-Coffee/virtualcoffee.io/blob/main/.github/workflows/pr-format.yml

But it doesn't look like this workflow is currently running.
I checked the last few open PR's and it doesn't look like the formatting action is running. 
I am trying to figure out how to get it working so every time someone creates a PR or makes changes, the format action will run. 

closes #700 