### PR TITLE
Adding lazy loading to members page

### DIFF
--- a/app/components/MemberCards.tsx
+++ b/app/components/MemberCards.tsx
@@ -45,6 +45,8 @@ export default function MemberCards({ data }: { data: MemberList }) {
 									<img
 										src={member.avatarUrl}
 										alt=""
+										loading="lazy"
+										decoding="async"
 										style={
 											member.flare?.profileMask
 												? { clipPath: member.flare.profileMask }

--- a/styles/_members.scss
+++ b/styles/_members.scss
@@ -59,6 +59,8 @@
 	}
 	img {
 		border-radius: $border-radius-sm;
+		width: 100%;
+		aspect-ratio: 1 / 1;
 	}
 }
 


### PR DESCRIPTION
Closes #655

## Description

Virtual Coffee member's page is growing rapidly. In order to improve the perforamce of the member's page, `loading = "lazy"` and `decoding="async"` were added into the `<img>` tag. Also to keep it uniformed and bit quicker with loading, added `width=100%` and `aspect-ratio:1/1` into the members css section.  

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)
