### PR TITLE
Change 4 to 6 for Hacktoberfest 2025 PRs

### DIFF
--- a/src/app/monthlychallenges/(challenges)/fall-2025/page.tsx
+++ b/src/app/monthlychallenges/(challenges)/fall-2025/page.tsx
@@ -75,7 +75,7 @@ export default function Challenge() {
 
 			<h3>October: Hacktoberfest</h3>
 			<p>
-				<strong>Goal</strong>: Complete four meaningful contributions during
+				<strong>Goal</strong>: Complete six meaningful contributions during
 				October. We have two tracks:
 			</p>
 			<ul>
@@ -86,7 +86,7 @@ export default function Challenge() {
 				</li>
 				<li>
 					<strong>Contributors</strong>: Find repositories and solve issues to
-					achieve four approved pull requests
+					achieve six approved pull requests
 				</li>
 			</ul>
 
@@ -354,13 +354,13 @@ export default function Challenge() {
 
 			<h3>Completing Hacktoberfest</h3>
 			<p className="mt-3">
-				To complete the Hacktoberfest challenge, you need to complete four
+				To complete the Hacktoberfest challenge, you need to complete six
 				meaningful contributions during October.
 			</p>
 			<p>
 				Remember, VC is here to support you during Hacktoberfest but is not an
 				official event partner. To complete the official Hacktoberfest, you must
-				have four (4) pull requests (PRs) accepted.
+				have six (6) pull requests (PRs) accepted.
 			</p>
 
 			<h3>Virtual Coffee Approved Repositories for Hacktoberfest</h3>


### PR DESCRIPTION
## Linked Issue

Closes #1394 

## Description

Change text in the **Bi-Monthly Challenge for Fall 2025: Preptember & Hacktoberfest!** page to read 6 PRs as the 2025 Hacktoberfest goal instead of 4 PRs

## Methodology

Text replacement

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)
