### PR TITLE
add member card link in map marker popup

### DIFF
--- a/app/components/MemberMap.tsx
+++ b/app/components/MemberMap.tsx
@@ -24,7 +24,7 @@ function Markers({ members }: { members: MappableMember[] }) {
 					position={[member.location?.latitude, member.location?.longitude]}
 				>
 					<Popup>
-						{member.name}
+						<a href={`#member_${member.github}`}>{member.name}</a>
 						{member.location?.title && (
 							<>
 								{' - '}


### PR DESCRIPTION
## Linked Issue
Closes #1038

## Description
Adds link to popup window on Members page, which scrolls the page to member card.

<img src="https://i.imgur.com/D7UgRlJ.png" />


## Methodology

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)
