### PR TITLE
fix: update Prettier workflow to create PRs for protected main

### DIFF
--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -1,6 +1,7 @@
 name: Prettier Format
 
 on:
+  pull_request_target:
   push:
     branches-ignore:
       - main
@@ -12,16 +13,20 @@ on:
 jobs:
   prettier:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
+          ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
 
       - name: Run Prettier
         uses: creyD/prettier_action@v4.3
         with:
           prettier_options: --write "**/*.{js,ts,tsx,jsx,json,css,md,yml,yaml}"
+          only_changed: true
 
       - name: Create Pull Request with Prettier fixes
         uses: peter-evans/create-pull-request@v5
@@ -30,4 +35,3 @@ jobs:
           commit-message: "chore: Prettier fixes"
           title: "Prettier fixes"
           body: "This PR contains Prettier formatting changes."
-

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -1,29 +1,33 @@
-name: Prettier code formatting
+name: Prettier Format
 
-# This action works with pull requests and pushes
 on:
-  pull_request_target:
   push:
+    branches-ignore:
+      - main
+  pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   prettier:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{ github.head_ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          # This is important to fetch the changes to the previous commit
           fetch-depth: 0
 
-      - name: Prettify code
+      - name: Run Prettier
         uses: creyD/prettier_action@v4.3
         with:
-          # This part is also where you can pass other options, for example:
-          prettier_options: --ignore-unknown --write .
-          only_changed: true
+          prettier_options: --write "**/*.{js,ts,tsx,jsx,json,css,md,yml,yaml}"
+
+      - name: Create Pull Request with Prettier fixes
+        uses: peter-evans/create-pull-request@v5
+        with:
+          branch: prettier-fixes
+          commit-message: "chore: Prettier fixes"
+          title: "Prettier fixes"
+          body: "This PR contains Prettier formatting changes."
+


### PR DESCRIPTION
## Description
This PR updates the Prettier workflow to stop pushing directly to the protected main branch. 
It now creates a PR with the Prettier formatting changes.

## Changes
- Updated .github/workflows/pr-format.yml
- Added proper branch handling for Prettier action

## Notes
No functional code changes, only workflow improvements.
