### PR TITLE
added register link to login form

### DIFF
--- a/app/routes/__auth/login.tsx
+++ b/app/routes/__auth/login.tsx
@@ -96,6 +96,17 @@ function LogInForm({
 				<div className="flex items-center justify-end">
 					<div className="text-sm">
 						<Link
+							to="/register"
+							className="font-medium text-sky-600 hover:text-sky-500"
+						>
+							Register
+						</Link>
+					</div>
+				</div>
+
+				<div className="flex items-center justify-end">
+					<div className="text-sm">
+						<Link
 							to="/forgot-password"
 							className="font-medium text-sky-600 hover:text-sky-500"
 						>


### PR DESCRIPTION
 ## Linked Issue

 Closes #754 

 ## Description

I added a "Register" link to the login form that routes users to the register page.

## Methodology

At the moment there is no way users are able to register for an account from the login page. Adding the link allows them to do so.

## Code of Conduct

 By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)


