### PR TITLE
add category discussion template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/css-battles.yml
+++ b/.github/DISCUSSION_TEMPLATE/css-battles.yml
@@ -1,0 +1,48 @@
+title: "CSS Battle #NUMBER – NAME"
+labels: ["CSS Battles"]
+body:
+  - type: input
+    id: link
+    attributes:
+      label: "Link to battle:"
+      description: Replace NUMBER with current battle number      
+      value: |
+       [Lets battle! ⚔️](https://cssbattle.dev/play/NUMBER)
+    validations:
+      required: true
+  - type: markdown
+    attributes: 
+      value: |
+        **That’s all! You can now click the “Start discussion” button.** :smile:
+        **Please note:** Don't change text areas - they need to stay that way to be visible after creating discussion.
+  - type: textarea
+    attributes:
+      label:  "Copy the code block below to format your comment on the discussion thread:"
+      description: Solution template for players
+      value: |
+        ```html
+        <details>
+        <summary>Description – <strong>score {characters}</strong></summary><br />
+        <!-- Has to be followed by an empty line! -->
+
+        <!-- remove + character -->
+        +```html
+        Your CSSBattles.dev code here! ⚔️
+        +```
+
+        </details>
+        ```
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: "What others will see:"
+      description: Solution preview
+      value: |
+        This will result in a nice hidden bit like so:<br />
+        <details>
+        <summary>Description – <strong>score {characters}</strong></summary><br />
+        Your CSSBattles.dev code here! ⚔️
+        </details>
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/css-battles.yml
+++ b/.github/DISCUSSION_TEMPLATE/css-battles.yml
@@ -46,7 +46,7 @@ body:
       value: |
         This will result in a nice hidden bit like so:<br />
         <details>
-        <summary>Code Source  – <strong>score {character count}</strong></summary>
+        <summary>Code Source  – <strong>score {character count}</strong></summary><br />
         your cssbattles code here!
         </details>
     validations:

--- a/.github/DISCUSSION_TEMPLATE/css-battles.yml
+++ b/.github/DISCUSSION_TEMPLATE/css-battles.yml
@@ -45,10 +45,10 @@ body:
       description: Solution preview
       value: |
         This will result in a nice hidden bit like so:
-        
+
         <details>
         <summary>Code Source  – <strong>score {character count}</strong></summary>
-        
+
         ```html
         your cssbattles code here!
         ```

--- a/.github/DISCUSSION_TEMPLATE/css-battles.yml
+++ b/.github/DISCUSSION_TEMPLATE/css-battles.yml
@@ -14,24 +14,29 @@ body:
     attributes: 
       value: |
         **That’s all! You can now click the “Start discussion” button.** :smile:
-        **Please note:** Don't change text areas - they need to stay that way to be visible after creating discussion.
+        > **Please note**
+        > Don't change text areas - they need to stay that way to be visible after creating discussion
+        > 
+        > Don't change anything below this line!
+
+        ---
+
   - type: textarea
     attributes:
       label:  "Copy the code block below to format your comment on the discussion thread:"
       description: Solution template for players
       value: |
-        ```html
+        ````md
         <details>
-        <summary>Description – <strong>score {characters}</strong></summary><br />
-        <!-- Has to be followed by an empty line! -->
+        <summary>Code Source  – <strong>score {character count}</strong></summary>
+        <!-- have to be followed by an empty line! -->
 
-        <!-- remove + character -->
-        +```html
-        Your CSSBattles.dev code here! ⚔️
-        +```
+        ```html
+        your cssbattles code here!
+        ```
 
         </details>
-        ```
+        ````
     validations:
       required: true
   - type: textarea
@@ -41,8 +46,8 @@ body:
       value: |
         This will result in a nice hidden bit like so:<br />
         <details>
-        <summary>Description – <strong>score {characters}</strong></summary><br />
-        Your CSSBattles.dev code here! ⚔️
+        <summary>Code Source  – <strong>score {character count}</strong></summary>
+        your cssbattles code here!
         </details>
     validations:
       required: true

--- a/.github/DISCUSSION_TEMPLATE/css-battles.yml
+++ b/.github/DISCUSSION_TEMPLATE/css-battles.yml
@@ -1,17 +1,17 @@
-title: "CSS Battle #NUMBER – NAME"
-labels: ["CSS Battles"]
+title: 'CSS Battle #NUMBER – NAME'
+labels: ['CSS Battles']
 body:
   - type: input
     id: link
     attributes:
-      label: "Link to battle:"
-      description: Replace NUMBER with current battle number      
+      label: 'Link to battle:'
+      description: Replace NUMBER with current battle number
       value: |
-       [Lets battle! ⚔️](https://cssbattle.dev/play/NUMBER)
+        [Lets battle! ⚔️](https://cssbattle.dev/play/NUMBER)
     validations:
       required: true
   - type: markdown
-    attributes: 
+    attributes:
       value: |
         **That’s all! You can now click the “Start discussion” button.** :smile:
         > **Please note**
@@ -23,7 +23,7 @@ body:
 
   - type: textarea
     attributes:
-      label:  "Copy the code block below to format your comment on the discussion thread:"
+      label: 'Copy the code block below to format your comment on the discussion thread:'
       description: Solution template for players
       value: |
         ````md
@@ -41,7 +41,7 @@ body:
       required: true
   - type: textarea
     attributes:
-      label: "What others will see:"
+      label: 'What others will see:'
       description: Solution preview
       value: |
         This will result in a nice hidden bit like so:<br />

--- a/.github/DISCUSSION_TEMPLATE/css-battles.yml
+++ b/.github/DISCUSSION_TEMPLATE/css-battles.yml
@@ -44,10 +44,14 @@ body:
       label: 'What others will see:'
       description: Solution preview
       value: |
-        This will result in a nice hidden bit like so:<br />
+        This will result in a nice hidden bit like so:
+        
         <details>
-        <summary>Code Source  – <strong>score {character count}</strong></summary><br />
+        <summary>Code Source  – <strong>score {character count}</strong></summary>
+        
+        ```html
         your cssbattles code here!
+        ```
         </details>
     validations:
       required: true


### PR DESCRIPTION
## Linked Issue
Closes #900 

## Description
Adds discussion template for category CSS Battles on Virtual Coffee discussion forums

@danieltott what do you think? 😄 

## Methodology

### Current form for creating discussion:
| creating discussion | discussion look |
|:-------:|-------|
|<img src="https://i.imgur.com/sFgrkrE.png" width="300"> | <img src="https://i.imgur.com/QOqkCku.png" width="300">|

### Proposed changes
| creating discussion | discussion look |
|:-------:|-------|
|<img src="https://i.imgur.com/JSjjCnx.png" width="300"> | <img src="https://i.imgur.com/XaEAlo0.png" width="300">|

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)