### PR TITLE
Update podcast page to reflect archive status

### DIFF
--- a/src/app/podcast/page.tsx
+++ b/src/app/podcast/page.tsx
@@ -12,7 +12,7 @@ export async function generateMetadata() {
 	return await createMetaData({
 		title: 'Virtual Coffee Podcast',
 		description:
-			'This is the Virtual Coffee Podcast, where we interview members of the community to learn more about their stories as developers.',
+			'Explore nine seasons of the Virtual Coffee Podcast, where we shared the stories, lessons, and conversations from our community of developers.',
 		Hero: 'UndrawWalkInTheCity',
 		hero: 'UndrawWalkInTheCity',
 	});
@@ -28,26 +28,23 @@ export default async function PodcastsIndex() {
 			heroHeader="Virtual Coffee Podcast"
 			Hero="UndrawWalkInTheCity"
 		>
-			<div className="container bodycopy py-5 lead">
-				<p>
-					Virtual Coffee is an intimate community for developers at all stages
-					of the journey. In the Virtual Coffee Podcast, hosted by Bekah Hawrot
-					Weigel and Dan Ott, you&apos;ll find interviews with members of our
-					community to learn more about their stories, who they are, how they
-					found Virtual Coffee, and how it has influenced their lives as
-					developers.
-				</p>
-				<p>
-					We want to bring everything that&apos;s special about Virtual Coffee,
-					the intimacy and the friendships we&rsquo;ve built, and share that
-					with everyone through the podcast. We&rsquo;re always growing and
-					learning together as a group, and there&rsquo;s something really
-					special about being able to do that knowing that you&rsquo;ll have the
-					full support of the community around you. And that&rsquo;s what this
-					podcast is about too.
-				</p>
+		<div className="container bodycopy py-5 lead">
+			<p>
+				The Virtual Coffee Podcast was our way of sharing the stories,
+				lessons, and conversations that grew out of the Virtual Coffee
+				community.
+			</p>
+			<p>
+				We&apos;re not currently recording new episodes, but we&apos;re
+				grateful for the many guests who shared their experiences with us
+				across nine seasons. These conversations reflect so much of what we
+				love about Virtual Coffee: learning together, supporting one another,
+				being honest about the hard parts, and celebrating the many different
+				paths people take through tech.
+			</p>
+			<p>We hope you enjoy exploring the archive.</p>
 
-				<hr />
+			<hr />
 
 				<PodcastSubscribe />
 
@@ -116,8 +113,8 @@ export default async function PodcastsIndex() {
 			</div>
 
 			<div className="bg-light py-5">
-				<div className="container-xl">
-					<h2 className="display-5">All Episodes:</h2>
+			<div className="container-xl">
+				<h2 className="display-5">Episode Archive:</h2>
 
 					<PostList
 						items={podcastEpisodes.map(

--- a/src/app/podcast/page.tsx
+++ b/src/app/podcast/page.tsx
@@ -28,23 +28,23 @@ export default async function PodcastsIndex() {
 			heroHeader="Virtual Coffee Podcast"
 			Hero="UndrawWalkInTheCity"
 		>
-		<div className="container bodycopy py-5 lead">
-			<p>
-				The Virtual Coffee Podcast was our way of sharing the stories,
-				lessons, and conversations that grew out of the Virtual Coffee
-				community.
-			</p>
-			<p>
-				We&apos;re not currently recording new episodes, but we&apos;re
-				grateful for the many guests who shared their experiences with us
-				across nine seasons. These conversations reflect so much of what we
-				love about Virtual Coffee: learning together, supporting one another,
-				being honest about the hard parts, and celebrating the many different
-				paths people take through tech.
-			</p>
-			<p>We hope you enjoy exploring the archive.</p>
+			<div className="container bodycopy py-5 lead">
+				<p>
+					The Virtual Coffee Podcast was our way of sharing the stories,
+					lessons, and conversations that grew out of the Virtual Coffee
+					community.
+				</p>
+				<p>
+					We&apos;re not currently recording new episodes, but we&apos;re
+					grateful for the many guests who shared their experiences with us
+					across nine seasons. These conversations reflect so much of what we
+					love about Virtual Coffee: learning together, supporting one another,
+					being honest about the hard parts, and celebrating the many different
+					paths people take through tech.
+				</p>
+				<p>We hope you enjoy exploring the archive.</p>
 
-			<hr />
+				<hr />
 
 				<PodcastSubscribe />
 
@@ -113,8 +113,8 @@ export default async function PodcastsIndex() {
 			</div>
 
 			<div className="bg-light py-5">
-			<div className="container-xl">
-				<h2 className="display-5">Episode Archive:</h2>
+				<div className="container-xl">
+					<h2 className="display-5">Episode Archive:</h2>
 
 					<PostList
 						items={podcastEpisodes.map(


### PR DESCRIPTION
## Summary
- Updated podcast page intro text to communicate that the podcast is no longer recording new episodes
- Changed language from present to past tense to position the podcast as an archive
- Updated metadata description for SEO and social sharing
- Renamed "All Episodes" heading to "Episode Archive"

## Changes
The page now clearly communicates:
- The podcast was our way of sharing stories from the community
- We're not currently recording new episodes
- We're grateful for nine seasons of conversations
- The archive is available for exploration


Made with [Cursor](https://cursor.com)