### PR TITLE
feat: Add redirects to create VCIO URLs for the CFP and survey forms

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -224,3 +224,12 @@
   to = "https://plausible.io/api/event"
   status = 200
 
+[[redirects]]
+  from = "/l/vc-conf-survey"
+  to = "https://docs.google.com/forms/d/e/1FAIpQLSd3l-YJIhA-lAAkWqEP5qbWGUPg8_HtKOfIN5M_NKYfStv4nA/viewform"
+  status = 302
+
+[[redirects]]
+  from = "/l/vc-conf-cfp-form"
+  to = "https://docs.google.com/forms/d/e/1FAIpQLSc_F6A6hhOO8PNgRoR32sxKnIePZdHY7gMTK-nD0yGCFuClCQ/viewform"
+  status = 302


### PR DESCRIPTION
## Linked Issue

Closes #1316 

## Description

I have added two redirects so the CFP form and Conference Survey can be shared using VCIO links.

## Methodology

I've used 302 redirects so the links can be reused in future to link to new forms.

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)
