### PR TITLE
updated deprecated links for Nick Taylor's news letter 

### DIFF
--- a/app/routes/__frontend/newsletter/issues/2023-02.jsx
+++ b/app/routes/__frontend/newsletter/issues/2023-02.jsx
@@ -255,9 +255,7 @@ export default function Issue() {
 					<a href="https://www.twitch.tv/iandouglas736">Ian</a>.
 				</li>
 				<li>
-					<a href="https://www.nickyt.co/news">
-						Nick Taylor's newsletter
-					</a>{' '}
+					<a href="https://www.nickyt.co/news">Nick Taylor's newsletter</a>{' '}
 					keeps you up to date with the hot topics in tech.
 				</li>
 				<li>

--- a/app/routes/__frontend/newsletter/issues/2023-02.jsx
+++ b/app/routes/__frontend/newsletter/issues/2023-02.jsx
@@ -255,7 +255,7 @@ export default function Issue() {
 					<a href="https://www.twitch.tv/iandouglas736">Ian</a>.
 				</li>
 				<li>
-					<a href="https://www.getrevue.co/profile/nickytonline/issues/yet-another-newsletter-lol-issue-31-1002343">
+					<a href="https://www.nickyt.co/news">
 						Nick Taylor's newsletter
 					</a>{' '}
 					keeps you up to date with the hot topics in tech.

--- a/app/routes/__frontend/newsletter/issues/2023-03.jsx
+++ b/app/routes/__frontend/newsletter/issues/2023-03.jsx
@@ -262,9 +262,7 @@ export default function Issue() {
 			</p>
 			<ul>
 				<li>
-					<a href="https://www.nickyt.co/news">
-						Nick Taylor's newsletter
-					</a>{' '}
+					<a href="https://www.nickyt.co/news">Nick Taylor's newsletter</a>{' '}
 					keeps you up to date with the hot topics in tech.
 				</li>
 				<li>

--- a/app/routes/__frontend/newsletter/issues/2023-03.jsx
+++ b/app/routes/__frontend/newsletter/issues/2023-03.jsx
@@ -262,7 +262,7 @@ export default function Issue() {
 			</p>
 			<ul>
 				<li>
-					<a href="https://www.getrevue.co/profile/nickytonline/issues/yet-another-newsletter-lol-issue-31-1002343">
+					<a href="https://www.nickyt.co/news">
 						Nick Taylor's newsletter
 					</a>{' '}
 					keeps you up to date with the hot topics in tech.

--- a/app/routes/__frontend/newsletter/issues/2023-04.jsx
+++ b/app/routes/__frontend/newsletter/issues/2023-04.jsx
@@ -245,7 +245,7 @@ export default function Issue() {
 					.
 				</li>
 				<li>
-					<a href="https://www.getrevue.co/profile/nickytonline/issues/yet-another-newsletter-lol-issue-31-1002343">
+					<a href="https://www.nickyt.co/news">
 						Nick Taylor's newsletter
 					</a>{' '}
 					keeps you up to date with the hot topics in tech.

--- a/app/routes/__frontend/newsletter/issues/2023-04.jsx
+++ b/app/routes/__frontend/newsletter/issues/2023-04.jsx
@@ -245,9 +245,7 @@ export default function Issue() {
 					.
 				</li>
 				<li>
-					<a href="https://www.nickyt.co/news">
-						Nick Taylor's newsletter
-					</a>{' '}
+					<a href="https://www.nickyt.co/news">Nick Taylor's newsletter</a>{' '}
 					keeps you up to date with the hot topics in tech.
 				</li>
 				<li>

--- a/app/routes/__frontend/newsletter/issues/2023-10.jsx
+++ b/app/routes/__frontend/newsletter/issues/2023-10.jsx
@@ -272,7 +272,7 @@ export default function Issue() {
 					</a>
 				</li>
 				<li>
-					<a href="https://www.getrevue.co/profile/nickytonline/issues/yet-another-newsletter-lol-issue-31-1002343">
+					<a href="https://www.nickyt.co/news">
 						Nick Taylor's newsletter
 					</a>{' '}
 					keeps you up to date with the hot topics in tech.

--- a/app/routes/__frontend/newsletter/issues/2023-10.jsx
+++ b/app/routes/__frontend/newsletter/issues/2023-10.jsx
@@ -272,9 +272,7 @@ export default function Issue() {
 					</a>
 				</li>
 				<li>
-					<a href="https://www.nickyt.co/news">
-						Nick Taylor's newsletter
-					</a>{' '}
+					<a href="https://www.nickyt.co/news">Nick Taylor's newsletter</a>{' '}
 					keeps you up to date with the hot topics in tech.
 				</li>
 				<li>

--- a/app/routes/__frontend/newsletter/issues/2023-12.jsx
+++ b/app/routes/__frontend/newsletter/issues/2023-12.jsx
@@ -288,7 +288,7 @@ export default function Issue() {
 					</a>
 				</li>
 				<li>
-					<a href="https://www.getrevue.co/profile/nickytonline/issues/yet-another-newsletter-lol-issue-31-1002343">
+					<a href="https://www.nickyt.co/news">
 						Nick Taylor's newsletter
 					</a>{' '}
 					keeps you up to date with the hot topics in tech.

--- a/app/routes/__frontend/newsletter/issues/2023-12.jsx
+++ b/app/routes/__frontend/newsletter/issues/2023-12.jsx
@@ -288,9 +288,7 @@ export default function Issue() {
 					</a>
 				</li>
 				<li>
-					<a href="https://www.nickyt.co/news">
-						Nick Taylor's newsletter
-					</a>{' '}
+					<a href="https://www.nickyt.co/news">Nick Taylor's newsletter</a>{' '}
 					keeps you up to date with the hot topics in tech.
 				</li>
 				<li>

--- a/app/routes/__frontend/newsletter/issues/2024-01.jsx
+++ b/app/routes/__frontend/newsletter/issues/2024-01.jsx
@@ -313,9 +313,7 @@ export default function Issue() {
 					</a>
 				</li>
 				<li>
-					<a href="https://www.nickyt.co/news">
-						Nick Taylor's newsletter
-					</a>{' '}
+					<a href="https://www.nickyt.co/news">Nick Taylor's newsletter</a>{' '}
 					keeps you up to date with the hot topics in tech.
 				</li>
 				<li>

--- a/app/routes/__frontend/newsletter/issues/2024-01.jsx
+++ b/app/routes/__frontend/newsletter/issues/2024-01.jsx
@@ -313,7 +313,7 @@ export default function Issue() {
 					</a>
 				</li>
 				<li>
-					<a href="https://www.getrevue.co/profile/nickytonline/issues/yet-another-newsletter-lol-issue-31-1002343">
+					<a href="https://www.nickyt.co/news">
 						Nick Taylor's newsletter
 					</a>{' '}
 					keeps you up to date with the hot topics in tech.


### PR DESCRIPTION
## Linked Issue


https://github.com/Virtual-Coffee/virtualcoffee.io/issues/1120


## Description


Changed all the links for Nick Taylor's news letter to  https://www.nickyt.co/news


## Methodology


Needed to keep product up to date and not have any dead links.


## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)
