### PR TITLE
Feature/update airtable api keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,8 +21,16 @@ URL='http://localhost:9000'
 # CMS_TOKEN=cmstoken
 #
 # Airtable:
-# There are some monthly challenges that use Airtable data. If you'd like to see live data in these sections,
-# ask a maintainer for an airtable token. Once you have that, add the token and uncomment the following line:
 #
-# AIRTABLE_API_KEY=yourtoken
+# There are some monthly challenges that use Airtable data. If you'd like to see live data in these sections,
+# ask a maintainer for an airtable token for the Public Data base. Once you have that, add the token and uncomment the following line:
+#
+# readonly key for public base:
+# PUBLIC_AIRTABLE_API_KEY=token
+#
+# The signup function currently also uses airtable. If you'd like to run this locally,
+# ask a maintainer for an airtable token for the membership base. Once you have that, add the token and uncomment the following line:
+#
+# readonly key for membership base:
+# MEMBERSHIP_AIRTABLE_API_KEY=token
 #

--- a/app/api/userlookup.server.ts
+++ b/app/api/userlookup.server.ts
@@ -1,8 +1,8 @@
 import Airtable from 'airtable';
 
-var base = new Airtable({ apiKey: process.env.POWERFUL_AIRTABLE_KEY }).base(
-	'appGHm8ztVWug6UxH',
-);
+var base = new Airtable({
+	apiKey: process.env.MEMBERSHIP_AIRTABLE_API_KEY,
+}).base('appGHm8ztVWug6UxH');
 
 type Profile = {
 	Name?: string;

--- a/app/data/monthlyChallenges/nov-2021.js
+++ b/app/data/monthlyChallenges/nov-2021.js
@@ -1,11 +1,11 @@
 import slugify from '@sindresorhus/slugify';
 
 async function fetchRecords() {
-	if (process.env.AIRTABLE_API_KEY) {
+	if (process.env.PUBLIC_AIRTABLE_API_KEY) {
 		const Airtable = require('airtable');
-		const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(
-			'appJStQemmYeoRcox',
-		);
+		const base = new Airtable({
+			apiKey: process.env.PUBLIC_AIRTABLE_API_KEY,
+		}).base('appJStQemmYeoRcox');
 
 		const result = await base('Member Articles').select().all();
 

--- a/app/data/monthlyChallenges/oct-2022.js
+++ b/app/data/monthlyChallenges/oct-2022.js
@@ -13,11 +13,11 @@ const mockData = [
 
 async function fetchRecords() {
 	try {
-		if (process.env.AIRTABLE_API_KEY) {
+		if (process.env.PUBLIC_AIRTABLE_API_KEY) {
 			const Airtable = require('airtable');
-			const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(
-				'appJStQemmYeoRcox',
-			);
+			const base = new Airtable({
+				apiKey: process.env.PUBLIC_AIRTABLE_API_KEY,
+			}).base('appJStQemmYeoRcox');
 
 			const result = await base('Hacktoberfest2022 Repos')
 				.select({ view: 'Default' })


### PR DESCRIPTION
Airtable [has new API auth methods](https://community.airtable.com/t5/announcements/new-api-capabilities-now-in-ga-and-upcoming-api-keys-deprecation/ba-p/141824?utm_ID=recdXE5vJZZ5vR0mh&utm_ID=recdXE5vJZZ5vR0mh&utm_source=lifecycle_team&utm_source=lifecycle_team&utm_medium=email&utm_medium=email&utm_campaign=it_ss_ss_api_deprecation&utm_campaign=it_ss_ss_api_depreciation&utm_content=email-blast_api_1a&utm_content=email-blast_api_key_users) and so the old API keys were deprecated. 