### PR TITLE
Add profile to members page with location

### DIFF
--- a/members/members/JustinQuinn51.ts
+++ b/members/members/JustinQuinn51.ts
@@ -1,0 +1,19 @@
+import type { MemberObject } from '../types';
+
+export const JustinQuinn51: MemberObject = {
+	github: 'Justin-Quinn51',
+	mainUrl: 'https://justinquinn.dev',
+	bio: `Full-stack engineer trying to get better, one code block at a time.`,
+	flare: {},
+	accounts: [
+		{ type: 'linkedin', username: 'justin-quinn-' },
+		{ type: 'twitter', username: 'JustinQuinn_' },
+		{ type: 'website', url: 'https://justinquinn.dev', title: 'Justin Quinn' },
+	],
+	badges: ['Hacktoberfest2023'],
+  location: {
+		latitude: 40.748718,
+		longitude: -73.985352,
+		title: 'New York, NY',
+	},
+};


### PR DESCRIPTION
## Linked Issue

#13 

#995 

## Description

- Created JustinQuinn51.ts file under the members directory
- Updated JustinQuinn51.ts to include required fields
- Updated JustinQuinn51.ts to include location field

## Methodology

- Used latlong.net to generate approximate latitude and longitude coordinates

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)
