### PR TITLE
Update Monthly Challenge team leads

### DIFF
--- a/members/teams.ts
+++ b/members/teams.ts
@@ -55,7 +55,7 @@ const teams = {
 		'sadiejay',
 	],
 
-	'Monthly Challenge Team Lead': ['aurelieverrot', 'Andrew-Bush'],
+	'Monthly Challenge Team Lead': ['adiati98', 'dominicduffin1'],
 
 	'Documentation Team Lead': ['adiati98'],
 	'VC Advisor': [
@@ -85,7 +85,7 @@ const teams = {
 
 	'VC MC': ['meg-gutshall', 'SuzeShardlow', 'saramccombs'],
 
-	'Monthly Challenge Team': ['dominicduffin1', 'redapy', 'lsparlin'],
+	'Monthly Challenge Team': ['redapy', 'lsparlin'],
 } as const;
 
 export default teams;


### PR DESCRIPTION
## Linked Issue

Closes #1099 

## Description

- Remove the previous Monthly Challenge Team Leads from the Monthly Challenge Team Lead team.
- Add the new Monthly Challenge Team Leads (myself and @adiati98) to the Monthly Challenge Team Lead team.
- Remove myself from the (non-team lead) Monthly Challenge team to avoid duplicate badges.

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)

@BekahHW @juliaseid
