### PR TITLE
 feat: Add End Time to Events

### DIFF
--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -119,7 +119,7 @@ export default async function Page() {
 						<div className="card mb-4" key={event.startDateLocalized}>
 							<div className="card-header py-2 d-flex justify-content-between align-items-center flex-row flex-wrap">
 								<time dateTime={event.startDateLocalized}>
-									{dateForDisplay(event.startDateLocalized, 'EEEE, fff')}
+									{`${dateForDisplay(event.startDateLocalized, 'EEEE, LLLL d, yyyy')} - ${dateForDisplay(event.startDateLocalized, 't')} to ${dateForDisplay(event.endDateLocalized, 't ZZZZ')}`}
 								</time>
 
 								<a href={event.eventCalendarLink} download>


### PR DESCRIPTION
## Linked Issue
Closes #1271 

## Description
This PR adds the end time of events to the card headers on the Events page

## Methodology
This change helps event attendees by displaying the duration of all events in a prominent location on the page.

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)
