### PR TITLE
Remove `indent_size` from editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,6 @@ root = true
 
 [*]
 indent_style = tab
-indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true


### PR DESCRIPTION
This is a bit of a punt and something I noticed when doing https://github.com/Virtual-Coffee/virtualcoffee.io/pull/1040

## Description

<!--

A pull request description describes what constitutes the Pull Request and what changes you have made to the code.

It explains what you've done, including any code changes, configuration changes, migrations included, new APIs introduced, changes made to old APIs, any new workers/crons introduced in the system, copy changes, and so on. You get the gist.

A good description informs everyone that is reaading it of the purpose of the pull request. This helps not just the current maintainers but anyone reading it now or in the future to understand your intent.

If the request is not complete but you want feedback use  Draft Pull Request option of the Pull request dropdown menu.

@mention individuals that you want to review the PR, and mention why. (“ @username I want to know what you think of this code.”)

-->

The `.editorconfig` file specifies tabs (yay!) as the `indent_style`, however it was strict on the `indent_size` - which isn't required if using tabs.

It also adds the final new line to the `.editorconfig` file, as required in the `.editorconfig` file

## Methodology

<!--

This section explains why the above changes explained were done.

Sometimes a developer feels that it's okay to write "Business/Product requirement" in the description. That's fine, but doing so defeats the purpose of this section.

If there is a better explanation as to why the changes were suggested, it's always good to attach a document reference link for that information.

A good "Why" section should explain the reasoning behind any changes.

-->

I'm a massive tab fanboy, but love a good sized indent of 4 and have this set in my IDE. I was surprised, when opening VirtualCoffee that, despite everything using tabs, it was extremely tight.

After searching my IDE, i realised the `.editorconfig` specified `indent_size = 2` which, considering it is a tab character, should not be needed.

Removing this allows the tab _size_ to be set in an IDE level for user preference while still keeping the tab convention.

Side note: I appreciate this MR is being raised without an issue and is 95% personal preference. If there is a reason I've not thought of for 2 space tabs to be force, I completely understand! 😄 

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)
