### PR TITLE
fix: remove the shadowUrl from the custom map marker icon

### DIFF
--- a/src/components/MemberMap.tsx
+++ b/src/components/MemberMap.tsx
@@ -22,6 +22,7 @@ const createCustomIcon = function (avatarUrl?: string) {
 		iconUrl: avatarUrl || defaultCustomIcon,
 		iconSize: new L.Point(33, 33, true),
 		className: 'leaflet-custom-marker',
+		shadowUrl: undefined,
 	});
 };
 


### PR DESCRIPTION
## Linked Issue

#1400

## Description

remove the shadowUrl from the custom map marker icon

## Methodology

The leaflet-shadow-pane class was being rendered along with the custom icon as we are not passing anything into this property it can be removed

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)
