### PR TITLE
Bug/use location

### DIFF
--- a/app/components/content/NotFoundCatch.tsx
+++ b/app/components/content/NotFoundCatch.tsx
@@ -2,7 +2,7 @@ import DefaultLayout from '~/components/layouts/DefaultLayout';
 import PostList from '~/components/PostList';
 import Root from '~/components/layouts/Root';
 import { homePageLinks } from '~/routes/__frontend/index';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from '@remix-run/react';
 
 export function CatchBoundary() {
 	const location = useLocation();

--- a/app/root.jsx
+++ b/app/root.jsx
@@ -5,10 +5,10 @@ import {
 	Meta,
 	Scripts,
 	ScrollRestoration,
+	useLocation,
 } from '@remix-run/react';
 import { qualifiedUrl } from '~/util/url.server';
 import { removeTrailingSlash } from '~/util/http';
-import { useLocation } from 'react-router-dom';
 import { createMetaData } from '~/util/createMetaData.server';
 
 export async function loader({ request }) {

--- a/app/root.jsx
+++ b/app/root.jsx
@@ -5,10 +5,10 @@ import {
 	Meta,
 	Scripts,
 	ScrollRestoration,
-	useMatches,
 } from '@remix-run/react';
 import { qualifiedUrl } from '~/util/url.server';
 import { removeTrailingSlash } from '~/util/http';
+import { useLocation } from 'react-router-dom';
 import { createMetaData } from '~/util/createMetaData.server';
 
 export async function loader({ request }) {
@@ -119,8 +119,7 @@ export const LiveReload =
 		  };
 
 export default function App() {
-	const matches = useMatches();
-	const pathname = matches[matches.length - 1]?.pathname || '';
+	const location = useLocation();
 
 	return (
 		<html lang="en" className="h-full bg-gray-100">
@@ -128,7 +127,7 @@ export default function App() {
 				<Meta />
 				<Links />
 			</head>
-			<body className={`h-full ${pathname === '/' ? 'vc-home' : ''}`}>
+			<body className={`h-full ${location.pathname === '/' ? 'vc-home' : ''}`}>
 				<Outlet />
 				<ScrollRestoration />
 				<Scripts />

--- a/app/routes/__frontend/resources.jsx
+++ b/app/routes/__frontend/resources.jsx
@@ -1,12 +1,17 @@
 import { json } from '@remix-run/node';
-import { Link, Outlet, useLoaderData, useMatches } from '@remix-run/react';
+import {
+	Link,
+	Outlet,
+	useLoaderData,
+	useMatches,
+	useLocation,
+} from '@remix-run/react';
 import {
 	loadMdxDirectory,
 	loadMdxRouteFileAttributes,
 } from '~/util/loadMdx.server';
 import DefaultLayout from '~/components/layouts/DefaultLayout';
 import { useMemo } from 'react';
-import { useLocation } from 'react-router-dom';
 import { createMetaData } from '~/util/createMetaData.server';
 
 function trimString(s, c) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1580,9 +1580,9 @@
     "@types/node" "*"
 
 "@types/luxon@^3.0.0":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.0.1.tgz#2b1657096473e24b049bdedf3710f99645f3a17f"
-  integrity sha512-/LAvk1cMOJt0ghzMFrZEvByUhsiEfeeT2IF53Le+Ki3A538yEL9pRZ7a6MuCxdrYK+YNqNIDmrKU/r2nnw04zQ==
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.0.2.tgz#11361eb3c8a81e9b8d6b35b6ffe155e8eb95480d"
+  integrity sha512-HM2OVWckUMmXbWYZufmWT2XMURGDZ6XbyNyQ+Lx+gCFGFqbZaIjsz7b+AGeGP/AuVYHBiuGY+wXfweP1RremnA==
 
 "@types/mdast@^3.0.0":
   version "3.0.10"


### PR DESCRIPTION
- closes #715 

Importing `useLocation` from `react-router-dom` has suddenly stopped working. Haven't figured out exactly why yet, but importing from `@remix-run/react` works fine.