### PR TITLE
Make .tool-versions file versions match package.json file versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 20.17.0
-pnpm 9.9.0
+nodejs 20.17
+pnpm 9.10.0


### PR DESCRIPTION
## Linked Issue

Resolves #1265 

## Description

This changes the `.tool-versions` file to accurately reflect the versions used in the site build.

## Methodology

I copied the versions referenced in the `package.json` file into the `.tool-versions` file.

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)
