### PR TITLE
feat: migrate podcast data from Craft CMS to vc-data

### DIFF
--- a/src/data/podcast.ts
+++ b/src/data/podcast.ts
@@ -12,10 +12,10 @@ const IMGIX_PREFIX = 'https://virtualcoffeeio-cms.imgix.net/podcast/';
 
 /** Strip the full imgix URL down to just the filename, which is what createCmsImage expects. */
 function extractPath(fullUrl: string | null | undefined): string {
-		if (!fullUrl) return '';
-		return fullUrl.startsWith(IMGIX_PREFIX)
-			? fullUrl.slice(IMGIX_PREFIX.length)
-					: fullUrl;
+	if (!fullUrl) return '';
+	return fullUrl.startsWith(IMGIX_PREFIX)
+		? fullUrl.slice(IMGIX_PREFIX.length)
+		: fullUrl;
 }
 
 // ---------------------------------------------------------------------------
@@ -23,39 +23,39 @@ function extractPath(fullUrl: string | null | undefined): string {
 // ---------------------------------------------------------------------------
 
 export interface PodcastEpisode {
+	title: string;
+	slug: string;
+	id: string;
+	metaDescription: string;
+	podcastEpisode: number;
+	podcastSeason: number;
+	podcastPublishDate: string;
+	podcastBuzzsproutId: string;
+	podcastShortDescription: {
+		renderHtml: string;
+	};
+	podcastShowNotes: {
+		renderHtml: string;
+	};
+	podcastGuests: Array<{
+		id: number | string;
+		guestName: string;
+		guestBio: { renderHtml: string };
+		headshot: Array<{ path: string }>;
+	}>;
+	podcastEpisodeCard: Array<{ path: string }>;
+	url: string;
+	episodeSponsors: Array<{
 		title: string;
-		slug: string;
-		id: string;
-		metaDescription: string;
-		podcastEpisode: number;
-		podcastSeason: number;
-		podcastPublishDate: string;
-		podcastBuzzsproutId: string;
-		podcastShortDescription: {
-			renderHtml: string;
-		};
-		podcastShowNotes: {
-			renderHtml: string;
-		};
-		podcastGuests: Array<{
-			id: number | string;
-			guestName: string;
-			guestBio: { renderHtml: string };
-			headshot: Array<{ path: string }>;
-		}>;
-		podcastEpisodeCard: Array<{ path: string }>;
-		url: string;
-		episodeSponsors: Array<{
-			title: string;
-			sponsorUrl: string;
-			sponsorImage: Array<{ path: string; width: number; height: number }>;
-			sponsorDescription: { renderHtml: string };
-		}>;
+		sponsorUrl: string;
+		sponsorImage: Array<{ path: string; width: number; height: number }>;
+		sponsorDescription: { renderHtml: string };
+	}>;
 }
 
 type PodcastEpisodes = Pick<
-		PodcastEpisode,
-		| 'title'
+	PodcastEpisode,
+	| 'title'
 	| 'slug'
 	| 'id'
 	| 'metaDescription'
@@ -72,30 +72,30 @@ type PodcastEpisodes = Pick<
 // ---------------------------------------------------------------------------
 
 interface VcDataEpisode {
+	title: string;
+	slug: string;
+	id: string;
+	metaDescription: string;
+	season: number;
+	episode: number;
+	buzzsproutId: string;
+	publishDate: string;
+	shortDescription: string;
+	showNotes: string;
+	episodeCard: string;
+	guests: Array<{
+		guestName: string;
+		guestBio: string;
+		headshot: string | null;
+	}>;
+	sponsors: Array<{
 		title: string;
-		slug: string;
-		id: string;
-		metaDescription: string;
-		season: number;
-		episode: number;
-		buzzsproutId: string;
-		publishDate: string;
-		shortDescription: string;
-		showNotes: string;
-		episodeCard: string;
-		guests: Array<{
-			guestName: string;
-			guestBio: string;
-			headshot: string | null;
-		}>;
-		sponsors: Array<{
-			title: string;
-			url: string;
-			logo: string | null;
-			logoWidth: number;
-			logoHeight: number;
-			description: string;
-		}>;
+		url: string;
+		logo: string | null;
+		logoWidth: number;
+		logoHeight: number;
+		description: string;
+	}>;
 }
 
 // ---------------------------------------------------------------------------
@@ -103,143 +103,140 @@ interface VcDataEpisode {
 // ---------------------------------------------------------------------------
 
 function mapEpisode(e: VcDataEpisode): PodcastEpisode {
-		return {
-					title: e.title,
-					slug: e.slug,
-					id: e.id,
-					metaDescription: e.metaDescription,
-					podcastEpisode: e.episode,
-					podcastSeason: e.season,
-					podcastPublishDate: e.publishDate,
-					podcastBuzzsproutId: e.buzzsproutId,
-					podcastShortDescription: { renderHtml: e.shortDescription },
-					podcastShowNotes: { renderHtml: e.showNotes },
-					podcastEpisodeCard: e.episodeCard
-						? [{ path: extractPath(e.episodeCard) }]
-									: [],
-					podcastGuests: (e.guests || []).map((g, i) => ({
-									id: i,
-									guestName: g.guestName,
-									guestBio: { renderHtml: g.guestBio },
-									headshot: g.headshot ? [{ path: extractPath(g.headshot) }] : [],
-					})),
-					episodeSponsors: (e.sponsors || []).map((s) => ({
-									title: s.title,
-									sponsorUrl: s.url,
-									sponsorImage: s.logo
-										? [
-											{
-																			path: extractPath(s.logo),
-																			width: s.logoWidth,
-																			height: s.logoHeight,
-											},
-																]
-														: [],
-									sponsorDescription: { renderHtml: s.description },
-					})),
-					url: `/podcast/${e.slug}`,
-		};
+	return {
+		title: e.title,
+		slug: e.slug,
+		id: e.id,
+		metaDescription: e.metaDescription,
+		podcastEpisode: e.episode,
+		podcastSeason: e.season,
+		podcastPublishDate: e.publishDate,
+		podcastBuzzsproutId: e.buzzsproutId,
+		podcastShortDescription: { renderHtml: e.shortDescription },
+		podcastShowNotes: { renderHtml: e.showNotes },
+		podcastEpisodeCard: e.episodeCard
+			? [{ path: extractPath(e.episodeCard) }]
+			: [],
+		podcastGuests: (e.guests || []).map((g, i) => ({
+			id: i,
+			guestName: g.guestName,
+			guestBio: { renderHtml: g.guestBio },
+			headshot: g.headshot ? [{ path: extractPath(g.headshot) }] : [],
+		})),
+		episodeSponsors: (e.sponsors || []).map((s) => ({
+			title: s.title,
+			sponsorUrl: s.url,
+			sponsorImage: s.logo
+				? [
+						{
+							path: extractPath(s.logo),
+							width: s.logoWidth,
+							height: s.logoHeight,
+						},
+					]
+				: [],
+			sponsorDescription: { renderHtml: s.description },
+		})),
+		url: `/podcast/${e.slug}`,
+	};
 }
 
 // Map all episodes once at module load (bundled JSON, no async needed)
 const allMappedEpisodes: PodcastEpisode[] = (
-		rawEpisodes as VcDataEpisode[]
-	).map(mapEpisode);
+	rawEpisodes as VcDataEpisode[]
+).map(mapEpisode);
 
 // ---------------------------------------------------------------------------
 // Public API (same signatures as before)
 // ---------------------------------------------------------------------------
 
 export const getEpisodes = unstable_cache(
-		async ({ limit = 5 }: { limit?: number } = {}): Promise<PodcastEpisodes> => {
-					return allMappedEpisodes.slice(0, limit);
-		},
-		[],
+	async ({ limit = 5 }: { limit?: number } = {}): Promise<PodcastEpisodes> => {
+		return allMappedEpisodes.slice(0, limit);
+	},
+	[],
 	{ revalidate: false, tags: ['podcast'] },
-	);
+);
 
 export const getEpisode = unstable_cache(
-		async ({
-					slug,
-		}: {
-					slug: PodcastEpisode['slug'];
-					queryParams?: string;
-		}): Promise<PodcastEpisode | null> => {
-					return allMappedEpisodes.find((e) => e.slug === slug) ?? null;
-		},
-		[],
+	async ({
+		slug,
+	}: {
+		slug: PodcastEpisode['slug'];
+		queryParams?: string;
+	}): Promise<PodcastEpisode | null> => {
+		return allMappedEpisodes.find((e) => e.slug === slug) ?? null;
+	},
+	[],
 	{ revalidate: false, tags: ['podcast'] },
-	);
+);
 
 // ---------------------------------------------------------------------------
 // Transcript — unchanged, reads from feeds.virtualcoffee.io
 // ---------------------------------------------------------------------------
 
 type TranscriptSegment = {
-		speaker: string;
-		startTime: number;
-		endTime: number;
-		body: string;
+	speaker: string;
+	startTime: number;
+	endTime: number;
+	body: string;
 };
 type TranscriptItem = {
-		name: string;
-		text: string;
-		timestamp: string;
+	name: string;
+	text: string;
+	timestamp: string;
 };
 type Transcript = Array<TranscriptItem>;
 
 export const getTranscript = unstable_cache(
-		async ({ id }: Partial<PodcastEpisode>): Promise<Transcript | null> => {
-					try {
-									const response: { segments: TranscriptSegment[] } = await fetch(
-														`https://feeds.virtualcoffee.io/podcast-assets/${id}/transcript.json`,
-													).then((res) => res.json());
+	async ({ id }: Partial<PodcastEpisode>): Promise<Transcript | null> => {
+		try {
+			const response: { segments: TranscriptSegment[] } = await fetch(
+				`https://feeds.virtualcoffee.io/podcast-assets/${id}/transcript.json`,
+			).then((res) => res.json());
 
-						if (response && response.segments) {
-											return response.segments.reduce(
-																	(arr: Transcript, segment: TranscriptSegment) => {
-																								if (
-																																arr.length &&
-																																arr[arr.length - 1].name === segment.speaker
-																															) {
-																																const cur: TranscriptItem | undefined = arr.pop();
-																																if (typeof cur === 'undefined') return [...arr];
-																																return [
-																																									...arr,
-																																	{
-																																											...cur,
-																																											text: cur.text + ' ' + segment.body,
-																																	},
-																																								];
-																								} else {
-																																const date = new Date(0);
-																																date.setSeconds(segment.startTime);
+			if (response && response.segments) {
+				return response.segments.reduce(
+					(arr: Transcript, segment: TranscriptSegment) => {
+						if (arr.length && arr[arr.length - 1].name === segment.speaker) {
+							const cur: TranscriptItem | undefined = arr.pop();
+							if (typeof cur === 'undefined') return [...arr];
+							return [
+								...arr,
+								{
+									...cur,
+									text: cur.text + ' ' + segment.body,
+								},
+							];
+						} else {
+							const date = new Date(0);
+							date.setSeconds(segment.startTime);
 
-																									return [
-																																		...arr,
-																										{
-																																				name: segment.speaker,
-																																				text: segment.body,
-																																				timestamp: date.toISOString().substr(14, 5),
-																										},
-																																	];
-																								}
-																	},
-																	[],
-																);
+							return [
+								...arr,
+								{
+									name: segment.speaker,
+									text: segment.body,
+									timestamp: date.toISOString().substr(14, 5),
+								},
+							];
 						}
+					},
+					[],
+				);
+			}
 
-						console.log('no response.segments');
+			console.log('no response.segments');
 
-						return null;
-					} catch (error) {
-									console.error(`Error loading transcript ${id}`, error);
-									return null;
-					}
-		},
-		[],
+			return null;
+		} catch (error) {
+			console.error(`Error loading transcript ${id}`, error);
+			return null;
+		}
+	},
+	[],
 	{ revalidate: 86400, tags: ['podcast'] },
-	);
+);
 
 // ---------------------------------------------------------------------------
 // Kept for backwards compatibility — no longer needed with vc-data
@@ -247,5 +244,5 @@ export const getTranscript = unstable_cache(
 // ---------------------------------------------------------------------------
 
 export async function getEpisodeQueryParams(_request: Request) {
-		return '';
+	return '';
 }

--- a/src/data/podcast.ts
+++ b/src/data/podcast.ts
@@ -1,142 +1,60 @@
-import { GraphQLClient, gql } from 'graphql-request';
 import { unstable_cache } from 'next/cache';
 
 export const buzzsproutPodcastId = '1558601' as const;
 
-const episodeQuery = gql`
-	query getEpisode($slug: String!) {
-		entry(section: "podcast", slug: [$slug]) {
-			title
-			... on podcast_default_Entry {
-				id
-				episodeSponsors {
-					title
-					... on podcastSponsors_default_Entry {
-						sponsorUrl: urlValue
-						sponsorImage: podcastEpisodeCard {
-							path
-							width
-							height
-						}
-						sponsorDescription: podcastShowNotes {
-							renderHtml
-						}
-					}
-				}
-				metaDescription
-				podcastEpisode
-				podcastBuzzsproutId
-				podcastPublishDate
-				podcastSeason
-				podcastShortDescription {
-					renderHtml
-				}
-				podcastShowNotes {
-					renderHtml
-				}
-				podcastGuests {
-					... on podcastGuests_guest_BlockType {
-						id
-						guestName
-						guestBio {
-							renderHtml
-						}
-						headshot {
-							path
-						}
-					}
-				}
-				podcastEpisodeCard {
-					path
-				}
-			}
-		}
-	}
-`;
+// vc-data is the single source of truth for podcast data.
+// https://github.com/Virtual-Coffee/vc-data
+const VC_DATA_EPISODES_URL =
+		'https://raw.githubusercontent.com/Virtual-Coffee/vc-data/main/podcast/episodes.json';
 
-const episodesQuery = gql`
-	query getEpisodes($limit: Int!) {
-		entries(section: "podcast", limit: $limit) {
-			title
-			slug
-			... on podcast_default_Entry {
-				id
-				metaDescription
-				podcastEpisode
-				podcastSeason
-				podcastPublishDate
-				podcastBuzzsproutId
-				episodeSponsors {
-					title
-					... on podcastSponsors_default_Entry {
-						sponsorUrl: urlValue
-						sponsorImage: podcastEpisodeCard {
-							path
-							width
-							height
-						}
-						sponsorDescription: podcastShowNotes {
-							renderHtml
-						}
-					}
-				}
-			}
-		}
-	}
-`;
+const IMGIX_PREFIX = 'https://virtualcoffeeio-cms.imgix.net/podcast/';
 
-export async function getEpisodeQueryParams(request: Request) {
-	const url = new URL(request.url);
-
-	const sp = new URLSearchParams();
-	const craftPreview = url.searchParams.get('x-craft-preview');
-	if (craftPreview) {
-		sp.set('x-craft-preview', craftPreview);
-	}
-
-	const token = url.searchParams.get('token');
-	if (token) {
-		sp.set('token', token);
-	}
-
-	return sp.toString();
+/** Strip the full imgix URL down to just the filename, which is what createCmsImage expects. */
+function extractPath(fullUrl: string | null | undefined): string {
+		if (!fullUrl) return '';
+		return fullUrl.startsWith(IMGIX_PREFIX)
+			? fullUrl.slice(IMGIX_PREFIX.length)
+					: fullUrl;
 }
+
+// ---------------------------------------------------------------------------
+// Types that match the shape the rest of the app expects (unchanged from before)
+// ---------------------------------------------------------------------------
 
 export interface PodcastEpisode {
-	title: string;
-	slug: string;
-	id: string;
-	metaDescription: string;
-	podcastEpisode: number;
-	podcastSeason: number;
-	podcastPublishDate: string;
-	podcastBuzzsproutId: string;
-	podcastShortDescription: {
-		renderHtml: string;
-	};
-	podcastShowNotes: {
-		renderHtml: string;
-	};
-	podcastGuests: Array<{
-		id: number | string;
-		guestName: string;
-		guestBio: { renderHtml: string };
-		headshot: Array<{ path: string }>;
-	}>;
-	podcastEpisodeCard: Array<{ path: string }>;
-	url: string;
-	episodeSponsors: Array<{
 		title: string;
-		sponsorUrl: string;
-		sponsorImage: Array<{ path: string; width: number; height: number }>;
-		sponsorDescription: { renderHtml: string };
-	}>;
+		slug: string;
+		id: string;
+		metaDescription: string;
+		podcastEpisode: number;
+		podcastSeason: number;
+		podcastPublishDate: string;
+		podcastBuzzsproutId: string;
+		podcastShortDescription: {
+			renderHtml: string;
+		};
+		podcastShowNotes: {
+			renderHtml: string;
+		};
+		podcastGuests: Array<{
+			id: number | string;
+			guestName: string;
+			guestBio: { renderHtml: string };
+			headshot: Array<{ path: string }>;
+		}>;
+		podcastEpisodeCard: Array<{ path: string }>;
+		url: string;
+		episodeSponsors: Array<{
+			title: string;
+			sponsorUrl: string;
+			sponsorImage: Array<{ path: string; width: number; height: number }>;
+			sponsorDescription: { renderHtml: string };
+		}>;
 }
 
-// type PodcastEpisodes = Partial<PodcastEpisode>[];
 type PodcastEpisodes = Pick<
-	PodcastEpisode,
-	| 'title'
+		PodcastEpisode,
+		| 'title'
 	| 'slug'
 	| 'id'
 	| 'metaDescription'
@@ -147,156 +65,202 @@ type PodcastEpisodes = Pick<
 	| 'url'
 	| 'episodeSponsors'
 >[];
-type PodcastEpisodeResponse = {
-	entries: PodcastEpisode[];
-};
+
+// ---------------------------------------------------------------------------
+// Shape of data in vc-data/podcast/episodes.json
+// ---------------------------------------------------------------------------
+
+interface VcDataEpisode {
+		title: string;
+		slug: string;
+		id: string;
+		metaDescription: string;
+		season: number;
+		episode: number;
+		buzzsproutId: string;
+		publishDate: string;
+		shortDescription: string;
+		showNotes: string;
+		episodeCard: string;
+		guests: Array<{
+			guestName: string;
+			guestBio: string;
+			headshot: string | null;
+		}>;
+		sponsors: Array<{
+			title: string;
+			url: string;
+			logo: string | null;
+			logoWidth: number;
+			logoHeight: number;
+			description: string;
+		}>;
+}
+
+// ---------------------------------------------------------------------------
+// Mapping: vc-data shape → legacy Craft shape the app expects
+// ---------------------------------------------------------------------------
+
+function mapEpisode(e: VcDataEpisode): PodcastEpisode {
+		return {
+					title: e.title,
+					slug: e.slug,
+					id: e.id,
+					metaDescription: e.metaDescription,
+					podcastEpisode: e.episode,
+					podcastSeason: e.season,
+					podcastPublishDate: e.publishDate,
+					podcastBuzzsproutId: e.buzzsproutId,
+					podcastShortDescription: { renderHtml: e.shortDescription },
+					podcastShowNotes: { renderHtml: e.showNotes },
+					podcastEpisodeCard: e.episodeCard
+						? [{ path: extractPath(e.episodeCard) }]
+									: [],
+					podcastGuests: (e.guests || []).map((g, i) => ({
+									id: i,
+									guestName: g.guestName,
+									guestBio: { renderHtml: g.guestBio },
+									headshot: g.headshot ? [{ path: extractPath(g.headshot) }] : [],
+					})),
+					episodeSponsors: (e.sponsors || []).map((s) => ({
+									title: s.title,
+									sponsorUrl: s.url,
+									sponsorImage: s.logo
+										? [
+											{
+																			path: extractPath(s.logo),
+																			width: s.logoWidth,
+																			height: s.logoHeight,
+											},
+																]
+														: [],
+									sponsorDescription: { renderHtml: s.description },
+					})),
+					url: `/podcast/${e.slug}`,
+		};
+}
+
+// ---------------------------------------------------------------------------
+// Fetch all episodes from vc-data (cached 24 hrs)
+// ---------------------------------------------------------------------------
+
+const getAllEpisodes = unstable_cache(
+		async (): Promise<PodcastEpisode[]> => {
+					const res = await fetch(VC_DATA_EPISODES_URL, {
+									next: { revalidate: 86400 },
+					});
+					if (!res.ok) {
+									throw new Error(`Failed to fetch episodes: ${res.status}`);
+					}
+					const raw: VcDataEpisode[] = await res.json();
+					return raw.map(mapEpisode);
+		},
+		['vc-data-podcast-episodes'],
+	{ revalidate: 86400, tags: ['podcast'] },
+	);
+
+// ---------------------------------------------------------------------------
+// Public API (same signatures as before)
+// ---------------------------------------------------------------------------
 
 export const getEpisodes = unstable_cache(
-	async ({ limit = 5 }: { limit?: number } = {}): Promise<PodcastEpisodes> => {
-		if (!(process.env.CMS_URL && process.env.CMS_TOKEN)) {
-			const fakeData = await import('./mocks/podcast.server');
-			return fakeData.getEpisodes({ limit }).map((entry) => ({
-				...entry,
-				url: `/podcast/${entry.slug}`,
-			}));
-		}
-
-		const graphQLClient = new GraphQLClient(`${process.env.CMS_URL}/api`, {
-			headers: {
-				Authorization: `bearer ${process.env.CMS_TOKEN}`,
-			},
-		});
-
-		try {
-			const episodesResponse =
-				await graphQLClient.request<PodcastEpisodeResponse>(episodesQuery, {
-					limit,
-				});
-			return episodesResponse.entries.map((entry) => ({
-				...entry,
-				url: `/podcast/${entry.slug}`,
-			}));
-		} catch (e) {
-			console.error(e);
-			return [];
-		}
-	},
-	[],
+		async ({ limit = 5 }: { limit?: number } = {}): Promise<PodcastEpisodes> => {
+					const episodes = await getAllEpisodes();
+					return episodes.slice(0, limit);
+		},
+		[],
 	{ revalidate: 86400, tags: ['podcast'] },
-);
+	);
 
 export const getEpisode = unstable_cache(
-	async ({
-		slug,
-		queryParams = '',
-	}: {
-		slug: PodcastEpisode['slug'];
-		queryParams?: string;
-	}): Promise<PodcastEpisode | null> => {
-		if (!(process.env.CMS_URL && process.env.CMS_TOKEN)) {
-			const fakeData = await import('./mocks/podcast.server');
-			const episode = fakeData.getEpisode({ slug });
-			return {
-				...episode,
-				url: `/podcast/${episode.slug}`,
-			};
-		}
-
-		const graphQLClient = new GraphQLClient(
-			`${process.env.CMS_URL}/api?${queryParams || ''}`,
-			{
-				headers: {
-					Authorization: `bearer ${process.env.CMS_TOKEN}`,
-				},
-			},
-		);
-
-		try {
-			console.log('requesting');
-			const episodesResponse = await graphQLClient.request<{
-				entry: PodcastEpisode;
-			}>(episodeQuery, {
-				slug,
-			});
-			console.log('finished:');
-
-			// return response.slice(0, 10);
-			if (!episodesResponse.entry) {
-				throw new Error('No episode found');
-			}
-
-			return {
-				...episodesResponse.entry,
-				url: `/podcast/${episodesResponse.entry.slug}`,
-			};
-		} catch (e) {
-			console.error(e);
-			return null;
-		}
-	},
-	[],
+		async ({
+					slug,
+		}: {
+					slug: PodcastEpisode['slug'];
+					queryParams?: string;
+		}): Promise<PodcastEpisode | null> => {
+					const episodes = await getAllEpisodes();
+					return episodes.find((e) => e.slug === slug) ?? null;
+		},
+		[],
 	{ revalidate: 86400, tags: ['podcast'] },
-);
+	);
+
+// ---------------------------------------------------------------------------
+// Transcript — unchanged, reads from feeds.virtualcoffee.io
+// ---------------------------------------------------------------------------
 
 type TranscriptSegment = {
-	speaker: string;
-	startTime: number;
-	endTime: number;
-	body: string;
+		speaker: string;
+		startTime: number;
+		endTime: number;
+		body: string;
 };
 type TranscriptItem = {
-	name: string;
-	text: string;
-	timestamp: string;
+		name: string;
+		text: string;
+		timestamp: string;
 };
 type Transcript = Array<TranscriptItem>;
 
 export const getTranscript = unstable_cache(
-	async ({ id }: Partial<PodcastEpisode>): Promise<Transcript | null> => {
-		try {
-			const response: { segments: TranscriptSegment[] } = await fetch(
-				`https://feeds.virtualcoffee.io/podcast-assets/${id}/transcript.json`,
-			).then((res) => res.json());
+		async ({ id }: Partial<PodcastEpisode>): Promise<Transcript | null> => {
+					try {
+									const response: { segments: TranscriptSegment[] } = await fetch(
+														`https://feeds.virtualcoffee.io/podcast-assets/${id}/transcript.json`,
+													).then((res) => res.json());
 
-			if (response && response.segments) {
-				return response.segments.reduce(
-					(arr: Transcript, segment: TranscriptSegment) => {
-						if (arr.length && arr[arr.length - 1].name === segment.speaker) {
-							const cur: TranscriptItem | undefined = arr.pop();
-							if (typeof cur === 'undefined') return [...arr];
-							return [
-								...arr,
-								{
-									...cur,
-									text: cur.text + ' ' + segment.body,
-								},
-							];
-						} else {
-							const date = new Date(0);
-							date.setSeconds(segment.startTime);
+						if (response && response.segments) {
+											return response.segments.reduce(
+																	(arr: Transcript, segment: TranscriptSegment) => {
+																								if (
+																																arr.length &&
+																																arr[arr.length - 1].name === segment.speaker
+																															) {
+																																const cur: TranscriptItem | undefined = arr.pop();
+																																if (typeof cur === 'undefined') return [...arr];
+																																return [
+																																									...arr,
+																																	{
+																																											...cur,
+																																											text: cur.text + ' ' + segment.body,
+																																	},
+																																								];
+																								} else {
+																																const date = new Date(0);
+																																date.setSeconds(segment.startTime);
 
-							return [
-								...arr,
-								{
-									name: segment.speaker,
-									text: segment.body,
-									timestamp: date.toISOString().substr(14, 5),
-								},
-							];
+																									return [
+																																		...arr,
+																										{
+																																				name: segment.speaker,
+																																				text: segment.body,
+																																				timestamp: date.toISOString().substr(14, 5),
+																										},
+																																	];
+																								}
+																	},
+																	[],
+																);
 						}
-					},
-					[],
-				);
-			}
 
-			console.log('no response.segments');
+						console.log('no response.segments');
 
-			return null;
-		} catch (error) {
-			console.error(`Error loading transcript ${id}`, error);
-			return null;
-		}
-	},
-	[],
+						return null;
+					} catch (error) {
+									console.error(`Error loading transcript ${id}`, error);
+									return null;
+					}
+		},
+		[],
 	{ revalidate: 86400, tags: ['podcast'] },
-);
+	);
+
+// ---------------------------------------------------------------------------
+// Kept for backwards compatibility — no longer needed with vc-data
+// but removing it would be a breaking change if anything imports it.
+// ---------------------------------------------------------------------------
+
+export async function getEpisodeQueryParams(_request: Request) {
+		return '';
+}

--- a/src/data/podcast.ts
+++ b/src/data/podcast.ts
@@ -6,16 +6,16 @@ export const buzzsproutPodcastId = '1558601' as const;
 // https://github.com/Virtual-Coffee/vc-data
 // Uses the GitHub Contents API so it works with private repos (via GITHUB_TOKEN).
 const VC_DATA_EPISODES_API_URL =
-		'https://api.github.com/repos/Virtual-Coffee/vc-data/contents/podcast/episodes.json';
+	'https://api.github.com/repos/Virtual-Coffee/vc-data/contents/podcast/episodes.json';
 
 const IMGIX_PREFIX = 'https://virtualcoffeeio-cms.imgix.net/podcast/';
 
 /** Strip the full imgix URL down to just the filename, which is what createCmsImage expects. */
 function extractPath(fullUrl: string | null | undefined): string {
-		if (!fullUrl) return '';
-		return fullUrl.startsWith(IMGIX_PREFIX)
-			? fullUrl.slice(IMGIX_PREFIX.length)
-					: fullUrl;
+	if (!fullUrl) return '';
+	return fullUrl.startsWith(IMGIX_PREFIX)
+		? fullUrl.slice(IMGIX_PREFIX.length)
+		: fullUrl;
 }
 
 // ---------------------------------------------------------------------------
@@ -23,39 +23,39 @@ function extractPath(fullUrl: string | null | undefined): string {
 // ---------------------------------------------------------------------------
 
 export interface PodcastEpisode {
+	title: string;
+	slug: string;
+	id: string;
+	metaDescription: string;
+	podcastEpisode: number;
+	podcastSeason: number;
+	podcastPublishDate: string;
+	podcastBuzzsproutId: string;
+	podcastShortDescription: {
+		renderHtml: string;
+	};
+	podcastShowNotes: {
+		renderHtml: string;
+	};
+	podcastGuests: Array<{
+		id: number | string;
+		guestName: string;
+		guestBio: { renderHtml: string };
+		headshot: Array<{ path: string }>;
+	}>;
+	podcastEpisodeCard: Array<{ path: string }>;
+	url: string;
+	episodeSponsors: Array<{
 		title: string;
-		slug: string;
-		id: string;
-		metaDescription: string;
-		podcastEpisode: number;
-		podcastSeason: number;
-		podcastPublishDate: string;
-		podcastBuzzsproutId: string;
-		podcastShortDescription: {
-			renderHtml: string;
-		};
-		podcastShowNotes: {
-			renderHtml: string;
-		};
-		podcastGuests: Array<{
-			id: number | string;
-			guestName: string;
-			guestBio: { renderHtml: string };
-			headshot: Array<{ path: string }>;
-		}>;
-		podcastEpisodeCard: Array<{ path: string }>;
-		url: string;
-		episodeSponsors: Array<{
-			title: string;
-			sponsorUrl: string;
-			sponsorImage: Array<{ path: string; width: number; height: number }>;
-			sponsorDescription: { renderHtml: string };
-		}>;
+		sponsorUrl: string;
+		sponsorImage: Array<{ path: string; width: number; height: number }>;
+		sponsorDescription: { renderHtml: string };
+	}>;
 }
 
 type PodcastEpisodes = Pick<
-		PodcastEpisode,
-		| 'title'
+	PodcastEpisode,
+	| 'title'
 	| 'slug'
 	| 'id'
 	| 'metaDescription'
@@ -72,30 +72,30 @@ type PodcastEpisodes = Pick<
 // ---------------------------------------------------------------------------
 
 interface VcDataEpisode {
+	title: string;
+	slug: string;
+	id: string;
+	metaDescription: string;
+	season: number;
+	episode: number;
+	buzzsproutId: string;
+	publishDate: string;
+	shortDescription: string;
+	showNotes: string;
+	episodeCard: string;
+	guests: Array<{
+		guestName: string;
+		guestBio: string;
+		headshot: string | null;
+	}>;
+	sponsors: Array<{
 		title: string;
-		slug: string;
-		id: string;
-		metaDescription: string;
-		season: number;
-		episode: number;
-		buzzsproutId: string;
-		publishDate: string;
-		shortDescription: string;
-		showNotes: string;
-		episodeCard: string;
-		guests: Array<{
-			guestName: string;
-			guestBio: string;
-			headshot: string | null;
-		}>;
-		sponsors: Array<{
-			title: string;
-			url: string;
-			logo: string | null;
-			logoWidth: number;
-			logoHeight: number;
-			description: string;
-		}>;
+		url: string;
+		logo: string | null;
+		logoWidth: number;
+		logoHeight: number;
+		description: string;
+	}>;
 }
 
 // ---------------------------------------------------------------------------
@@ -103,42 +103,42 @@ interface VcDataEpisode {
 // ---------------------------------------------------------------------------
 
 function mapEpisode(e: VcDataEpisode): PodcastEpisode {
-		return {
-					title: e.title,
-					slug: e.slug,
-					id: e.id,
-					metaDescription: e.metaDescription,
-					podcastEpisode: e.episode,
-					podcastSeason: e.season,
-					podcastPublishDate: e.publishDate,
-					podcastBuzzsproutId: e.buzzsproutId,
-					podcastShortDescription: { renderHtml: e.shortDescription },
-					podcastShowNotes: { renderHtml: e.showNotes },
-					podcastEpisodeCard: e.episodeCard
-						? [{ path: extractPath(e.episodeCard) }]
-									: [],
-					podcastGuests: (e.guests || []).map((g, i) => ({
-									id: i,
-									guestName: g.guestName,
-									guestBio: { renderHtml: g.guestBio },
-									headshot: g.headshot ? [{ path: extractPath(g.headshot) }] : [],
-					})),
-					episodeSponsors: (e.sponsors || []).map((s) => ({
-									title: s.title,
-									sponsorUrl: s.url,
-									sponsorImage: s.logo
-										? [
-											{
-																			path: extractPath(s.logo),
-																			width: s.logoWidth,
-																			height: s.logoHeight,
-											},
-																]
-														: [],
-									sponsorDescription: { renderHtml: s.description },
-					})),
-					url: `/podcast/${e.slug}`,
-		};
+	return {
+		title: e.title,
+		slug: e.slug,
+		id: e.id,
+		metaDescription: e.metaDescription,
+		podcastEpisode: e.episode,
+		podcastSeason: e.season,
+		podcastPublishDate: e.publishDate,
+		podcastBuzzsproutId: e.buzzsproutId,
+		podcastShortDescription: { renderHtml: e.shortDescription },
+		podcastShowNotes: { renderHtml: e.showNotes },
+		podcastEpisodeCard: e.episodeCard
+			? [{ path: extractPath(e.episodeCard) }]
+			: [],
+		podcastGuests: (e.guests || []).map((g, i) => ({
+			id: i,
+			guestName: g.guestName,
+			guestBio: { renderHtml: g.guestBio },
+			headshot: g.headshot ? [{ path: extractPath(g.headshot) }] : [],
+		})),
+		episodeSponsors: (e.sponsors || []).map((s) => ({
+			title: s.title,
+			sponsorUrl: s.url,
+			sponsorImage: s.logo
+				? [
+						{
+							path: extractPath(s.logo),
+							width: s.logoWidth,
+							height: s.logoHeight,
+						},
+					]
+				: [],
+			sponsorDescription: { renderHtml: s.description },
+		})),
+		url: `/podcast/${e.slug}`,
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -146,130 +146,127 @@ function mapEpisode(e: VcDataEpisode): PodcastEpisode {
 // ---------------------------------------------------------------------------
 
 const getAllEpisodes = unstable_cache(
-		async (): Promise<PodcastEpisode[]> => {
-					const headers: Record<string, string> = {
-									Accept: 'application/vnd.github.v3.raw',
-					};
-					// GITHUB_TOKEN is available in the Netlify build environment and enables
-			// access to private repos. Falls back gracefully if not set (public repos).
-			if (process.env.GITHUB_TOKEN) {
-							headers['Authorization'] = `token ${process.env.GITHUB_TOKEN}`;
-			}
+	async (): Promise<PodcastEpisode[]> => {
+		const headers: Record<string, string> = {
+			Accept: 'application/vnd.github.v3.raw',
+		};
+		// GITHUB_TOKEN is available in the Netlify build environment and enables
+		// access to private repos. Falls back gracefully if not set (public repos).
+		if (process.env.GITHUB_TOKEN) {
+			headers['Authorization'] = `token ${process.env.GITHUB_TOKEN}`;
+		}
 
-			const res = await fetch(VC_DATA_EPISODES_API_URL, {
-							headers,
-							next: { revalidate: 86400 },
-			});
+		const res = await fetch(VC_DATA_EPISODES_API_URL, {
+			headers,
+			next: { revalidate: 86400 },
+		});
 
-			if (!res.ok) {
-							throw new Error(
-												`Failed to fetch episodes from vc-data: ${res.status} ${res.statusText}`,
-											);
-			}
+		if (!res.ok) {
+			throw new Error(
+				`Failed to fetch episodes from vc-data: ${res.status} ${res.statusText}`,
+			);
+		}
 
-			const raw: VcDataEpisode[] = await res.json();
-					return raw.map(mapEpisode);
-		},
-		['vc-data-podcast-episodes'],
+		const raw: VcDataEpisode[] = await res.json();
+		return raw.map(mapEpisode);
+	},
+	['vc-data-podcast-episodes'],
 	{ revalidate: 86400, tags: ['podcast'] },
-	);
+);
 
 // ---------------------------------------------------------------------------
 // Public API (same signatures as before)
 // ---------------------------------------------------------------------------
 
 export const getEpisodes = unstable_cache(
-		async ({ limit = 5 }: { limit?: number } = {}): Promise<PodcastEpisodes> => {
-					const episodes = await getAllEpisodes();
-					return episodes.slice(0, limit);
-		},
-		[],
+	async ({ limit = 5 }: { limit?: number } = {}): Promise<PodcastEpisodes> => {
+		const episodes = await getAllEpisodes();
+		return episodes.slice(0, limit);
+	},
+	[],
 	{ revalidate: 86400, tags: ['podcast'] },
-	);
+);
 
 export const getEpisode = unstable_cache(
-		async ({
-					slug,
-		}: {
-					slug: PodcastEpisode['slug'];
-					queryParams?: string;
-		}): Promise<PodcastEpisode | null> => {
-					const episodes = await getAllEpisodes();
-					return episodes.find((e) => e.slug === slug) ?? null;
-		},
-		[],
+	async ({
+		slug,
+	}: {
+		slug: PodcastEpisode['slug'];
+		queryParams?: string;
+	}): Promise<PodcastEpisode | null> => {
+		const episodes = await getAllEpisodes();
+		return episodes.find((e) => e.slug === slug) ?? null;
+	},
+	[],
 	{ revalidate: 86400, tags: ['podcast'] },
-	);
+);
 
 // ---------------------------------------------------------------------------
 // Transcript — unchanged, reads from feeds.virtualcoffee.io
 // ---------------------------------------------------------------------------
 
 type TranscriptSegment = {
-		speaker: string;
-		startTime: number;
-		endTime: number;
-		body: string;
+	speaker: string;
+	startTime: number;
+	endTime: number;
+	body: string;
 };
 type TranscriptItem = {
-		name: string;
-		text: string;
-		timestamp: string;
+	name: string;
+	text: string;
+	timestamp: string;
 };
 type Transcript = Array<TranscriptItem>;
 
 export const getTranscript = unstable_cache(
-		async ({ id }: Partial<PodcastEpisode>): Promise<Transcript | null> => {
-					try {
-									const response: { segments: TranscriptSegment[] } = await fetch(
-														`https://feeds.virtualcoffee.io/podcast-assets/${id}/transcript.json`,
-													).then((res) => res.json());
+	async ({ id }: Partial<PodcastEpisode>): Promise<Transcript | null> => {
+		try {
+			const response: { segments: TranscriptSegment[] } = await fetch(
+				`https://feeds.virtualcoffee.io/podcast-assets/${id}/transcript.json`,
+			).then((res) => res.json());
 
-						if (response && response.segments) {
-											return response.segments.reduce(
-																	(arr: Transcript, segment: TranscriptSegment) => {
-																								if (
-																																arr.length &&
-																																arr[arr.length - 1].name === segment.speaker
-																															) {
-																																const cur: TranscriptItem | undefined = arr.pop();
-																																if (typeof cur === 'undefined') return [...arr];
-																																return [
-																																									...arr,
-																																	{
-																																											...cur,
-																																											text: cur.text + ' ' + segment.body,
-																																	},
-																																								];
-																								} else {
-																																const date = new Date(0);
-																																date.setSeconds(segment.startTime);
+			if (response && response.segments) {
+				return response.segments.reduce(
+					(arr: Transcript, segment: TranscriptSegment) => {
+						if (arr.length && arr[arr.length - 1].name === segment.speaker) {
+							const cur: TranscriptItem | undefined = arr.pop();
+							if (typeof cur === 'undefined') return [...arr];
+							return [
+								...arr,
+								{
+									...cur,
+									text: cur.text + ' ' + segment.body,
+								},
+							];
+						} else {
+							const date = new Date(0);
+							date.setSeconds(segment.startTime);
 
-																									return [
-																																		...arr,
-																										{
-																																				name: segment.speaker,
-																																				text: segment.body,
-																																				timestamp: date.toISOString().substr(14, 5),
-																										},
-																																	];
-																								}
-																	},
-																	[],
-																);
+							return [
+								...arr,
+								{
+									name: segment.speaker,
+									text: segment.body,
+									timestamp: date.toISOString().substr(14, 5),
+								},
+							];
 						}
+					},
+					[],
+				);
+			}
 
-						console.log('no response.segments');
+			console.log('no response.segments');
 
-						return null;
-					} catch (error) {
-									console.error(`Error loading transcript ${id}`, error);
-									return null;
-					}
-		},
-		[],
+			return null;
+		} catch (error) {
+			console.error(`Error loading transcript ${id}`, error);
+			return null;
+		}
+	},
+	[],
 	{ revalidate: 86400, tags: ['podcast'] },
-	);
+);
 
 // ---------------------------------------------------------------------------
 // Kept for backwards compatibility — no longer needed with vc-data
@@ -277,5 +274,5 @@ export const getTranscript = unstable_cache(
 // ---------------------------------------------------------------------------
 
 export async function getEpisodeQueryParams(_request: Request) {
-		return '';
+	return '';
 }

--- a/src/data/podcast.ts
+++ b/src/data/podcast.ts
@@ -1,21 +1,21 @@
 import { unstable_cache } from 'next/cache';
+import rawEpisodes from './podcast/episodes.json';
 
 export const buzzsproutPodcastId = '1558601' as const;
 
-// vc-data is the single source of truth for podcast data.
-// https://github.com/Virtual-Coffee/vc-data
-// Uses the GitHub Contents API so it works with private repos (via GITHUB_TOKEN).
-const VC_DATA_EPISODES_API_URL =
-	'https://api.github.com/repos/Virtual-Coffee/vc-data/contents/podcast/episodes.json';
+// episodes.json is sourced from vc-data and bundled here at build time.
+// To update: copy the latest episodes.json from Virtual-Coffee/vc-data into
+// src/data/podcast/episodes.json and open a PR.
+// https://github.com/Virtual-Coffee/vc-data/blob/main/podcast/episodes.json
 
 const IMGIX_PREFIX = 'https://virtualcoffeeio-cms.imgix.net/podcast/';
 
 /** Strip the full imgix URL down to just the filename, which is what createCmsImage expects. */
 function extractPath(fullUrl: string | null | undefined): string {
-	if (!fullUrl) return '';
-	return fullUrl.startsWith(IMGIX_PREFIX)
-		? fullUrl.slice(IMGIX_PREFIX.length)
-		: fullUrl;
+		if (!fullUrl) return '';
+		return fullUrl.startsWith(IMGIX_PREFIX)
+			? fullUrl.slice(IMGIX_PREFIX.length)
+					: fullUrl;
 }
 
 // ---------------------------------------------------------------------------
@@ -23,39 +23,39 @@ function extractPath(fullUrl: string | null | undefined): string {
 // ---------------------------------------------------------------------------
 
 export interface PodcastEpisode {
-	title: string;
-	slug: string;
-	id: string;
-	metaDescription: string;
-	podcastEpisode: number;
-	podcastSeason: number;
-	podcastPublishDate: string;
-	podcastBuzzsproutId: string;
-	podcastShortDescription: {
-		renderHtml: string;
-	};
-	podcastShowNotes: {
-		renderHtml: string;
-	};
-	podcastGuests: Array<{
-		id: number | string;
-		guestName: string;
-		guestBio: { renderHtml: string };
-		headshot: Array<{ path: string }>;
-	}>;
-	podcastEpisodeCard: Array<{ path: string }>;
-	url: string;
-	episodeSponsors: Array<{
 		title: string;
-		sponsorUrl: string;
-		sponsorImage: Array<{ path: string; width: number; height: number }>;
-		sponsorDescription: { renderHtml: string };
-	}>;
+		slug: string;
+		id: string;
+		metaDescription: string;
+		podcastEpisode: number;
+		podcastSeason: number;
+		podcastPublishDate: string;
+		podcastBuzzsproutId: string;
+		podcastShortDescription: {
+			renderHtml: string;
+		};
+		podcastShowNotes: {
+			renderHtml: string;
+		};
+		podcastGuests: Array<{
+			id: number | string;
+			guestName: string;
+			guestBio: { renderHtml: string };
+			headshot: Array<{ path: string }>;
+		}>;
+		podcastEpisodeCard: Array<{ path: string }>;
+		url: string;
+		episodeSponsors: Array<{
+			title: string;
+			sponsorUrl: string;
+			sponsorImage: Array<{ path: string; width: number; height: number }>;
+			sponsorDescription: { renderHtml: string };
+		}>;
 }
 
 type PodcastEpisodes = Pick<
-	PodcastEpisode,
-	| 'title'
+		PodcastEpisode,
+		| 'title'
 	| 'slug'
 	| 'id'
 	| 'metaDescription'
@@ -68,34 +68,34 @@ type PodcastEpisodes = Pick<
 >[];
 
 // ---------------------------------------------------------------------------
-// Shape of data in vc-data/podcast/episodes.json
+// Shape of data in episodes.json (sourced from vc-data)
 // ---------------------------------------------------------------------------
 
 interface VcDataEpisode {
-	title: string;
-	slug: string;
-	id: string;
-	metaDescription: string;
-	season: number;
-	episode: number;
-	buzzsproutId: string;
-	publishDate: string;
-	shortDescription: string;
-	showNotes: string;
-	episodeCard: string;
-	guests: Array<{
-		guestName: string;
-		guestBio: string;
-		headshot: string | null;
-	}>;
-	sponsors: Array<{
 		title: string;
-		url: string;
-		logo: string | null;
-		logoWidth: number;
-		logoHeight: number;
-		description: string;
-	}>;
+		slug: string;
+		id: string;
+		metaDescription: string;
+		season: number;
+		episode: number;
+		buzzsproutId: string;
+		publishDate: string;
+		shortDescription: string;
+		showNotes: string;
+		episodeCard: string;
+		guests: Array<{
+			guestName: string;
+			guestBio: string;
+			headshot: string | null;
+		}>;
+		sponsors: Array<{
+			title: string;
+			url: string;
+			logo: string | null;
+			logoWidth: number;
+			logoHeight: number;
+			description: string;
+		}>;
 }
 
 // ---------------------------------------------------------------------------
@@ -103,170 +103,143 @@ interface VcDataEpisode {
 // ---------------------------------------------------------------------------
 
 function mapEpisode(e: VcDataEpisode): PodcastEpisode {
-	return {
-		title: e.title,
-		slug: e.slug,
-		id: e.id,
-		metaDescription: e.metaDescription,
-		podcastEpisode: e.episode,
-		podcastSeason: e.season,
-		podcastPublishDate: e.publishDate,
-		podcastBuzzsproutId: e.buzzsproutId,
-		podcastShortDescription: { renderHtml: e.shortDescription },
-		podcastShowNotes: { renderHtml: e.showNotes },
-		podcastEpisodeCard: e.episodeCard
-			? [{ path: extractPath(e.episodeCard) }]
-			: [],
-		podcastGuests: (e.guests || []).map((g, i) => ({
-			id: i,
-			guestName: g.guestName,
-			guestBio: { renderHtml: g.guestBio },
-			headshot: g.headshot ? [{ path: extractPath(g.headshot) }] : [],
-		})),
-		episodeSponsors: (e.sponsors || []).map((s) => ({
-			title: s.title,
-			sponsorUrl: s.url,
-			sponsorImage: s.logo
-				? [
-						{
-							path: extractPath(s.logo),
-							width: s.logoWidth,
-							height: s.logoHeight,
-						},
-					]
-				: [],
-			sponsorDescription: { renderHtml: s.description },
-		})),
-		url: `/podcast/${e.slug}`,
-	};
+		return {
+					title: e.title,
+					slug: e.slug,
+					id: e.id,
+					metaDescription: e.metaDescription,
+					podcastEpisode: e.episode,
+					podcastSeason: e.season,
+					podcastPublishDate: e.publishDate,
+					podcastBuzzsproutId: e.buzzsproutId,
+					podcastShortDescription: { renderHtml: e.shortDescription },
+					podcastShowNotes: { renderHtml: e.showNotes },
+					podcastEpisodeCard: e.episodeCard
+						? [{ path: extractPath(e.episodeCard) }]
+									: [],
+					podcastGuests: (e.guests || []).map((g, i) => ({
+									id: i,
+									guestName: g.guestName,
+									guestBio: { renderHtml: g.guestBio },
+									headshot: g.headshot ? [{ path: extractPath(g.headshot) }] : [],
+					})),
+					episodeSponsors: (e.sponsors || []).map((s) => ({
+									title: s.title,
+									sponsorUrl: s.url,
+									sponsorImage: s.logo
+										? [
+											{
+																			path: extractPath(s.logo),
+																			width: s.logoWidth,
+																			height: s.logoHeight,
+											},
+																]
+														: [],
+									sponsorDescription: { renderHtml: s.description },
+					})),
+					url: `/podcast/${e.slug}`,
+		};
 }
 
-// ---------------------------------------------------------------------------
-// Fetch all episodes from vc-data via GitHub Contents API (supports private repos)
-// ---------------------------------------------------------------------------
-
-const getAllEpisodes = unstable_cache(
-	async (): Promise<PodcastEpisode[]> => {
-		const headers: Record<string, string> = {
-			Accept: 'application/vnd.github.v3.raw',
-		};
-		// GITHUB_TOKEN is available in the Netlify build environment and enables
-		// access to private repos. Falls back gracefully if not set (public repos).
-		if (process.env.GITHUB_TOKEN) {
-			headers['Authorization'] = `token ${process.env.GITHUB_TOKEN}`;
-		}
-
-		const res = await fetch(VC_DATA_EPISODES_API_URL, {
-			headers,
-			next: { revalidate: 86400 },
-		});
-
-		if (!res.ok) {
-			throw new Error(
-				`Failed to fetch episodes from vc-data: ${res.status} ${res.statusText}`,
-			);
-		}
-
-		const raw: VcDataEpisode[] = await res.json();
-		return raw.map(mapEpisode);
-	},
-	['vc-data-podcast-episodes'],
-	{ revalidate: 86400, tags: ['podcast'] },
-);
+// Map all episodes once at module load (bundled JSON, no async needed)
+const allMappedEpisodes: PodcastEpisode[] = (
+		rawEpisodes as VcDataEpisode[]
+	).map(mapEpisode);
 
 // ---------------------------------------------------------------------------
 // Public API (same signatures as before)
 // ---------------------------------------------------------------------------
 
 export const getEpisodes = unstable_cache(
-	async ({ limit = 5 }: { limit?: number } = {}): Promise<PodcastEpisodes> => {
-		const episodes = await getAllEpisodes();
-		return episodes.slice(0, limit);
-	},
-	[],
-	{ revalidate: 86400, tags: ['podcast'] },
-);
+		async ({ limit = 5 }: { limit?: number } = {}): Promise<PodcastEpisodes> => {
+					return allMappedEpisodes.slice(0, limit);
+		},
+		[],
+	{ revalidate: false, tags: ['podcast'] },
+	);
 
 export const getEpisode = unstable_cache(
-	async ({
-		slug,
-	}: {
-		slug: PodcastEpisode['slug'];
-		queryParams?: string;
-	}): Promise<PodcastEpisode | null> => {
-		const episodes = await getAllEpisodes();
-		return episodes.find((e) => e.slug === slug) ?? null;
-	},
-	[],
-	{ revalidate: 86400, tags: ['podcast'] },
-);
+		async ({
+					slug,
+		}: {
+					slug: PodcastEpisode['slug'];
+					queryParams?: string;
+		}): Promise<PodcastEpisode | null> => {
+					return allMappedEpisodes.find((e) => e.slug === slug) ?? null;
+		},
+		[],
+	{ revalidate: false, tags: ['podcast'] },
+	);
 
 // ---------------------------------------------------------------------------
 // Transcript — unchanged, reads from feeds.virtualcoffee.io
 // ---------------------------------------------------------------------------
 
 type TranscriptSegment = {
-	speaker: string;
-	startTime: number;
-	endTime: number;
-	body: string;
+		speaker: string;
+		startTime: number;
+		endTime: number;
+		body: string;
 };
 type TranscriptItem = {
-	name: string;
-	text: string;
-	timestamp: string;
+		name: string;
+		text: string;
+		timestamp: string;
 };
 type Transcript = Array<TranscriptItem>;
 
 export const getTranscript = unstable_cache(
-	async ({ id }: Partial<PodcastEpisode>): Promise<Transcript | null> => {
-		try {
-			const response: { segments: TranscriptSegment[] } = await fetch(
-				`https://feeds.virtualcoffee.io/podcast-assets/${id}/transcript.json`,
-			).then((res) => res.json());
+		async ({ id }: Partial<PodcastEpisode>): Promise<Transcript | null> => {
+					try {
+									const response: { segments: TranscriptSegment[] } = await fetch(
+														`https://feeds.virtualcoffee.io/podcast-assets/${id}/transcript.json`,
+													).then((res) => res.json());
 
-			if (response && response.segments) {
-				return response.segments.reduce(
-					(arr: Transcript, segment: TranscriptSegment) => {
-						if (arr.length && arr[arr.length - 1].name === segment.speaker) {
-							const cur: TranscriptItem | undefined = arr.pop();
-							if (typeof cur === 'undefined') return [...arr];
-							return [
-								...arr,
-								{
-									...cur,
-									text: cur.text + ' ' + segment.body,
-								},
-							];
-						} else {
-							const date = new Date(0);
-							date.setSeconds(segment.startTime);
+						if (response && response.segments) {
+											return response.segments.reduce(
+																	(arr: Transcript, segment: TranscriptSegment) => {
+																								if (
+																																arr.length &&
+																																arr[arr.length - 1].name === segment.speaker
+																															) {
+																																const cur: TranscriptItem | undefined = arr.pop();
+																																if (typeof cur === 'undefined') return [...arr];
+																																return [
+																																									...arr,
+																																	{
+																																											...cur,
+																																											text: cur.text + ' ' + segment.body,
+																																	},
+																																								];
+																								} else {
+																																const date = new Date(0);
+																																date.setSeconds(segment.startTime);
 
-							return [
-								...arr,
-								{
-									name: segment.speaker,
-									text: segment.body,
-									timestamp: date.toISOString().substr(14, 5),
-								},
-							];
+																									return [
+																																		...arr,
+																										{
+																																				name: segment.speaker,
+																																				text: segment.body,
+																																				timestamp: date.toISOString().substr(14, 5),
+																										},
+																																	];
+																								}
+																	},
+																	[],
+																);
 						}
-					},
-					[],
-				);
-			}
 
-			console.log('no response.segments');
+						console.log('no response.segments');
 
-			return null;
-		} catch (error) {
-			console.error(`Error loading transcript ${id}`, error);
-			return null;
-		}
-	},
-	[],
+						return null;
+					} catch (error) {
+									console.error(`Error loading transcript ${id}`, error);
+									return null;
+					}
+		},
+		[],
 	{ revalidate: 86400, tags: ['podcast'] },
-);
+	);
 
 // ---------------------------------------------------------------------------
 // Kept for backwards compatibility — no longer needed with vc-data
@@ -274,5 +247,5 @@ export const getTranscript = unstable_cache(
 // ---------------------------------------------------------------------------
 
 export async function getEpisodeQueryParams(_request: Request) {
-	return '';
+		return '';
 }

--- a/src/data/podcast.ts
+++ b/src/data/podcast.ts
@@ -4,17 +4,18 @@ export const buzzsproutPodcastId = '1558601' as const;
 
 // vc-data is the single source of truth for podcast data.
 // https://github.com/Virtual-Coffee/vc-data
-const VC_DATA_EPISODES_URL =
-	'https://raw.githubusercontent.com/Virtual-Coffee/vc-data/main/podcast/episodes.json';
+// Uses the GitHub Contents API so it works with private repos (via GITHUB_TOKEN).
+const VC_DATA_EPISODES_API_URL =
+		'https://api.github.com/repos/Virtual-Coffee/vc-data/contents/podcast/episodes.json';
 
 const IMGIX_PREFIX = 'https://virtualcoffeeio-cms.imgix.net/podcast/';
 
 /** Strip the full imgix URL down to just the filename, which is what createCmsImage expects. */
 function extractPath(fullUrl: string | null | undefined): string {
-	if (!fullUrl) return '';
-	return fullUrl.startsWith(IMGIX_PREFIX)
-		? fullUrl.slice(IMGIX_PREFIX.length)
-		: fullUrl;
+		if (!fullUrl) return '';
+		return fullUrl.startsWith(IMGIX_PREFIX)
+			? fullUrl.slice(IMGIX_PREFIX.length)
+					: fullUrl;
 }
 
 // ---------------------------------------------------------------------------
@@ -22,39 +23,39 @@ function extractPath(fullUrl: string | null | undefined): string {
 // ---------------------------------------------------------------------------
 
 export interface PodcastEpisode {
-	title: string;
-	slug: string;
-	id: string;
-	metaDescription: string;
-	podcastEpisode: number;
-	podcastSeason: number;
-	podcastPublishDate: string;
-	podcastBuzzsproutId: string;
-	podcastShortDescription: {
-		renderHtml: string;
-	};
-	podcastShowNotes: {
-		renderHtml: string;
-	};
-	podcastGuests: Array<{
-		id: number | string;
-		guestName: string;
-		guestBio: { renderHtml: string };
-		headshot: Array<{ path: string }>;
-	}>;
-	podcastEpisodeCard: Array<{ path: string }>;
-	url: string;
-	episodeSponsors: Array<{
 		title: string;
-		sponsorUrl: string;
-		sponsorImage: Array<{ path: string; width: number; height: number }>;
-		sponsorDescription: { renderHtml: string };
-	}>;
+		slug: string;
+		id: string;
+		metaDescription: string;
+		podcastEpisode: number;
+		podcastSeason: number;
+		podcastPublishDate: string;
+		podcastBuzzsproutId: string;
+		podcastShortDescription: {
+			renderHtml: string;
+		};
+		podcastShowNotes: {
+			renderHtml: string;
+		};
+		podcastGuests: Array<{
+			id: number | string;
+			guestName: string;
+			guestBio: { renderHtml: string };
+			headshot: Array<{ path: string }>;
+		}>;
+		podcastEpisodeCard: Array<{ path: string }>;
+		url: string;
+		episodeSponsors: Array<{
+			title: string;
+			sponsorUrl: string;
+			sponsorImage: Array<{ path: string; width: number; height: number }>;
+			sponsorDescription: { renderHtml: string };
+		}>;
 }
 
 type PodcastEpisodes = Pick<
-	PodcastEpisode,
-	| 'title'
+		PodcastEpisode,
+		| 'title'
 	| 'slug'
 	| 'id'
 	| 'metaDescription'
@@ -71,30 +72,30 @@ type PodcastEpisodes = Pick<
 // ---------------------------------------------------------------------------
 
 interface VcDataEpisode {
-	title: string;
-	slug: string;
-	id: string;
-	metaDescription: string;
-	season: number;
-	episode: number;
-	buzzsproutId: string;
-	publishDate: string;
-	shortDescription: string;
-	showNotes: string;
-	episodeCard: string;
-	guests: Array<{
-		guestName: string;
-		guestBio: string;
-		headshot: string | null;
-	}>;
-	sponsors: Array<{
 		title: string;
-		url: string;
-		logo: string | null;
-		logoWidth: number;
-		logoHeight: number;
-		description: string;
-	}>;
+		slug: string;
+		id: string;
+		metaDescription: string;
+		season: number;
+		episode: number;
+		buzzsproutId: string;
+		publishDate: string;
+		shortDescription: string;
+		showNotes: string;
+		episodeCard: string;
+		guests: Array<{
+			guestName: string;
+			guestBio: string;
+			headshot: string | null;
+		}>;
+		sponsors: Array<{
+			title: string;
+			url: string;
+			logo: string | null;
+			logoWidth: number;
+			logoHeight: number;
+			description: string;
+		}>;
 }
 
 // ---------------------------------------------------------------------------
@@ -102,156 +103,173 @@ interface VcDataEpisode {
 // ---------------------------------------------------------------------------
 
 function mapEpisode(e: VcDataEpisode): PodcastEpisode {
-	return {
-		title: e.title,
-		slug: e.slug,
-		id: e.id,
-		metaDescription: e.metaDescription,
-		podcastEpisode: e.episode,
-		podcastSeason: e.season,
-		podcastPublishDate: e.publishDate,
-		podcastBuzzsproutId: e.buzzsproutId,
-		podcastShortDescription: { renderHtml: e.shortDescription },
-		podcastShowNotes: { renderHtml: e.showNotes },
-		podcastEpisodeCard: e.episodeCard
-			? [{ path: extractPath(e.episodeCard) }]
-			: [],
-		podcastGuests: (e.guests || []).map((g, i) => ({
-			id: i,
-			guestName: g.guestName,
-			guestBio: { renderHtml: g.guestBio },
-			headshot: g.headshot ? [{ path: extractPath(g.headshot) }] : [],
-		})),
-		episodeSponsors: (e.sponsors || []).map((s) => ({
-			title: s.title,
-			sponsorUrl: s.url,
-			sponsorImage: s.logo
-				? [
-						{
-							path: extractPath(s.logo),
-							width: s.logoWidth,
-							height: s.logoHeight,
-						},
-					]
-				: [],
-			sponsorDescription: { renderHtml: s.description },
-		})),
-		url: `/podcast/${e.slug}`,
-	};
+		return {
+					title: e.title,
+					slug: e.slug,
+					id: e.id,
+					metaDescription: e.metaDescription,
+					podcastEpisode: e.episode,
+					podcastSeason: e.season,
+					podcastPublishDate: e.publishDate,
+					podcastBuzzsproutId: e.buzzsproutId,
+					podcastShortDescription: { renderHtml: e.shortDescription },
+					podcastShowNotes: { renderHtml: e.showNotes },
+					podcastEpisodeCard: e.episodeCard
+						? [{ path: extractPath(e.episodeCard) }]
+									: [],
+					podcastGuests: (e.guests || []).map((g, i) => ({
+									id: i,
+									guestName: g.guestName,
+									guestBio: { renderHtml: g.guestBio },
+									headshot: g.headshot ? [{ path: extractPath(g.headshot) }] : [],
+					})),
+					episodeSponsors: (e.sponsors || []).map((s) => ({
+									title: s.title,
+									sponsorUrl: s.url,
+									sponsorImage: s.logo
+										? [
+											{
+																			path: extractPath(s.logo),
+																			width: s.logoWidth,
+																			height: s.logoHeight,
+											},
+																]
+														: [],
+									sponsorDescription: { renderHtml: s.description },
+					})),
+					url: `/podcast/${e.slug}`,
+		};
 }
 
 // ---------------------------------------------------------------------------
-// Fetch all episodes from vc-data (cached 24 hrs)
+// Fetch all episodes from vc-data via GitHub Contents API (supports private repos)
 // ---------------------------------------------------------------------------
 
 const getAllEpisodes = unstable_cache(
-	async (): Promise<PodcastEpisode[]> => {
-		const res = await fetch(VC_DATA_EPISODES_URL, {
-			next: { revalidate: 86400 },
-		});
-		if (!res.ok) {
-			throw new Error(`Failed to fetch episodes: ${res.status}`);
-		}
-		const raw: VcDataEpisode[] = await res.json();
-		return raw.map(mapEpisode);
-	},
-	['vc-data-podcast-episodes'],
+		async (): Promise<PodcastEpisode[]> => {
+					const headers: Record<string, string> = {
+									Accept: 'application/vnd.github.v3.raw',
+					};
+					// GITHUB_TOKEN is available in the Netlify build environment and enables
+			// access to private repos. Falls back gracefully if not set (public repos).
+			if (process.env.GITHUB_TOKEN) {
+							headers['Authorization'] = `token ${process.env.GITHUB_TOKEN}`;
+			}
+
+			const res = await fetch(VC_DATA_EPISODES_API_URL, {
+							headers,
+							next: { revalidate: 86400 },
+			});
+
+			if (!res.ok) {
+							throw new Error(
+												`Failed to fetch episodes from vc-data: ${res.status} ${res.statusText}`,
+											);
+			}
+
+			const raw: VcDataEpisode[] = await res.json();
+					return raw.map(mapEpisode);
+		},
+		['vc-data-podcast-episodes'],
 	{ revalidate: 86400, tags: ['podcast'] },
-);
+	);
 
 // ---------------------------------------------------------------------------
 // Public API (same signatures as before)
 // ---------------------------------------------------------------------------
 
 export const getEpisodes = unstable_cache(
-	async ({ limit = 5 }: { limit?: number } = {}): Promise<PodcastEpisodes> => {
-		const episodes = await getAllEpisodes();
-		return episodes.slice(0, limit);
-	},
-	[],
+		async ({ limit = 5 }: { limit?: number } = {}): Promise<PodcastEpisodes> => {
+					const episodes = await getAllEpisodes();
+					return episodes.slice(0, limit);
+		},
+		[],
 	{ revalidate: 86400, tags: ['podcast'] },
-);
+	);
 
 export const getEpisode = unstable_cache(
-	async ({
-		slug,
-	}: {
-		slug: PodcastEpisode['slug'];
-		queryParams?: string;
-	}): Promise<PodcastEpisode | null> => {
-		const episodes = await getAllEpisodes();
-		return episodes.find((e) => e.slug === slug) ?? null;
-	},
-	[],
+		async ({
+					slug,
+		}: {
+					slug: PodcastEpisode['slug'];
+					queryParams?: string;
+		}): Promise<PodcastEpisode | null> => {
+					const episodes = await getAllEpisodes();
+					return episodes.find((e) => e.slug === slug) ?? null;
+		},
+		[],
 	{ revalidate: 86400, tags: ['podcast'] },
-);
+	);
 
 // ---------------------------------------------------------------------------
 // Transcript — unchanged, reads from feeds.virtualcoffee.io
 // ---------------------------------------------------------------------------
 
 type TranscriptSegment = {
-	speaker: string;
-	startTime: number;
-	endTime: number;
-	body: string;
+		speaker: string;
+		startTime: number;
+		endTime: number;
+		body: string;
 };
 type TranscriptItem = {
-	name: string;
-	text: string;
-	timestamp: string;
+		name: string;
+		text: string;
+		timestamp: string;
 };
 type Transcript = Array<TranscriptItem>;
 
 export const getTranscript = unstable_cache(
-	async ({ id }: Partial<PodcastEpisode>): Promise<Transcript | null> => {
-		try {
-			const response: { segments: TranscriptSegment[] } = await fetch(
-				`https://feeds.virtualcoffee.io/podcast-assets/${id}/transcript.json`,
-			).then((res) => res.json());
+		async ({ id }: Partial<PodcastEpisode>): Promise<Transcript | null> => {
+					try {
+									const response: { segments: TranscriptSegment[] } = await fetch(
+														`https://feeds.virtualcoffee.io/podcast-assets/${id}/transcript.json`,
+													).then((res) => res.json());
 
-			if (response && response.segments) {
-				return response.segments.reduce(
-					(arr: Transcript, segment: TranscriptSegment) => {
-						if (arr.length && arr[arr.length - 1].name === segment.speaker) {
-							const cur: TranscriptItem | undefined = arr.pop();
-							if (typeof cur === 'undefined') return [...arr];
-							return [
-								...arr,
-								{
-									...cur,
-									text: cur.text + ' ' + segment.body,
-								},
-							];
-						} else {
-							const date = new Date(0);
-							date.setSeconds(segment.startTime);
+						if (response && response.segments) {
+											return response.segments.reduce(
+																	(arr: Transcript, segment: TranscriptSegment) => {
+																								if (
+																																arr.length &&
+																																arr[arr.length - 1].name === segment.speaker
+																															) {
+																																const cur: TranscriptItem | undefined = arr.pop();
+																																if (typeof cur === 'undefined') return [...arr];
+																																return [
+																																									...arr,
+																																	{
+																																											...cur,
+																																											text: cur.text + ' ' + segment.body,
+																																	},
+																																								];
+																								} else {
+																																const date = new Date(0);
+																																date.setSeconds(segment.startTime);
 
-							return [
-								...arr,
-								{
-									name: segment.speaker,
-									text: segment.body,
-									timestamp: date.toISOString().substr(14, 5),
-								},
-							];
+																									return [
+																																		...arr,
+																										{
+																																				name: segment.speaker,
+																																				text: segment.body,
+																																				timestamp: date.toISOString().substr(14, 5),
+																										},
+																																	];
+																								}
+																	},
+																	[],
+																);
 						}
-					},
-					[],
-				);
-			}
 
-			console.log('no response.segments');
+						console.log('no response.segments');
 
-			return null;
-		} catch (error) {
-			console.error(`Error loading transcript ${id}`, error);
-			return null;
-		}
-	},
-	[],
+						return null;
+					} catch (error) {
+									console.error(`Error loading transcript ${id}`, error);
+									return null;
+					}
+		},
+		[],
 	{ revalidate: 86400, tags: ['podcast'] },
-);
+	);
 
 // ---------------------------------------------------------------------------
 // Kept for backwards compatibility — no longer needed with vc-data
@@ -259,5 +277,5 @@ export const getTranscript = unstable_cache(
 // ---------------------------------------------------------------------------
 
 export async function getEpisodeQueryParams(_request: Request) {
-	return '';
+		return '';
 }

--- a/src/data/podcast.ts
+++ b/src/data/podcast.ts
@@ -143,7 +143,7 @@ function mapEpisode(e: VcDataEpisode): PodcastEpisode {
 
 // Map all episodes once at module load (bundled JSON, no async needed)
 const allMappedEpisodes: PodcastEpisode[] = (
-	rawEpisodes as VcDataEpisode[]
+	rawEpisodes as unknown as VcDataEpisode[]
 ).map(mapEpisode);
 
 // ---------------------------------------------------------------------------

--- a/src/data/podcast.ts
+++ b/src/data/podcast.ts
@@ -5,16 +5,16 @@ export const buzzsproutPodcastId = '1558601' as const;
 // vc-data is the single source of truth for podcast data.
 // https://github.com/Virtual-Coffee/vc-data
 const VC_DATA_EPISODES_URL =
-		'https://raw.githubusercontent.com/Virtual-Coffee/vc-data/main/podcast/episodes.json';
+	'https://raw.githubusercontent.com/Virtual-Coffee/vc-data/main/podcast/episodes.json';
 
 const IMGIX_PREFIX = 'https://virtualcoffeeio-cms.imgix.net/podcast/';
 
 /** Strip the full imgix URL down to just the filename, which is what createCmsImage expects. */
 function extractPath(fullUrl: string | null | undefined): string {
-		if (!fullUrl) return '';
-		return fullUrl.startsWith(IMGIX_PREFIX)
-			? fullUrl.slice(IMGIX_PREFIX.length)
-					: fullUrl;
+	if (!fullUrl) return '';
+	return fullUrl.startsWith(IMGIX_PREFIX)
+		? fullUrl.slice(IMGIX_PREFIX.length)
+		: fullUrl;
 }
 
 // ---------------------------------------------------------------------------
@@ -22,39 +22,39 @@ function extractPath(fullUrl: string | null | undefined): string {
 // ---------------------------------------------------------------------------
 
 export interface PodcastEpisode {
+	title: string;
+	slug: string;
+	id: string;
+	metaDescription: string;
+	podcastEpisode: number;
+	podcastSeason: number;
+	podcastPublishDate: string;
+	podcastBuzzsproutId: string;
+	podcastShortDescription: {
+		renderHtml: string;
+	};
+	podcastShowNotes: {
+		renderHtml: string;
+	};
+	podcastGuests: Array<{
+		id: number | string;
+		guestName: string;
+		guestBio: { renderHtml: string };
+		headshot: Array<{ path: string }>;
+	}>;
+	podcastEpisodeCard: Array<{ path: string }>;
+	url: string;
+	episodeSponsors: Array<{
 		title: string;
-		slug: string;
-		id: string;
-		metaDescription: string;
-		podcastEpisode: number;
-		podcastSeason: number;
-		podcastPublishDate: string;
-		podcastBuzzsproutId: string;
-		podcastShortDescription: {
-			renderHtml: string;
-		};
-		podcastShowNotes: {
-			renderHtml: string;
-		};
-		podcastGuests: Array<{
-			id: number | string;
-			guestName: string;
-			guestBio: { renderHtml: string };
-			headshot: Array<{ path: string }>;
-		}>;
-		podcastEpisodeCard: Array<{ path: string }>;
-		url: string;
-		episodeSponsors: Array<{
-			title: string;
-			sponsorUrl: string;
-			sponsorImage: Array<{ path: string; width: number; height: number }>;
-			sponsorDescription: { renderHtml: string };
-		}>;
+		sponsorUrl: string;
+		sponsorImage: Array<{ path: string; width: number; height: number }>;
+		sponsorDescription: { renderHtml: string };
+	}>;
 }
 
 type PodcastEpisodes = Pick<
-		PodcastEpisode,
-		| 'title'
+	PodcastEpisode,
+	| 'title'
 	| 'slug'
 	| 'id'
 	| 'metaDescription'
@@ -71,30 +71,30 @@ type PodcastEpisodes = Pick<
 // ---------------------------------------------------------------------------
 
 interface VcDataEpisode {
+	title: string;
+	slug: string;
+	id: string;
+	metaDescription: string;
+	season: number;
+	episode: number;
+	buzzsproutId: string;
+	publishDate: string;
+	shortDescription: string;
+	showNotes: string;
+	episodeCard: string;
+	guests: Array<{
+		guestName: string;
+		guestBio: string;
+		headshot: string | null;
+	}>;
+	sponsors: Array<{
 		title: string;
-		slug: string;
-		id: string;
-		metaDescription: string;
-		season: number;
-		episode: number;
-		buzzsproutId: string;
-		publishDate: string;
-		shortDescription: string;
-		showNotes: string;
-		episodeCard: string;
-		guests: Array<{
-			guestName: string;
-			guestBio: string;
-			headshot: string | null;
-		}>;
-		sponsors: Array<{
-			title: string;
-			url: string;
-			logo: string | null;
-			logoWidth: number;
-			logoHeight: number;
-			description: string;
-		}>;
+		url: string;
+		logo: string | null;
+		logoWidth: number;
+		logoHeight: number;
+		description: string;
+	}>;
 }
 
 // ---------------------------------------------------------------------------
@@ -102,42 +102,42 @@ interface VcDataEpisode {
 // ---------------------------------------------------------------------------
 
 function mapEpisode(e: VcDataEpisode): PodcastEpisode {
-		return {
-					title: e.title,
-					slug: e.slug,
-					id: e.id,
-					metaDescription: e.metaDescription,
-					podcastEpisode: e.episode,
-					podcastSeason: e.season,
-					podcastPublishDate: e.publishDate,
-					podcastBuzzsproutId: e.buzzsproutId,
-					podcastShortDescription: { renderHtml: e.shortDescription },
-					podcastShowNotes: { renderHtml: e.showNotes },
-					podcastEpisodeCard: e.episodeCard
-						? [{ path: extractPath(e.episodeCard) }]
-									: [],
-					podcastGuests: (e.guests || []).map((g, i) => ({
-									id: i,
-									guestName: g.guestName,
-									guestBio: { renderHtml: g.guestBio },
-									headshot: g.headshot ? [{ path: extractPath(g.headshot) }] : [],
-					})),
-					episodeSponsors: (e.sponsors || []).map((s) => ({
-									title: s.title,
-									sponsorUrl: s.url,
-									sponsorImage: s.logo
-										? [
-											{
-																			path: extractPath(s.logo),
-																			width: s.logoWidth,
-																			height: s.logoHeight,
-											},
-																]
-														: [],
-									sponsorDescription: { renderHtml: s.description },
-					})),
-					url: `/podcast/${e.slug}`,
-		};
+	return {
+		title: e.title,
+		slug: e.slug,
+		id: e.id,
+		metaDescription: e.metaDescription,
+		podcastEpisode: e.episode,
+		podcastSeason: e.season,
+		podcastPublishDate: e.publishDate,
+		podcastBuzzsproutId: e.buzzsproutId,
+		podcastShortDescription: { renderHtml: e.shortDescription },
+		podcastShowNotes: { renderHtml: e.showNotes },
+		podcastEpisodeCard: e.episodeCard
+			? [{ path: extractPath(e.episodeCard) }]
+			: [],
+		podcastGuests: (e.guests || []).map((g, i) => ({
+			id: i,
+			guestName: g.guestName,
+			guestBio: { renderHtml: g.guestBio },
+			headshot: g.headshot ? [{ path: extractPath(g.headshot) }] : [],
+		})),
+		episodeSponsors: (e.sponsors || []).map((s) => ({
+			title: s.title,
+			sponsorUrl: s.url,
+			sponsorImage: s.logo
+				? [
+						{
+							path: extractPath(s.logo),
+							width: s.logoWidth,
+							height: s.logoHeight,
+						},
+					]
+				: [],
+			sponsorDescription: { renderHtml: s.description },
+		})),
+		url: `/podcast/${e.slug}`,
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -145,116 +145,113 @@ function mapEpisode(e: VcDataEpisode): PodcastEpisode {
 // ---------------------------------------------------------------------------
 
 const getAllEpisodes = unstable_cache(
-		async (): Promise<PodcastEpisode[]> => {
-					const res = await fetch(VC_DATA_EPISODES_URL, {
-									next: { revalidate: 86400 },
-					});
-					if (!res.ok) {
-									throw new Error(`Failed to fetch episodes: ${res.status}`);
-					}
-					const raw: VcDataEpisode[] = await res.json();
-					return raw.map(mapEpisode);
-		},
-		['vc-data-podcast-episodes'],
+	async (): Promise<PodcastEpisode[]> => {
+		const res = await fetch(VC_DATA_EPISODES_URL, {
+			next: { revalidate: 86400 },
+		});
+		if (!res.ok) {
+			throw new Error(`Failed to fetch episodes: ${res.status}`);
+		}
+		const raw: VcDataEpisode[] = await res.json();
+		return raw.map(mapEpisode);
+	},
+	['vc-data-podcast-episodes'],
 	{ revalidate: 86400, tags: ['podcast'] },
-	);
+);
 
 // ---------------------------------------------------------------------------
 // Public API (same signatures as before)
 // ---------------------------------------------------------------------------
 
 export const getEpisodes = unstable_cache(
-		async ({ limit = 5 }: { limit?: number } = {}): Promise<PodcastEpisodes> => {
-					const episodes = await getAllEpisodes();
-					return episodes.slice(0, limit);
-		},
-		[],
+	async ({ limit = 5 }: { limit?: number } = {}): Promise<PodcastEpisodes> => {
+		const episodes = await getAllEpisodes();
+		return episodes.slice(0, limit);
+	},
+	[],
 	{ revalidate: 86400, tags: ['podcast'] },
-	);
+);
 
 export const getEpisode = unstable_cache(
-		async ({
-					slug,
-		}: {
-					slug: PodcastEpisode['slug'];
-					queryParams?: string;
-		}): Promise<PodcastEpisode | null> => {
-					const episodes = await getAllEpisodes();
-					return episodes.find((e) => e.slug === slug) ?? null;
-		},
-		[],
+	async ({
+		slug,
+	}: {
+		slug: PodcastEpisode['slug'];
+		queryParams?: string;
+	}): Promise<PodcastEpisode | null> => {
+		const episodes = await getAllEpisodes();
+		return episodes.find((e) => e.slug === slug) ?? null;
+	},
+	[],
 	{ revalidate: 86400, tags: ['podcast'] },
-	);
+);
 
 // ---------------------------------------------------------------------------
 // Transcript — unchanged, reads from feeds.virtualcoffee.io
 // ---------------------------------------------------------------------------
 
 type TranscriptSegment = {
-		speaker: string;
-		startTime: number;
-		endTime: number;
-		body: string;
+	speaker: string;
+	startTime: number;
+	endTime: number;
+	body: string;
 };
 type TranscriptItem = {
-		name: string;
-		text: string;
-		timestamp: string;
+	name: string;
+	text: string;
+	timestamp: string;
 };
 type Transcript = Array<TranscriptItem>;
 
 export const getTranscript = unstable_cache(
-		async ({ id }: Partial<PodcastEpisode>): Promise<Transcript | null> => {
-					try {
-									const response: { segments: TranscriptSegment[] } = await fetch(
-														`https://feeds.virtualcoffee.io/podcast-assets/${id}/transcript.json`,
-													).then((res) => res.json());
+	async ({ id }: Partial<PodcastEpisode>): Promise<Transcript | null> => {
+		try {
+			const response: { segments: TranscriptSegment[] } = await fetch(
+				`https://feeds.virtualcoffee.io/podcast-assets/${id}/transcript.json`,
+			).then((res) => res.json());
 
-						if (response && response.segments) {
-											return response.segments.reduce(
-																	(arr: Transcript, segment: TranscriptSegment) => {
-																								if (
-																																arr.length &&
-																																arr[arr.length - 1].name === segment.speaker
-																															) {
-																																const cur: TranscriptItem | undefined = arr.pop();
-																																if (typeof cur === 'undefined') return [...arr];
-																																return [
-																																									...arr,
-																																	{
-																																											...cur,
-																																											text: cur.text + ' ' + segment.body,
-																																	},
-																																								];
-																								} else {
-																																const date = new Date(0);
-																																date.setSeconds(segment.startTime);
+			if (response && response.segments) {
+				return response.segments.reduce(
+					(arr: Transcript, segment: TranscriptSegment) => {
+						if (arr.length && arr[arr.length - 1].name === segment.speaker) {
+							const cur: TranscriptItem | undefined = arr.pop();
+							if (typeof cur === 'undefined') return [...arr];
+							return [
+								...arr,
+								{
+									...cur,
+									text: cur.text + ' ' + segment.body,
+								},
+							];
+						} else {
+							const date = new Date(0);
+							date.setSeconds(segment.startTime);
 
-																									return [
-																																		...arr,
-																										{
-																																				name: segment.speaker,
-																																				text: segment.body,
-																																				timestamp: date.toISOString().substr(14, 5),
-																										},
-																																	];
-																								}
-																	},
-																	[],
-																);
+							return [
+								...arr,
+								{
+									name: segment.speaker,
+									text: segment.body,
+									timestamp: date.toISOString().substr(14, 5),
+								},
+							];
 						}
+					},
+					[],
+				);
+			}
 
-						console.log('no response.segments');
+			console.log('no response.segments');
 
-						return null;
-					} catch (error) {
-									console.error(`Error loading transcript ${id}`, error);
-									return null;
-					}
-		},
-		[],
+			return null;
+		} catch (error) {
+			console.error(`Error loading transcript ${id}`, error);
+			return null;
+		}
+	},
+	[],
 	{ revalidate: 86400, tags: ['podcast'] },
-	);
+);
 
 // ---------------------------------------------------------------------------
 // Kept for backwards compatibility — no longer needed with vc-data
@@ -262,5 +259,5 @@ export const getTranscript = unstable_cache(
 // ---------------------------------------------------------------------------
 
 export async function getEpisodeQueryParams(_request: Request) {
-		return '';
+	return '';
 }

--- a/src/data/podcast/episodes.json
+++ b/src/data/podcast/episodes.json
@@ -1,1922 +1,1922 @@
 [
-  {
-    "title": "Virtual Coffee Podcast Trailer",
-    "slug": "0000-trailer",
-    "id": "271",
-    "metaDescription": "Welcome to the Virtual Coffee Podcast!",
-    "season": 1,
-    "episode": 0,
-    "buzzsproutId": "7119532",
-    "publishDate": "2021-01-04T05:00:00+00:00",
-    "shortDescription": "<p>Welcome to the Virtual Coffee Podcast!</p>",
-    "showNotes": "<p>This is the Virtual Coffee Podcast, hosted by Bekah Hawrot Weigel and Dan Ott. You'll find interviews with members of our community to learn more about their stories, who they are, how they found Virtual Coffee, and how it has influenced their lives as developers. We want to bring everything that's special about Virtual Coffee, the intimacy and the friendships we’ve built, and share that with everyone through the podcast. We’re always growing and learning together as a group, and there’s something really special about being able to do that knowing that you’ll have the full support of the community around you. And that’s what this podcast is about too.</p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/virtual-coffee-mug-square.png",
-    "guests": [
-      {
-        "name": "Virtual Coffee IO",
-        "bio": "<ul><li><p><a href=\"https://virtualcoffee.io/podcast\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee Podcast</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/virtual-coffee-mug-square.png"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Nick Taylor: Open Source, Live Streaming, and Structured YOLO",
-    "slug": "0101-nickyt",
-    "id": "284",
-    "metaDescription": "Season One, Episode One of the Virtual Coffee Podcast",
-    "season": 1,
-    "episode": 1,
-    "buzzsproutId": "7238548",
-    "publishDate": "2021-01-11T05:00:00+00:00",
-    "shortDescription": "<p>Dan and Bekah welcome Nick Taylor (Senior Software Engineer at Forem/DEV) to talk about his journey into tech, open source, and the importance of community</p>",
-    "showNotes": "<p>Dan and Bekah welcome Nick Taylor (Senior Software Engineer at Forem/DEV) to talk about his journey into tech, open source, and the importance of community. Nick talks about his journey through University and into tech, how the landscape of tech has changed with increased resources and community, and how his idea of \"structured YOLO\" has lead him to this point in his career. He talks about how his job at Forem and how the pandemic led to his livestreaming, where he tries to make coding as realistic as possible. His hour and a half livestreams focus on one issue, but realistically those issues won't be solved during that time. And that's ok, because coding takes time, and working through issues won't always be a simple solution. His approach to teaching includes learning as you go, which made him an amazing contributor, mentor, and maintainer for the Virtual Coffee Hacktoberfest Initiative. Every conversation with Nick is an interesting one, and this one isn't an exception.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Nick: <a href=\"https://dev.to/nickytonline\" rel=\"noopener noreferrer\" target=\"_blank\">https://dev.to/nickytonline</a></p></li><li><p>Forem: <a href=\"https://www.forem.com/\" rel=\"noopener noreferrer\" target=\"_blank\">https://www.forem.com/</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0101-nickyt-episode.jpg",
-    "guests": [
-      {
-        "name": "Nick Taylor",
-        "bio": "<p>Senior Software Engineer at <a href=\"https://www.forem.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Forem</a>, the software that powers <a href=\"https://dev.to/\" rel=\"noopener noreferrer\" target=\"_blank\">DEV</a>, working on all things Forem.</p><ul><li><p><a href=\"https://iamdeveloper.com/\" rel=\"noopener noreferrer\" target=\"_blank\">iamdeveloper.com</a></p></li><li><p><a href=\"https://livecoding.ca/\" rel=\"noopener noreferrer\" target=\"_blank\">livecoding.ca</a></p></li><li><p><a href=\"https://twitter.com/nickytonline\" rel=\"noopener noreferrer\" target=\"_blank\">twitter.com/nickytonline</a></p></li><li><p><a href=\"https://dev.to/nickytonline\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/nickytonline</a></p></li><li><p><a href=\"https://iamdeveloper.com/hacktoberfest2020\" rel=\"noopener noreferrer\" target=\"_blank\">Getting the Most Out of Open Source</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0101-nickyt.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Marie Antons: From Chef to Tech",
-    "slug": "0102-marieantons",
-    "id": "291",
-    "metaDescription": "Season One, Episode Two of the Virtual Coffee Podcast",
-    "season": 1,
-    "episode": 2,
-    "buzzsproutId": "7323430",
-    "publishDate": "2021-01-18T05:00:00+00:00",
-    "shortDescription": "<p>In this episode, Marie Antons talks with Dan, Bekah, and Kirk about how she went from being a chef to a junior developer.</p>",
-    "showNotes": "<p>In this episode, Marie Antons talks with Dan, Bekah, and Kirk about how she went from being a chef to a junior developer. With more and more developers coming into tech from non-traditional backgrounds, Marie shares her own unique story and how taking her past experience as a chef allowed her to understand coding in her own way. There are ingredients and steps to follow with recipes, and similarly, as you learn to code, you'll find what you need to get your code to work and the process you need to take to get there. She also talks about the challenges of coming into her first job from a bootcamp, and what she wishes she would've known before starting that job.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p><a href=\"https://www.deltavcodeschool.com/\" rel=\"noopener noreferrer\" target=\"_blank\">DeltaV Code School</a></p></li><li><p><a href=\"https://stratafolio.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Stratafolio</a></p></li><li><p><a href=\"https://d3js.org/\" rel=\"noopener noreferrer\" target=\"_blank\">D3 javascript library</a></p></li><li><p><a href=\"https://wattenberger.com/blog/css-percents\" rel=\"noopener noreferrer\" target=\"_blank\">Amy Wattenberger</a> (the blogger Dan couldn't remember!)</p></li><li><p><a href=\"https://twitter.com/MarieAntons\" rel=\"noopener noreferrer\" target=\"_blank\">@MarieAntons</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/marie\" rel=\"noopener noreferrer\" target=\"_blank\">Marie Antons</a> on LinkedIn</p></li><li><p>Kirk: <a href=\"https://twitter.com/tkshillinz\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshillinz</a> on Twitter</p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0102-marie-episode.jpg",
-    "guests": [
-      {
-        "name": "Marie Antons",
-        "bio": "<p>Marie is a C#/.NET developer working for a small start-up called Stratafolio.</p><ul><li><p><a href=\"https://twitter.com/MarieAntons\" rel=\"noopener noreferrer\" target=\"_blank\">@MarieAntons</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/marie\" rel=\"noopener noreferrer\" target=\"_blank\">Marie Antons</a> on LinkedIn</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0102-marie.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Tori Crawford: Interviewing — If it's broke, fix it",
-    "slug": "0103-tori-crawford",
-    "id": "298",
-    "metaDescription": "Season One, Episode Three of the Virtual Coffee Podcast",
-    "season": 1,
-    "episode": 3,
-    "buzzsproutId": "7474594",
-    "publishDate": "2021-01-25T05:00:00+00:00",
-    "shortDescription": "<p>In this episode, Dan and Bekah welcome Tori Crawford to talk about her journey through the interview process that included about 53 interviews, 430 applications, and a pandemic offer that ultimately led to her being ghosted by the company.</p>",
-    "showNotes": "<p>In this episode, Dan and Bekah welcome Tori to talk about her journey through the interview process that included about 53 interviews, 430 applications, and a pandemic offer that ultimately led to her being ghosted by the company. She gives her tips and tricks, including recognizing that interviews are a two-way street; you should also be interviewing the companies that are interviewing you. She talks about the problems of technical interviewing, how she's hopeful that the industry can make changes, and how the job she ultimately landed has been a great experience, starting with the interview.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Tori: <a href=\"https://dev.to/torianne02\" rel=\"noopener noreferrer\" target=\"_blank\">DEV</a>, <a href=\"https://twitter.com/_torrborr\" rel=\"noopener noreferrer\" target=\"_blank\">Twitter</a></p></li><li><p>Article Tori wrote detailing her interview journey: <a href=\"https://dev.to/torianne02/444-days-later-tori-hit-the-jackpot-3o4p\" rel=\"noopener noreferrer\" target=\"_blank\">444 Days Later, Tori Hit the Jackpot</a></p></li><li><p>Udemy course mentioned: <a href=\"https://www.udemy.com/course/master-the-coding-interview-data-structures-algorithms/\" rel=\"noopener noreferrer\" target=\"_blank\">Master the Coding Interview: Data Structures + Algorithms</a></p></li><li><p><a href=\"https://flatironschool.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Flatiron School</a></p></li><li><p><a href=\"https://firehydrant.io/\" rel=\"noopener noreferrer\" target=\"_blank\">FireHydrant</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0103-tori-episode.jpg",
-    "guests": [
-      {
-        "name": "Tori Crawford",
-        "bio": "<p>Software Engineer at <a href=\"https://firehydrant.io/\" rel=\"noopener noreferrer\" target=\"_blank\">FireHydrant</a>.</p><ul><li><p><a href=\"https://twitter.com/_torrborr\" rel=\"noopener noreferrer\" target=\"_blank\">@_torrborr</a> on Twitter</p></li><li><p><a href=\"https://dev.to/torianne02\" rel=\"noopener noreferrer\" target=\"_blank\">torianne02</a> on DEV</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0103-tori.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Vic Vijayakumar: Indie Hacking",
-    "slug": "0104-vic-vijayakumar",
-    "id": "305",
-    "metaDescription": "Season One, Episode Four of the Virtual Coffee Podcast",
-    "season": 1,
-    "episode": 4,
-    "buzzsproutId": "7564483",
-    "publishDate": "2021-02-01T05:00:00+00:00",
-    "shortDescription": "<p>In this episode, Vic talks about Indie Hacking and gives us his take on when to ship, what to focus on, and the value of diverse opinions in your community.</p>",
-    "showNotes": "<p>In this episode, Vic talks about Indie Hacking and gives us his take on when to ship, what to focus on, and the value of diverse opinions in your community. He also talks about treating life as a lot of drafts and about building things that you're passionate about as well as things that others find valuable. He cautions against the danger of survivorship bias, recognizing that it's difficult to find a path in indie hacking and that many of the popular voices have worked through challenges and no longer effectively represent how difficult it is to create a product that's successful.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><h5 class=\"text-left\"><strong>Vic:</strong></h5><ul><li><p><a href=\"https://vicvijayakumar.com/\" rel=\"noopener noreferrer\" target=\"_blank\">vicvijayakumar.com</a></p></li><li><p><a href=\"https://twitter.com/vicvijayakumar\" rel=\"noopener noreferrer\" target=\"_blank\">@vicvijayakumar</a> on Twitter</p></li></ul><h5 class=\"text-left\"><strong>Vic's Projects:</strong></h5><ul><li><p><a href=\"https://www.everyoak.com/\" rel=\"noopener noreferrer\" target=\"_blank\">EveryOak</a></p></li><li><p><a href=\"https://meetsweats.com/\" rel=\"noopener noreferrer\" target=\"_blank\">MeetSweats.com</a></p></li><li><p><a href=\"https://dogears.xyz/\" rel=\"noopener noreferrer\" target=\"_blank\">Dog Ears</a></p></li></ul><h5 class=\"text-left\"><strong>Low-Code Tools:</strong></h5><ul><li><p><a href=\"https://carrd.co/\" rel=\"noopener noreferrer\" target=\"_blank\">Carrd</a></p></li><li><p><a href=\"https://zapier.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Zapier</a></p></li><li><p><a href=\"https://airtable.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Airtable</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0104-vic-episode.jpg",
-    "guests": [
-      {
-        "name": "Vic Vijayakumar",
-        "bio": "<p>Principal software engineer at <a href=\"https://www.researchsquare.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Research Square</a>, a preprint platform</p><ul><li><p><a href=\"https://vicvijayakumar.com/\" rel=\"noopener noreferrer\" target=\"_blank\">vicvijayakumar.com</a></p></li><li><p><a href=\"https://twitter.com/vicvijayakumar\" rel=\"noopener noreferrer\" target=\"_blank\">@vicvijayakumar</a> on Twitter</p></li><li><p><a href=\"https://www.everyoak.com/\" rel=\"noopener noreferrer\" target=\"_blank\">EveryOak</a></p></li><li><p><a href=\"https://meetsweats.com/\" rel=\"noopener noreferrer\" target=\"_blank\">MeetSweats.com</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0104-vic.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Cameron Bardell and Rahat Chowdhury: Mental Health & Tech",
-    "slug": "0105-cameron-rahat",
-    "id": "312",
-    "metaDescription": "Season One, Episode Five of the Virtual Coffee Podcast",
-    "season": 1,
-    "episode": 5,
-    "buzzsproutId": "7741411",
-    "publishDate": "2021-02-08T05:00:00+00:00",
-    "shortDescription": "<p>In this episode, Bekah and Dan talk about mental health with Cameron Bardell, an iOS developer in the healthcare industry, and Rahat Chowdhury, a mental health start-up founder.</p>",
-    "showNotes": "<p>In this episode, Bekah and Dan talk about mental health with Cameron Bardell, an iOS developer in the healthcare industry, and Rahat Chowdhury, a mental health start-up founder. We talk about how sometimes building a product to meet our own needs is a great place to start and the importance of prioritizing mental health, especially in a fast-paced industry like tech. We walk through our own experiences, how mental health recovery isn't linear, and how different approaches to mental health technology create support for more people.</p><p class=\"text-left\">If you or someone else is suffering from mental health issues, you aren't alone. Below are some links to help you find resources or to seek help:</p><ul><li><p><a href=\"https://suicidepreventionlifeline.org/\" rel=\"noopener noreferrer\" target=\"_blank\">National Suicide Prevention Lifeline</a> - 1-800-273-8255</p></li><li><p><a href=\"https://www.samhsa.gov/find-help/national-helpline\" rel=\"noopener noreferrer\" target=\"_blank\">SAMHSA’s National Helpline</a> - 1-800-662-HELP (4357)</p></li><li><p><a href=\"https://cmha.ca/\" rel=\"noopener noreferrer\" target=\"_blank\">CMHA National</a></p></li></ul><h4 class=\"text-left\"><strong>Links:</strong></h4><h5 class=\"text-left\"><strong>Cameron:</strong></h5><ul><li><p><a href=\"https://cambardell.github.io/\" rel=\"noopener noreferrer\" target=\"_blank\">cambardell.github.io</a></p></li><li><p><a href=\"https://twitter.com/cameronbardell\" rel=\"noopener noreferrer\" target=\"_blank\">@cameronbardell</a> on Twitter</p></li></ul><h5 class=\"text-left\"><strong>Rahat:</strong></h5><ul><li><p><a href=\"https://www.rahatcodes.com/\" rel=\"noopener noreferrer\" target=\"_blank\">rahatcodes.com</a></p></li><li><p><a href=\"https://twitter.com/Rahatcodes\" rel=\"noopener noreferrer\" target=\"_blank\">@Rahatcodes</a> on Twitter</p></li><li><p><a href=\"https://whimser.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Whimser</a></p></li><li><p>Open source mental health resources database: <a href=\"https://www.sylarproject.com/\" rel=\"noopener noreferrer\" target=\"_blank\">The Sylar Project</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0105-camrahat-episode.jpg",
-    "guests": [
-      {
-        "name": "Cameron Bardell",
-        "bio": "<p>iOS developer in the healthcare industry</p><ul><li><p><a href=\"https://cambardell.github.io/\" rel=\"noopener noreferrer\" target=\"_blank\">cambardell.github.io</a></p></li><li><p><a href=\"https://twitter.com/cameronbardell\" rel=\"noopener noreferrer\" target=\"_blank\">@cameronbardell</a> on Twitter</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0105-cameron.jpg"
-      },
-      {
-        "name": "Rahat Chowdhury",
-        "bio": "<p>Mental health start-up founder</p><ul><li><p><a href=\"https://www.rahatcodes.com/\" rel=\"noopener noreferrer\" target=\"_blank\">rahatcodes.com</a></p></li><li><p><a href=\"https://twitter.com/Rahatcodes\" rel=\"noopener noreferrer\" target=\"_blank\">@Rahatcodes</a> on Twitter</p></li><li><p><a href=\"https://whimser.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Whimser</a></p></li><li><p><a href=\"https://www.sylarproject.com/\" rel=\"noopener noreferrer\" target=\"_blank\">The Sylar Project</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0105-rahat.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Drew Clements: Building a career and community",
-    "slug": "0106-drew",
-    "id": "329",
-    "metaDescription": "Season One, Episode Six of the Virtual Coffee Podcast",
-    "season": 1,
-    "episode": 6,
-    "buzzsproutId": "7867681",
-    "publishDate": "2021-02-15T05:00:00+00:00",
-    "shortDescription": "<p>In this episode, Bekah and Dan are joined by Drew Clements to talk about the struggles of junior-level job searching, the importance of supportive company culture, and learning in public while building <a href=\"https://protege.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Protege.dev</a>.</p>",
-    "showNotes": "<p>In this episode, we talk to Drew Clements about the challenges junior developers face, learning through building Protege.dev, and the importance of community support. Drew is a career transitioner, father of two, and full-time developer who spends his spare time building Protege.dev, the platform curated with remote jobs for junior developers. We also talk about approaches to problem-solving, when to ask questions, and using live-streaming as an accountability tool.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><h5 class=\"text-left\"><strong>Drew:</strong></h5><ul><li><p><a href=\"https://twitter.com/drewclemcr8\" rel=\"noopener noreferrer\" target=\"_blank\">@drewclemcr8</a> on Twitter</p></li><li><p><a href=\"https://protege.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Protege.dev</a></p></li><li><p><a href=\"https://github.com/drewclem/\" rel=\"noopener noreferrer\" target=\"_blank\">drewclem</a> on GitHub</p></li><li><p><a href=\"https://dev.to/drewclem/\" rel=\"noopener noreferrer\" target=\"_blank\">drewclem</a> on DEV</p></li></ul><h5 class=\"text-left\"><strong>Stu the Rubber Duck!</strong></h5><p class=\"text-left\"></p><img src=\"http://storage.googleapis.com/virtualcoffeeio-assets/images/_podcastShowNotesImage/0106-drew-duck.jpg\" alt=\"Drew holding Stu the Rubber Duck!\" title=\"\">",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0106-drew-episode.jpg",
-    "guests": [
-      {
-        "name": "Drew Clements",
-        "bio": "<p>Frontend Engineer at <a href=\"https://www.fostercommerce.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Foster Commerce</a>, co-founder of <a href=\"https://protege.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Protege.dev</a></p><ul><li><p><a href=\"https://twitter.com/drewclemcr8\" rel=\"noopener noreferrer\" target=\"_blank\">@drewclemcr8</a> on Twitter</p></li><li><p><a href=\"https://protege.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Protege.dev</a></p></li><li><p><a href=\"https://github.com/drewclem/\" rel=\"noopener noreferrer\" target=\"_blank\">drewclem</a> on GitHub</p></li><li><p><a href=\"https://dev.to/drewclem/\" rel=\"noopener noreferrer\" target=\"_blank\">drewclem</a> on DEV</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0106-drew.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Colleen Schnettler -- Tech: It's hard, but it's worth it",
-    "slug": "0107-colleen",
-    "id": "337",
-    "metaDescription": "Season One, Episode Seven of the Virtual Coffee Podcast",
-    "season": 1,
-    "episode": 7,
-    "buzzsproutId": "8007425",
-    "publishDate": "2021-02-22T05:00:00+00:00",
-    "shortDescription": "<p>In this episode, Bekah and Dan are joined by Colleen Schnettler to talk about the challenges women face in the workplace, the benefits of working for yourself, and growing her SaaS business.</p>",
-    "showNotes": "<p>In this episode, we talk to Colleen Schnettler about the challenges of being a woman in the workplace, the benefits of working for yourself, and building her own SaaS business. Colleen is a Ruby on Rails consultant, who recently launched her <a href=\"https://www.simplefileupload.com/\" rel=\"noopener noreferrer\" target=\"_blank\">first product</a>, a career changer, and a mom. Colleen talks about how difficult it is to learn to code; it will take time and commitment, but when you get there, it will all be worth it.</p><h5 class=\"text-left\"><strong>Colleen:</strong></h5><ul><li><p><a href=\"https://twitter.com/leenyburger\" rel=\"noopener noreferrer\" target=\"_blank\">@leenyburger</a> on Twitter</p></li><li><p><a href=\"http://www.bitmappeddesigns.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Bitmapped Designs</a></p></li><li><p><a href=\"https://www.simplefileupload.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Simple File Upload</a></p></li><li><p><a href=\"https://twitter.com/softwaresocpod\" rel=\"noopener noreferrer\" target=\"_blank\">@softwaresocpod</a> - Software Social Podcast</p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0107-colleen-episode.jpg",
-    "guests": [
-      {
-        "name": "Colleen Schnettler",
-        "bio": "<p>Ruby on Rails consultant at <a href=\"http://www.bitmappeddesigns.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Bitmapped Designs</a>.</p><ul><li><p><a href=\"https://twitter.com/leenyburger\" rel=\"noopener noreferrer\" target=\"_blank\">@leenyburger</a> on Twitter</p></li><li><p><a href=\"http://www.bitmappeddesigns.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Bitmapped Designs</a></p></li><li><p><a href=\"https://www.simplefileupload.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Simple File Upload</a></p></li><li><p><a href=\"https://twitter.com/softwaresocpod\" rel=\"noopener noreferrer\" target=\"_blank\">@softwaresocpod</a> - Software Social Podcast</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0107-colleen.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Kirk Shillingford: On Making Mistakes, Growth, and the Importance of Community",
-    "slug": "0108-kirk",
-    "id": "344",
-    "metaDescription": "Season One, Episode Eight of the Virtual Coffee Podcast",
-    "season": 1,
-    "episode": 8,
-    "buzzsproutId": "8052553",
-    "publishDate": "2021-03-01T05:00:00+00:00",
-    "shortDescription": "<p>In this episode, Dan and Bekah talk to Kirk Shillingford, a software developer (and Community Maintainer at Virtual Coffee), about the importance of making mistakes and the growth that comes with it.</p>",
-    "showNotes": "<p>In this episode, Dan and Bekah talk to Kirk Shillingford, a software developer (and Community Maintainer at Virtual Coffee), who has been \"haphazardly writing code for about seven years,\" about the importance of making mistakes and the growth that comes with it. We also talk about empathy being a key indicator of a senior developer and the importance of having a supportive community.</p><h5 class=\"text-left\"><strong>Links:</strong></h5><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://twitter.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Neverwinter_Nights\" rel=\"noopener noreferrer\" target=\"_blank\">Never Winter Nights</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0108-kirk-episode.jpg",
-    "guests": [
-      {
-        "name": "Kirk Shillingford",
-        "bio": "<p>Software Developer, and Community Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://twitter.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0108-kirk.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Dan and Bekah: Season One Wrap-Up",
-    "slug": "0109-bekah-dan",
-    "id": "353",
-    "metaDescription": "Season One, Episode Nine of the Virtual Coffee Podcast",
-    "season": 1,
-    "episode": 9,
-    "buzzsproutId": "8096247",
-    "publishDate": "2021-03-07T05:00:00+00:00",
-    "shortDescription": "<p>In this episode of the podcast, Dan and Bekah switch things up. Since it's last episode of season one, they share a bit about their origin stories, when their paths connected, and how that led to where Virtual Coffee is today.</p>",
-    "showNotes": "<p>In this episode of the podcast, Dan and Bekah switch things up. Since it's last episode of season one, they share a bit about their origin stories, when their paths connected, and how that led to where Virtual Coffee is today. They talk about the challenges of the last year, how Virtual Coffee has been a light during dark times, and how growing can be painful, but also the process that allows you to become more than you could've imagined. And they also drop some of their favorite Virtual Coffee moments of the last year.</p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0109-bekahdan-episode.jpg",
-    "guests": [
-      {
-        "name": "Bekah Hawrot Weigel",
-        "bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dev.to/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/bekahhw</a></p></li><li><p><a href=\"https://twitter.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">@bekahhw</a> on Twitter</p></li><li><p><a href=\"https://www.instagram.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">bekahhw</a> on Instagram</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0109-bekah.jpg"
-      },
-      {
-        "name": "Dan Ott",
-        "bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dtott.com/\" rel=\"noopener noreferrer\" target=\"_blank\">dtott.com</a></p></li><li><p><a href=\"https://twitter.com/danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">@danieltott</a> on Twitter</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0109-dan.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Gant Laborde: Finding your Voice",
-    "slug": "0201-gant",
-    "id": "370",
-    "metaDescription": "Season Two, Episode One of the Virtual Coffee Podcast",
-    "season": 2,
-    "episode": 1,
-    "buzzsproutId": "8281596",
-    "publishDate": "2021-04-06T04:00:00+00:00",
-    "shortDescription": "<p>We're back! In this episode of the Virtual Coffee podcast, Dan and Bekah talk to Gant Laborde, an owner of Infinite Red, mentor, adjunct professor, published author, and award-winning speaker, about overcoming challenges, being authentic, and finding your voice.</p>",
-    "showNotes": "<p>In this episode of the Virtual Coffee podcast, Dan and Bekah talk to Gant Laborde, an owner of Infinite Red, mentor, adjunct professor, published author, and award-winning speaker, about overcoming challenges, being authentic, and finding your voice. They share some of the struggles they've faced, talk about how practice can lead to growth, and the importance of recognizing your body's signals in the process.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Gant: <a href=\"https://gantlaborde.com/\" rel=\"noopener noreferrer\" target=\"_blank\">gantlaborde.com</a>, <a href=\"https://twitter.com/GantLaborde\" rel=\"noopener noreferrer\" target=\"_blank\">@GantLaborde</a></p></li><li><p>Some blog posts about public speaking by Gant:</p><ul><li><p><a href=\"https://gantlaborde.medium.com/open-your-speech-and-make-it-marvelous-e031cfa18858\" rel=\"noopener noreferrer\" target=\"_blank\">Open your speech, and make it marvelous</a></p></li><li><p><a href=\"https://medium.com/hackernoon/5-conference-speaking-tips-from-tech-gurus-2f7d1a250af3\" rel=\"noopener noreferrer\" target=\"_blank\">5 Conference Speaking Tips from Tech Gurus</a></p></li><li><p><a href=\"https://shift.infinite.red/the-road-to-distinguished-c9e458da091c\" rel=\"noopener noreferrer\" target=\"_blank\">The Road to Distinguished: From Afraid to Awarded — The path to public speaking success</a></p></li></ul></li><li><p><a href=\"https://cryptozombies.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Cryptozombies</a></p></li><li><p><a href=\"https://geddski.teachable.com/p/flexbox-zombies\" rel=\"noopener noreferrer\" target=\"_blank\">Flexbox zombies</a></p></li><li><p><a href=\"https://infinite.red/\" rel=\"noopener noreferrer\" target=\"_blank\">Infinite Red</a></p></li><li><p><a href=\"https://www.toastmasters.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Toastmasters</a></p></li><li><p><a href=\"https://www.amazon.com/gp/product/1492090794/ref=as_li_qf_asin_il_tl?ie=UTF8&amp;tag=gant0d-20&amp;creative=9325&amp;linkCode=as2&amp;creativeASIN=1492090794&amp;linkId=9b7b356b7b13efdaf9d34bfa47f7a6ee\" rel=\"noopener noreferrer\" target=\"_blank\">Learning TensorFlow.js: Powerful Machine Learning in JavaScript by Gant Laborde</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0201-gant-episode.jpg",
-    "guests": [
-      {
-        "name": "Gant Laborde",
-        "bio": "<p>Gant Laborde is an owner of Infinite Red, mentor, adjunct professor, published author, and award-winning speaker. For 20 years, he has been involved in software development and continues strong today. He is recognized as a Google Developer Expert in Web and Machine Learning, but informally he is an “open sourcerer” and aspires to one day become a mad scientist. He blogs, videos, and maintains popular repositories for the community. Follow Gant’s adventures at <a href=\"https://gantlaborde.com/\" rel=\"noopener noreferrer\" target=\"_blank\">gantlaborde.com</a>.</p>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0201-gant.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Lucia Cerchie: Mom life and finding your confidence",
-    "slug": "0202-lucia",
-    "id": "377",
-    "metaDescription": "Season Two, Episode Two of the Virtual Coffee Podcast",
-    "season": 2,
-    "episode": 2,
-    "buzzsproutId": "8315337",
-    "publishDate": "2021-04-11T04:00:00+00:00",
-    "shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk with Lucia Cercie, a Software Engineer, about the importance of having a growth-mindset, asking questions, and pair programming.</p>",
-    "showNotes": "<p>In this episode of the podcast, Dan and Bekah talk with Lucia Cercie, a Software Engineer at <a href=\"https://stepzen.com/\" rel=\"noopener noreferrer\" target=\"_blank\">StepZen</a>, mom, and Arizona transplant, about the importance of having a growth-mindset, asking questions, and pair programming. We also talk about the power of community and feeling comfortable asking questions and asking for help. When she's not coding, Lucia likes to make her baby laugh.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Lucia: <a href=\"https://luciacerchie.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">luciacerchie.dev</a>, <a href=\"https://twitter.com/CerchieLucia\" rel=\"noopener noreferrer\" target=\"_blank\">@CerchieLucia</a> on Twitter, <a href=\"https://dev.to/cerchie\" rel=\"noopener noreferrer\" target=\"_blank\">cerchi</a> on DEV</p></li><li><p><a href=\"https://stepzen.com/\" rel=\"noopener noreferrer\" target=\"_blank\">StepZen</a></p></li><li><p><a href=\"https://hbr.org/2016/01/what-having-a-growth-mindset-actually-means\" rel=\"noopener noreferrer\" target=\"_blank\"><em>What Having a “Growth Mindset” Actually Means</em></a><a href=\"https://hbr.org/2016/01/what-having-a-growth-mindset-actually-means\" rel=\"noopener noreferrer\" target=\"_blank\"> </a>by Carol Dweck</p></li><li><p><a href=\"https://martinfowler.com/articles/on-pair-programming.html\" rel=\"noopener noreferrer\" target=\"_blank\"><em>On Pair Programming</em></a> by Martin Fowler</p></li><li><p><a href=\"https://www.youtube.com/watch?v=u8qgehH3kEQ\" rel=\"noopener noreferrer\" target=\"_blank\">NCIS \"pair programming\"</a></p></li><li><p><a href=\"https://lindastone.net/2014/11/24/are-you-breathing-do-you-have-email-apnea/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Are You Breathing? Do You Have Email Apnea?</em></a> by Linda Stone</p></li><li><p><a href=\"https://oisinmoran.com/quinetweet\" rel=\"noopener noreferrer\" target=\"_blank\"><em>How I Made a Self-Quoting Tweet</em></a><a href=\"https://oisinmoran.com/quinetweet\" rel=\"noopener noreferrer\" target=\"_blank\"> </a>by Oisín Moran</p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0202-lucia-episode.jpg",
-    "guests": [
-      {
-        "name": "Lucia Cerchie",
-        "bio": "<p>Lucia Cerchie is a software engineer from Phoenix, AZ. She spends a lot of time orbiting outside her comfort zone and when she's not coding, she likes to make her baby laugh.</p>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0202-lucia.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Glen McCallum: From IC to Engineering Manager, and the lessons learned along the way",
-    "slug": "0203-glen",
-    "id": "384",
-    "metaDescription": "Season Two, Episode Three of the Virtual Coffee Podcast",
-    "season": 2,
-    "episode": 3,
-    "buzzsproutId": "8370318",
-    "publishDate": "2021-04-20T04:00:00+00:00",
-    "shortDescription": "<p>In this episode, Dan and Bekah talk to Glen McCallum, a Software engineer and manager from Victoria, Canada, about his unexpected career journey, the hard decisions he's had to make, and using open-source software with his artificial pancreas.</p>",
-    "showNotes": "<p>In this episode, Dan and Bekah talk to Glen McCallum, a Software engineer from Victoria, Canada who manages a team of 8 engineers for the 2nd largest independent book distributor in the US, about his unexpected career journey, the hard decisions he's had to make, and using open-source software with his artificial pancreas. Glen also talks about his near-death experience in his first IT job and the decision to move from Independent Contributor to Management.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Glen: <a href=\"https://glenmccallum.com/\" rel=\"noopener noreferrer\" target=\"_blank\">glenmccallum.com</a>, <a href=\"https://twitter.com/glenmccallumcan\" rel=\"noopener noreferrer\" target=\"_blank\">@glenmccallumcan</a> on Twitter,</p></li><li><p>Glen's Lightning Talk: <a href=\"https://youtu.be/2hIBz5Ogi3o\" rel=\"noopener noreferrer\" target=\"_blank\">From independent contributor to engineering manager</a></p></li><li><p><a href=\"https://www.healthline.com/health/diabetesmine/innovation/we-are-not-waiting#About-the-#WeAreNotWaiting-Movement\" rel=\"noopener noreferrer\" target=\"_blank\">We are not waiting movement</a></p></li><li><p><a href=\"https://openaps.org/\" rel=\"noopener noreferrer\" target=\"_blank\">OpenAPS</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0203-glen-episode.jpg",
-    "guests": [
-      {
-        "name": "Glen McCallum",
-        "bio": "<p>Glen McCallum is a Software engineer from Victoria, Canada. For the past 7 years he's been doing backend development in C# and SQL. Earlier, he did projects in Java and Rails. He's always learning, currently exploring big data with hadoop, python, and spark. Day-to-day he manages a team of 8 engineers for the 2nd largest independent book distributor in the United States.</p>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0203-glen.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Debra-Kaye Elliott: The Self-Taught Developer Journey",
-    "slug": "0204-debra-kaye",
-    "id": "391",
-    "metaDescription": "Season Two, Episode Four of the Virtual Coffee Podcast",
-    "season": 2,
-    "episode": 4,
-    "buzzsproutId": "8413543",
-    "publishDate": "2021-04-27T04:00:00+00:00",
-    "shortDescription": "<p>In this episode of the podcast, we talk to Debra-Kaye Elliott about what it's like to be on the self-taught developer journey, imposter syndrome, and some of the key things she's learned along the way.</p>",
-    "showNotes": "<p>In this episode of the podcast, we talk to Debra-Kaye Elliott, a self-taught frontend developer making her way through Frontend Masters Web Development Bootcamp, about what it's like to be on the self-taught developer journey, how she navigates imposter syndrome, and the lessons she's learned a long the way. She talks about the impact of being able to learn with support, choosing the resources that work best for you, and how blogging has been a part of her journey.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Debra-Kaye: <a href=\"https://twitter.com/debrakayelliott\" rel=\"noopener noreferrer\" target=\"_blank\">@debrakayelliott</a> on Twitter, <a href=\"https://www.linkedin.com/in/debrakayeelliott\" rel=\"noopener noreferrer\" target=\"_blank\">@debrakayeelliott</a> on LinkedIn, and <a href=\"https://dev.to/debrakayeelliott\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/debrakayeelliott</a>.</p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0204-debra-kaye-episode.jpg",
-    "guests": [
-      {
-        "name": "Debra-Kaye Elliott",
-        "bio": "<p>Debra-Kaye Elliott is a Front End Developer going through a bootcamp, who's adding community-learning to her learning process. She's a career changer from the administrative field and always wanted to be in tech.</p>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0204-debra-kaye.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Tom Cudd - Psychological Safety and DevOps",
-    "slug": "0205-tom-cudd",
-    "id": "399",
-    "metaDescription": "Season Two, Episode Five of the Virtual Coffee Podcast",
-    "season": 2,
-    "episode": 5,
-    "buzzsproutId": "8456725",
-    "publishDate": "2021-05-04T04:00:00+00:00",
-    "shortDescription": "<p>In this episode of the podcast, we talk to Tom Cudd about his experiences with DevOps, the importance of building psychological safety in to your team building and workflows.</p>",
-    "showNotes": "<p>In this episode of the podcast, we talk to Tom Cudd, a systems architect and 20-year veteran in technology. We talked about his experiences with DevOps and how it has changed over the years, about psychological safety: what it means to Tom, and how important it is to build in to your team and workflows, and about the dangers of \"hero culture\" in the workplace.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Tom Cudd: <a href=\"https://twitter.com/tomcudd\" rel=\"noopener noreferrer\" target=\"_blank\">@tomcudd</a> on Twitter, <a href=\"https://tomcudd.com/\" rel=\"noopener noreferrer\" target=\"_blank\">tomcudd.com</a></p></li></ul><h5 class=\"text-left\"><strong>Mentioned in the Episode:</strong></h5><ul><li><p><a href=\"https://www.goodreads.com/book/show/17255186-the-phoenix-project\" rel=\"noopener noreferrer\" target=\"_blank\">The Phoenix Project</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/44333183-the-unicorn-project\" rel=\"noopener noreferrer\" target=\"_blank\">the Unicorn Project</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/18167218-lean-enterprise\" rel=\"noopener noreferrer\" target=\"_blank\">Lean Enterprise</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/35747076-accelerate\" rel=\"noopener noreferrer\" target=\"_blank\">Accelerate</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/29939161-radical-candor\" rel=\"noopener noreferrer\" target=\"_blank\">Radical Candor</a></p></li><li><p><a href=\"https://softwaresocial.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Software Social Podcast</a></p></li><li><p><a href=\"https://www.manager-tools.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Manager Tools</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0205-tomcudd-episode.jpg",
-    "guests": [
-      {
-        "name": "Tom Cudd",
-        "bio": "<p>Tom Cudd is a Systems Architect and a reformed Systems Administrator for an ad agency in the Kansas City area. He has been employed in technology for nearly 20 years, but has been using computers and the internet for most of his life. Tom is a huge fan of DevOps, lean processes, learning mindsets, and empathy with action. He also rabidly follows Husker football and the Chiefs.</p>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0205-tomcudd.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Courtney Landau - On being quiet in a loud tech world",
-    "slug": "0206-courtney-landau",
-    "id": "406",
-    "metaDescription": "Season Two, Episode Six of the Virtual Coffee Podcast",
-    "season": 2,
-    "episode": 6,
-    "buzzsproutId": "8499055",
-    "publishDate": "2021-05-11T04:00:00+00:00",
-    "shortDescription": "<p>In this episode of the podcast, we talk to Courtney Landau about how the trend of constant self-marketing in tech has impacted her career, her experience as a developer, and what's it's been like to take on a variety of roles as a Virtual Coffee contributor.</p>",
-    "showNotes": "<p>In this episode of the podcast, we talk to Courtney Landau, a software engineer currently working at an early-stage startup in the Education Technology space. We talked about her experience with being quiet in tech with the constant push for self-marketing and how she learns new things. We also dive into her experience as a mentor, speaker, lightning talk team member, and the other roles she's played as part of Virtual Coffee.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Courtney Landau: <a href=\"https://twitter.com/sosuperc\" rel=\"noopener noreferrer\" target=\"_blank\">@sosuperc</a> on Twitter, <a href=\"http://www.celandau.com/\" rel=\"noopener noreferrer\" target=\"_blank\">celandau.com</a></p></li></ul><h5 class=\"text-left\"><strong>Mentioned in the Episode:</strong></h5><ul><li><p><a href=\"https://twitter.com/sosuperc/status/1372529647947288588?s=20\" rel=\"noopener noreferrer\" target=\"_blank\">Quiet & soft-spoken =/= inexperienced.</a></p></li><li><p>Courtney's Lightning Talk from 2021: <a href=\"https://www.youtube.com/watch?v=ghFNiCMy67M\" rel=\"noopener noreferrer\" target=\"_blank\">Breaking down coding problems in interviews</a></p></li><li><p><a href=\"https://chrome.google.com/webstore/detail/learnics-teacher-link/nhdacjmkhimeohpnahfmdmcknaneeffk\" rel=\"noopener noreferrer\" target=\"_blank\">Learnics Teacher Link Chrome Extension</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0206-courtney-episode.jpg",
-    "guests": [
-      {
-        "name": "Courtney Landau",
-        "bio": "<p>Courtney is a software engineer currently working at an early-stage startup in the Education Technology space. Previously in the medical imaging field, she’s been working in the industry since 2019 after obtaining her Master’s in Information Sciences. She works on full-stack web applications using primarily TypeScript and JavaScript, built on a cloud platform. For fun she likes to run, play board games with her family, and patronize local independent restaurants and breweries.</p>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0206-courtney.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Nerando Johnson - Keeping Momentum, Community, and Socialization as a Service",
-    "slug": "0207-nerando-johnson",
-    "id": "413",
-    "metaDescription": "Season Two, Episode Seven of the Virtual Coffee Podcast",
-    "season": 2,
-    "episode": 7,
-    "buzzsproutId": "8542053",
-    "publishDate": "2021-05-18T04:00:00+00:00",
-    "shortDescription": "<p>In this episode of the podcast we talk to Nerando Johnson, a full stack developer, about running freeCodeCamp meetups in Atlanta, learning through hackathons, and how his next endeavor should be socialization as a service for tech events.</p>",
-    "showNotes": "<p>In this episode of the podcast, Dan and Bekah talk with Nerando Johnson, a full stack developer looking for his next job, about running freeCodeCamp meetups in Atlanta, learning through hackathons (including that one time his team won the hackathon and donated the $40,000 in winnings to charity) and how his next endeavor should be socialization as a service for tech events. We also talk about the importance of having a solid support system and we laugh...a lot.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Nerando Johnson: <a href=\"https://twitter.com/nerajno\" rel=\"noopener noreferrer\" target=\"_blank\">@nerajno</a> on Twitter, <a href=\"https://dev.to/nerajno/\" rel=\"noopener noreferrer\" target=\"_blank\">nerajno</a> on DEV, <a href=\"https://github.com/Nerajno\" rel=\"noopener noreferrer\" target=\"_blank\">Nerajno</a> on GitHub</p></li></ul><h5 class=\"text-left\"><strong>Mentioned in the Episode:</strong></h5><ul><li><p><a href=\"https://www.itsmarta.com/marta-hackathon.aspx\" rel=\"noopener noreferrer\" target=\"_blank\">MARTA Hackathon</a></p></li><li><p>freeCodeCamp Atlanta - <a href=\"https://www.facebook.com/groups/free.code.camp.atlanta/\" rel=\"noopener noreferrer\" target=\"_blank\">Facebook</a> - <a href=\"https://study-group-directory.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Find your FCC Meetup</a>:</p></li><li><p>Reactadelphia - <a href=\"https://twitter.com/reactadelphia\" rel=\"noopener noreferrer\" target=\"_blank\">@reactadelphia</a></p></li><li><p><a href=\"https://connect.tech/\" rel=\"noopener noreferrer\" target=\"_blank\">Connect.Tech</a></p></li><li><p><a href=\"https://twitter.com/garyvee\" rel=\"noopener noreferrer\" target=\"_blank\">Gary Vee</a></p></li><li><p><a href=\"https://twitter.com/xirclebox\" rel=\"noopener noreferrer\" target=\"_blank\">Homer Gaines</a></p></li><li><p><a href=\"https://twitter.com/techieEliot\" rel=\"noopener noreferrer\" target=\"_blank\">Eliot Sanford</a></p></li><li><p><a href=\"https://twitter.com/DThompsonDev\" rel=\"noopener noreferrer\" target=\"_blank\">Danny Thompson</a></p></li><li><p><a href=\"https://twitter.com/Career_Karma\" rel=\"noopener noreferrer\" target=\"_blank\">Career Karma</a></p></li><li><p><a href=\"https://www.jim-butcher.com/books/Dresden\" rel=\"noopener noreferrer\" target=\"_blank\">Dresden Files</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/27213329-grit\" rel=\"noopener noreferrer\" target=\"_blank\">Grit: The Power of Passion and Perseverance</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0207-nerando-episode.jpg",
-    "guests": [
-      {
-        "name": "Nerando Johnson",
-        "bio": "<p>This is Nerando, he likes to use programming to solve problems, (Yup, he is a developer). Nerando has been a community organizer for <a href=\"https://www.facebook.com/groups/free.code.camp.atlanta/\" rel=\"noopener noreferrer\" target=\"_blank\">freeCodeCamp Atlanta</a> for over the last two years. He has been to a <a href=\"https://medium.com/paratransit-pal/paratransit-pal-won-40-000-at-at-ts-atlanta-civic-coding-challenge-and-gave-it-all-to-charity-30bba157d92d\" rel=\"noopener noreferrer\" target=\"_blank\">few hackathons</a> and is <a href=\"https://dev.to/nerajno\" rel=\"noopener noreferrer\" target=\"_blank\">an infrequent blogger</a>. When not coding, Nerando enjoys coding cooking, reading, the act of creating something from nothing and consuming the odd blog or podcast about the human mind (<a href=\"https://www.npr.org/programs/\" rel=\"noopener noreferrer\" target=\"_blank\">Hi, NPR</a>).</p>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0207-nerando.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Sara McCombs - Learning to leverage your past experience and embrace your whole self",
-    "slug": "0208-sara-mccombs",
-    "id": "420",
-    "metaDescription": "Season Two, Episode Eight of the Virtual Coffee Podcast",
-    "season": 2,
-    "episode": 8,
-    "buzzsproutId": "8584928",
-    "publishDate": "2021-05-25T04:00:00+00:00",
-    "shortDescription": "<p>In this episode of the podcast we talk to Sara McCombs, a software engineer, team lead, and Community Maintainer at Virtual Coffee, about how to leverage your past experience, talk about transferable skills, and owning your wins as an early career developer.</p>",
-    "showNotes": "<p>In this episode of the podcast, Dan and Bekah talk with Sara McCombs. Sara is a software engineer and team lead at <a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a>, and also one of the original organizers, and a current Community Maintainer, at Virtual Coffee. Sara shared her thoughts on how to think and talk about transferable skills, leveraging past experience to differentiate yourself, and the importance of embracing that past experience as part of your journey and strengths. She also talked about the impact of career changes, promotions, and overcoming self-doubt.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Sara McCombs: <a href=\"https://twitter.com/dino_momma\" rel=\"noopener noreferrer\" target=\"_blank\">@dino_momma</a> on Twitter, <a href=\"https://dev.to/saramccombs/\" rel=\"noopener noreferrer\" target=\"_blank\">saramccombs</a> on DEV, <a href=\"https://github.com/saramccombs\" rel=\"noopener noreferrer\" target=\"_blank\">saramccombs</a> on GitHub</p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0208-sara-episode.jpg",
-    "guests": [
-      {
-        "name": "Sara McCombs",
-        "bio": "<p>Sara is a published former research director turned software engineer and team lead at <a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a>, as well as a community engagement leader at <a href=\"https://www.projectalloy.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Project Alloy</a>. She is also one of the original organizers, and a current community maintainer, at <a href=\"https://virtualcoffee.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee</a>. Sara is passionate about diversity and inclusion, and has written frequently about her journey into tech. She has an M.Ag and a B.S.Ag from West Virginia University, and is a 2020 graduate of Flatiron School.</p>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0208-sara.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Season Two Wrap-Up: Code and Community",
-    "slug": "0209-season-two-wrapup",
-    "id": "427",
-    "metaDescription": "Season Two, Episode Nine of the Virtual Coffee Podcast",
-    "season": 2,
-    "episode": 9,
-    "buzzsproutId": "8625475",
-    "publishDate": "2021-06-01T04:00:00+00:00",
-    "shortDescription": "<p>In this episode of the podcast, Dan and Bekah wrap up season two by talking about what they've learned about community, supporting members, and trying to find the right tools to make it happen.</p>",
-    "showNotes": "<p>In this episode of the podcast, Dan and Bekah wrap up season two by talking about what they've learned about community building over the last year and some lessons they've learned along the way. They talk about Virtual Coffee's mission to support its members, and how Virtual Coffee's unique approach presents both challenges and opportunities when it comes to finding tools and guidance as the community grows.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p><a href=\"https://magnoliajs.com/\" rel=\"noopener noreferrer\" target=\"_blank\">MagnoliaJS</a></p></li><li><p><a href=\"https://www.radicalcandor.com/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Radical Candor</em></a> by Kim Scott</p></li><li><p><a href=\"https://twitter.com/kldickenson\" rel=\"noopener noreferrer\" target=\"_blank\">Karen Dickinson</a></p></li><li><p><a href=\"https://orbit.love/\" rel=\"noopener noreferrer\" target=\"_blank\">Orbit model</a></p></li><li><p><a href=\"https://twitter.com/MarieAntons\" rel=\"noopener noreferrer\" target=\"_blank\">Marie Antons</a></p></li><li><p><a href=\"https://twitter.com/ray_deck\" rel=\"noopener noreferrer\" target=\"_blank\">Ray Deck</a></p></li><li><p><a href=\"https://twitter.com/CerchieLucia\" rel=\"noopener noreferrer\" target=\"_blank\">Lucia Cerchie</a></p></li><li><p><a href=\"https://twitter.com/CerchieLucia/status/1397937325464723458\" rel=\"noopener noreferrer\" target=\"_blank\">Lucia's tweet about Hacktoberfest</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0209-season-2-wrapup.jpg",
-    "guests": [
-      {
-        "name": "Bekah Hawrot Weigel",
-        "bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dev.to/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/bekahhw</a></p></li><li><p><a href=\"https://twitter.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">@bekahhw</a> on Twitter</p></li><li><p><a href=\"https://www.instagram.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">bekahhw</a> on Instagram</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0209-bekah.jpg"
-      },
-      {
-        "name": "Dan Ott",
-        "bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dtott.com/\" rel=\"noopener noreferrer\" target=\"_blank\">dtott.com</a></p></li><li><p><a href=\"https://twitter.com/danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">@danieltott</a> on Twitter</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0209-dan.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Jono Yeong - Digital Gardening and Tim Tams",
-    "slug": "0301-jono-yeong",
-    "id": "444",
-    "metaDescription": "Season Three, Episode One of the Virtual Coffee Podcast",
-    "season": 3,
-    "episode": 1,
-    "buzzsproutId": "8821435",
-    "publishDate": "2021-07-06T04:00:00+00:00",
-    "shortDescription": "<p>In this episode of the podcast Bekah and Dan talk to Jono Yeong about digital gardening, learning Elixir, and how he brings learning new things to what he's doing with Rails. And for a bonus, he even walks us through how to do a proper Tim Tam slam.</p>",
-    "showNotes": "<p>In this episode of the podcast Bekah and Dan talk to Jono Yeong, a senior software engineer originally from Australia, but currently based in Seattle, USA, about how digital gardening leaves room for growth, allows you to develop what you enjoy, and is an investment in communication skills. We also talk about learning Elixir, the process he goes through as he's learning something new, and how he brings learning new things to what he's doing with Rails. Bonus: he even walks us through how to do a proper Tim Tam slam.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p><a href=\"https://www.jonathanyeong.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Jono's website</a></p></li><li><p><a href=\"https://www.descript.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Descript</a></p></li><li><p><a href=\"https://maggieappleton.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Maggie Appleton</a></p></li><li><p><a href=\"https://www.jonathanyeong.com/garden/using-github-and-notion-to-organise-side-projects\" rel=\"noopener noreferrer\" target=\"_blank\">Github and notion blogpost</a></p></li><li><p><a href=\"https://twitter.com/VicVijayakumar\" rel=\"noopener noreferrer\" target=\"_blank\">Vic Vijayakumar</a></p></li><li><p><a href=\"https://twitter.com/nickytonline\" rel=\"noopener noreferrer\" target=\"_blank\">NickyT</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=jhXJCqQBz04\" rel=\"noopener noreferrer\" target=\"_blank\">Building a social network for puppies</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=k8hEo4N8Nhs\" rel=\"noopener noreferrer\" target=\"_blank\">TimTams slams</a></p></li><li><p><a href=\"https://www.arnotts.com/products/tim-tam\" rel=\"noopener noreferrer\" target=\"_blank\">TimTams</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0301-jono-episode.jpg",
-    "guests": [
-      {
-        "name": "Jonathan Yeong",
-        "bio": "<p>Jonathan Yeong is a senior developer at Shopify. Being from Australia, he often goes by Jono. A Rubyist at heart, he blogs and produces videos about all things programming. He’s passionate about the human connections in technology. And believes that being part of a community, a mentor, and a teacher is one of the most rewarding things you can do.</p><ul><li><p><a href=\"https://twitter.com/JonoYeong\" rel=\"noopener noreferrer\" target=\"_blank\">Twitter</a></p></li><li><p><a href=\"https://www.jonathanyeong.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Website</a></p></li><li><p><a href=\"https://www.youtube.com/c/jonathanyeong\" rel=\"noopener noreferrer\" target=\"_blank\">YouTube</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0301-jono.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Abbey Perini - Finding Confidence and Opportunities",
-    "slug": "0302-abbey-perini",
-    "id": "451",
-    "metaDescription": "Season Three, Episode Two of the Virtual Coffee Podcast",
-    "season": 3,
-    "episode": 2,
-    "buzzsproutId": "8858957",
-    "publishDate": "2021-07-13T04:00:00+00:00",
-    "shortDescription": "<p>On this episode of the podcast, we talk to Abbey Perini, a full-stack web developer, about the importance of practice, building in public, and sending thank you notes when you're interviewing for your first tech job.</p>",
-    "showNotes": "<p>On this episode of the podcast, we talk to Abbey Perini, a full-stack web developer, about the impact building in public has had on her developer journey, what her experience as a recruiting admin taught her as she sent out 160 applications before landing her dev role, and how rehearsing before an interview can make a big impact.</p><h4 class=\"text-left\"><strong>Links mentioned in the episode:</strong></h4><ul><li><p>Github: <a href=\"https://github.com/abbeyperini\" rel=\"noopener noreferrer\" target=\"_blank\">https://github.com/abbeyperini</a></p></li><li><p><a href=\"https://www.indeed.com/career/salaries\" rel=\"noopener noreferrer\" target=\"_blank\">Indeed job rate checker</a></p></li><li><p>Abbey's posts mentioned:</p><ul><li><p><a href=\"https://dev.to/abbeyperini/css-animated-button-with-offset-border-1ibi\" rel=\"noopener noreferrer\" target=\"_blank\">CSS Animated Button with Offset Border</a></p></li><li><p><a href=\"https://javascript.plainenglish.io/react-redux-reload-a-page-when-a-user-makes-a-change-7661a3e1b8ed\" rel=\"noopener noreferrer\" target=\"_blank\">Sheba Counter: How To Reload a Page Whenever a User Makes a Change with React/Redux</a></p></li><li><p><a href=\"https://dev.to/abbeyperini/toggle-dark-mode-in-react-28c9\" rel=\"noopener noreferrer\" target=\"_blank\">Toggle Dark Mode in React</a></p></li><li><p><a href=\"https://dev.to/abbeyperini/knitting-as-programming-3e5\" rel=\"noopener noreferrer\" target=\"_blank\">Knitting as Programming</a></p></li><li><p><a href=\"https://dev.to/abbeyperini/practicing-confidence-for-the-job-search-38nj\" rel=\"noopener noreferrer\" target=\"_blank\">Practicing Confidence for the Job Search</a></p></li></ul></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0302-abbey-episode.jpg",
-    "guests": [
-      {
-        "name": "Abbey Perini",
-        "bio": "<p>Abbey Perini is many things - a metro Atlanta native, a person of many hobbies, and a full-stack web developer. Currently ramping up in her first development role, she loves blogging about stupid Discord bots, animated CSS buttons, and other fun and useful things about programming. You can find her work and ways to connect with her at <a href=\"https://abbeyperini.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">abbeyperini.dev</a>.</p><ul><li><p><a href=\"https://abbeyperini.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">abbeyperini.dev</a></p></li><li><p><a href=\"https://twitter.com/AbbeyPerini\" rel=\"noopener noreferrer\" target=\"_blank\">@AbbeyPerini</a> on Twitter</p></li><li><p><a href=\"https://github.com/abbeyperini\" rel=\"noopener noreferrer\" target=\"_blank\">@abbeyperini</a> on GitHub</p></li><li><p><a href=\"https://dev.to/abbeyperini\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/abbeyperini</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0302-abbey.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Ayu Adiati - Working through burnout as a self-taught developer",
-    "slug": "0303-ayu-adiati",
-    "id": "458",
-    "metaDescription": "Season Three, Episode Three of the Virtual Coffee Podcast",
-    "season": 3,
-    "episode": 3,
-    "buzzsproutId": "8893503",
-    "publishDate": "2021-07-20T04:00:00+00:00",
-    "shortDescription": "<p>In this episode, Dan and Bekah talk to Ayu about the impact of community, being a prolific blogger, and the very real challenge of burnout.</p>",
-    "showNotes": "<p>In this episode, Dan and Bekah talk to Ayu about the impact of community, being a prolific blogger, and the very real challenge of burnout. Ayu's openness about the challenges of being a mom on the self-taught track into tech, isolation, and fears of not being good enough are the stories that we don't share enough of. Because when we share, we can all work through them together. Thank you, Ayu, for reminding us that it's ok to not be ok.</p><h4 class=\"text-left\"><strong>Links mentioned in the episode:</strong></h4><ul><li><p><a href=\"https://community.codenewbie.org/adiatiayu/lesson-learned-massive-burnout-in-learning-web-development-3b5g?signin=true\" rel=\"noopener noreferrer\" target=\"_blank\">Lesson Learned: Massive Burnout In Learning Web Development</a></p></li><li><p><a href=\"https://twitter.com/AdiatiAyu/status/1400833965293019138?s=19\" rel=\"noopener noreferrer\" target=\"_blank\">Ayu's twitter thread about struggling with learning to code</a></p></li><li><p><a href=\"https://www.freecodecamp.org/learn/responsive-web-design/\" rel=\"noopener noreferrer\" target=\"_blank\">Free Code Camp - web responsive design certification</a></p></li><li><p><a href=\"https://community.codenewbie.org/codenewbie/ayu-polyglot-latte-lover-codenewbie-149m\" rel=\"noopener noreferrer\" target=\"_blank\">Ayu's CodeNewbie Community Spotlight</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0303-ayu-episode.jpg",
-    "guests": [
-      {
-        "name": "Ayu Adiati",
-        "bio": "<p>Originally from Indonesia and now based in The Netherlands, Ayu Adiati is a self-taught Frontend Developer & Technical Blogger. She’s on her way to break into tech from being a stay-at-home-mom of now a 4 years old daughter.</p><p class=\"text-left\">When Ayu is not coding, you can find her with the DLSR camera on her hands, cuddling with her daughter, or enjoying her iced macchiato latte.</p><ul><li><p><a href=\"https://virtualcoffee.io/podcast/0303-ayu-adiati/@AdiatiAyu%20(https://twitter.com/AdiatiAyu)\" rel=\"noopener noreferrer\" target=\"_blank\">Twitter</a></p></li><li><p><a href=\"https://adiati.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Blog</a></p></li><li><p><a href=\"https://dev.to/adiatiayu\" rel=\"noopener noreferrer\" target=\"_blank\">DEV</a></p></li><li><p><a href=\"https://community.codenewbie.org/adiatiayu\" rel=\"noopener noreferrer\" target=\"_blank\">CodeNewbie</a></p></li><li><p><a href=\"https://hashnode.com/@ayuadiati\" rel=\"noopener noreferrer\" target=\"_blank\">Hashnode</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0303-ayu.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Joan Marie Verba - Keeping hope through decades of challenges",
-    "slug": "0304-joan-marie-verba",
-    "id": "465",
-    "metaDescription": "Season Three, Episode Four of the Virtual Coffee Podcast",
-    "season": 3,
-    "episode": 4,
-    "buzzsproutId": "8929061",
-    "publishDate": "2021-07-27T04:00:00+00:00",
-    "shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk to Joan Marie Verba about her early days in tech using Fortran, and how refusal to accommodate her allergies has prevented her from having a lifelong career in tech. She talks about pushing forward and not taking no for an answer as she continues her decades-long journey into tech.</p>",
-    "showNotes": "<p>In this episode of the podcast, Dan and Bekah talk to Joan Marie Verba, a web developer, former astronomy teacher, and prolific science fiction writer, about her early days in tech using Fortran, and how refusal to accommodate her allergies has prevented her from having a lifelong career in tech. She shares the story of her recent job offer that actually turned out to be a scam that's being investigated by the FBI. But she's not done searching for her next place in tech. She's pushing past the challenges until she finds that next job.</p><h5 class=\"text-left\"><strong>Links:</strong></h5><ul><li><p><a href=\"https://www.ada.gov/\" rel=\"noopener noreferrer\" target=\"_blank\">Americans with Disabilities Act</a></p></li><li><p>Website: <a href=\"http://joanmarieverba.com/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.com</a></p></li><li><p>Blog: <a href=\"http://joanmarieverba.info/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.info</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/joanmarieverba\" rel=\"noopener noreferrer\" target=\"_blank\">@joanmarieverba</a></p></li><li><p>Web developer portfolio: <a href=\"http://joanmarieverba.co.technology/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.co.technology</a></p></li><li><p>Projects page: <a href=\"http://joanmarieverba.name/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.name</a></p></li><li><p>UX page: <a href=\"http://joanmarieverba.net/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.net</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0304-joan-episode.jpg",
-    "guests": [
-      {
-        "name": "Joan Marie Verba",
-        "bio": "<p>Joan Marie Verba earned a bachelor of physics degree from the University of Minnesota and attended the graduate school of astronomy at Indiana University, where she was an associate instructor of astronomy for one year. She has worked as a computer programmer and as an editor. She currently works as a writer, a publisher, and a web developer.</p><ul><li><p>Website: <a href=\"http://joanmarieverba.com/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.com</a></p></li><li><p>Blog: <a href=\"http://joanmarieverba.info/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.info</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/joanmarieverba\" rel=\"noopener noreferrer\" target=\"_blank\">@joanmarieverba</a></p></li><li><p>Web developer portfolio: <a href=\"http://joanmarieverba.co.technology/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.co.technology</a></p></li><li><p>Projects page: <a href=\"http://joanmarieverba.name/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.name</a></p></li><li><p>UX page: <a href=\"http://joanmarieverba.net/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.net</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0304-joan.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Kevin Truong - Tech Career Coaching",
-    "slug": "0305-kevin-truong",
-    "id": "472",
-    "metaDescription": "Season Three, Episode Five of the Virtual Coffee Podcast",
-    "season": 3,
-    "episode": 5,
-    "buzzsproutId": "8967149",
-    "publishDate": "2021-08-03T04:00:00+00:00",
-    "shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk to Kevin, a senior software consultant at Test Double and a coding career coach at his company Tap into Tech, about his approach to interviewing and how to navigate some of the biggest challenges early-career devs face when trying to break into the industry.</p>",
-    "showNotes": "<p>In this episode of the podcast, Dan and Bekah talk to Kevin, a senior software consultant at Test Double and a coding career coach at his company Tap into Tech, about some of the most common challenges early-career developers face getting into tech and offers practical advice for working through those problems. We dive into visualization, personal support, and ways to change the interview process in tech.</p><h5 class=\"text-left\"><strong>Links:</strong></h5><ul><li><p>Kevin's Twitter: <a href=\"https://twitter.com/TheKevinTruong\" rel=\"noopener noreferrer\" target=\"_blank\">@TheKevinTruong</a></p></li><li><p>Kevin's LinkedIn: <a href=\"https://www.linkedin.com/in/thekevintruong/\" rel=\"noopener noreferrer\" target=\"_blank\">thekevintruong</a></p></li><li><p><a href=\"https://tapintotech.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Tap into Tech</a></p></li><li><p><a href=\"https://testdouble.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Test Double</a></p></li><li><p><a href=\"http://thekevintruong.com/\" rel=\"noopener noreferrer\" target=\"_blank\">thekevintruong.com</a></p></li><li><p><a href=\"https://www.loom.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Loom</a></p></li><li><p><a href=\"https://twitter.com/terribledustin/status/1405903173684850695?s=19\" rel=\"noopener noreferrer\" target=\"_blank\">Dustin McCaffree Upwork/Loom Tweet</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0305-kevin-episode.jpg",
-    "guests": [
-      {
-        "name": "Kevin Truong",
-        "bio": "<p>Kevin Truong is a senior software consultant at Test Double and a coding career coach at his company Tap into Tech. Previously a coding boot camp instructor and mentor, Kevin realized that boot camps were missing a lot of information when it came to the final steps of getting hired. With his years of experience, he has developed a program where he has coached dozens of early career devs on how to improve their results on getting a tech job.</p><ul><li><p>Twitter: <a href=\"https://twitter.com/TheKevinTruong\" rel=\"noopener noreferrer\" target=\"_blank\">@TheKevinTruong</a></p></li><li><p>LinkedIn: <a href=\"https://www.linkedin.com/in/thekevintruong/\" rel=\"noopener noreferrer\" target=\"_blank\">thekevintruong</a></p></li><li><p><a href=\"https://tapintotech.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Tap into Tech</a></p></li><li><p><a href=\"http://thekevintruong.com/\" rel=\"noopener noreferrer\" target=\"_blank\">thekevintruong.com</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0305-kevin.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Ray Deck - Rubber-Ducking your Life",
-    "slug": "0306-ray-deck",
-    "id": "479",
-    "metaDescription": "Season Three, Episode Six of the Virtual Coffee Podcast",
-    "season": 3,
-    "episode": 6,
-    "buzzsproutId": "9007249",
-    "publishDate": "2021-08-10T04:00:00+00:00",
-    "shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk to Ray Deck about rubber ducking your career path, the importance of trust and relationships, and accepting that we're probably wrong more than we're right.</p>",
-    "showNotes": "<p>In this episode, Dan and Bekah talk to Ray Deck, a trained data scientist, occasional angel investor, and software entrepreneur, about finding the right career path through growth, learning, and motivation. We talk about the importance of trust and listening, and Ray drops a bunch of great resources to help everyone find their own path.</p><h5 class=\"text-left\"><strong>Favorite nonfiction books:</strong></h5><ul><li><p>Bekah's pick: <a href=\"https://allisonpataki.com/books/beauty-in-the-broken-places/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Beauty in the Broken Places</em></a><a href=\"https://allisonpataki.com/books/beauty-in-the-broken-places/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Allison Pataki</a></p></li><li><p>Bekah's second pick: <a href=\"https://drgabormate.com/book/scattered-minds/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Scattered Minds</em></a><a href=\"https://drgabormate.com/book/scattered-minds/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Dr. Gabor Maté</a></p></li><li><p>Dan's pick: <a href=\"https://www.hachettebooks.com/titles/lindy-west/shit-actually/9780316449847/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Shit, Actually</em></a><a href=\"https://www.hachettebooks.com/titles/lindy-west/shit-actually/9780316449847/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Lindy West</a></p></li><li><p>Ray's pick: <a href=\"https://www.edwardtufte.com/tufte/books_vdqi\" rel=\"noopener noreferrer\" target=\"_blank\"><em>The Visual Display of Quantitative Information</em></a><a href=\"https://www.edwardtufte.com/tufte/books_vdqi\" rel=\"noopener noreferrer\" target=\"_blank\"> by Edwarde Tufte</a></p></li></ul><h5 class=\"text-left\"><strong>Links to things mentioned in the episode:</strong></h5><ul><li><p><a href=\"https://simonsinek.com/product/start-with-why/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Start With Why</em></a><a href=\"https://simonsinek.com/product/start-with-why/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Simon Sinek</a></p></li><li><p><a href=\"https://www.franklincovey.com/the-7-habits/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>The 7 Habits of Highly Effective People</em></a><a href=\"https://www.franklincovey.com/the-7-habits/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Stephen R. Covey</a></p></li><li><p><a href=\"https://www.amazon.com/8th-Habit-Effectiveness-Greatness-Paperback/dp/B00GOHDKRI/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>The 8th Habit: From Effectiveness to Greatness</em></a><a href=\"https://www.amazon.com/8th-Habit-Effectiveness-Greatness-Paperback/dp/B00GOHDKRI/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Stephen R. Covey</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0306-ray-episode.jpg",
-    "guests": [
-      {
-        "name": "Ray Deck",
-        "bio": "<p>Ray is a trained data scientist, occasional angel investor, and software entrepreneur. His 25-year career spans industries from law to finance. Most recently, Ray is the founder of Sustained Ventures, a software product studio where he also publishes essays on technology and markets.</p><p class=\"text-left\">Ray's thoughts can be followed at <a href=\"https://sustainedventures.com/essays\" rel=\"noopener noreferrer\" target=\"_blank\">sustainedventures.com/essays</a>, and his less-thoughtful self is on Twitter <a href=\"https://twitter.com/ray_deck\" rel=\"noopener noreferrer\" target=\"_blank\">@ray_deck</a>.</p><ul><li><p><a href=\"https://sustainedventures.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Sustained Ventures</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/ray_deck\" rel=\"noopener noreferrer\" target=\"_blank\">@ray_deck</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0306-ray.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Mike Rogers - Tend Your Career like a Garden",
-    "slug": "0307-mike-rogers",
-    "id": "486",
-    "metaDescription": "Season Three, Episode Seven of the Virtual Coffee Podcast",
-    "season": 3,
-    "episode": 7,
-    "buzzsproutId": "9044559",
-    "publishDate": "2021-08-17T04:00:00+00:00",
-    "shortDescription": "<p>In this episode, Dan and Bekah are joined by Mike Rogers, to talk about changing course as a dev, and tending careers like gardens.</p>",
-    "showNotes": "<p>In this episode, Dan and Bekah are joined by Mike Rogers. Mike has had a long and successful career, but at one point he realized he no longer felt good or satisfied with where he was as a developer. He shared with us what he did to change course, and how he has learned to approach tending his career almost like a garden.</p><h5 class=\"text-left\"><strong>Links to things mentioned in the episode:</strong></h5><ul><li><p>Mike's YouTube: <a href=\"https://www.youtube.com/c/MikeRogers0\" rel=\"noopener noreferrer\" target=\"_blank\">MikeRogers0</a></p></li><li><p><a href=\"http://www.slate.com/articles/technology/technology/2012/03/ruby_ruby_on_rails_and__why_the_disappearance_of_one_of_the_world_s_most_beloved_computer_programmers_.html\" rel=\"noopener noreferrer\" target=\"_blank\">Where’s _why?</a> - What happened when one of the world’s most unusual, and beloved, computer programmers disappeared.</p></li><li><p>Meditation Minis podcast: <a href=\"https://www.meditationminis.com/\" rel=\"noopener noreferrer\" target=\"_blank\">meditationminis.com</a></p></li><li><p>Mike's Business Times cover:</p></li><li><p></p><img src=\"https://optimise2.assets-servd.host/virtual-coffee/production/images/0307-mike-bt-cover.jpg?w=378&amp;auto=compress%2Cformat&amp;fit=crop&amp;dm=1648577051&amp;s=3b73d41bc861dfe62cff7d45baac177b\" alt=\"Mike&#039;s cover on the Business Times\" title=\"\"></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0307-mike-episode.jpg",
-    "guests": [
-      {
-        "name": "Mike Rogers",
-        "bio": "<p>Mike Rogers is a Ruby developer from the UK. He made the chat bots for Virtual Coffee, has an awesome Ruby Event Calendar, and loves Docker.</p><ul><li><p><a href=\"https://mikerogers.io/\" rel=\"noopener noreferrer\" target=\"_blank\">mikerogers.io</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/mikerogers0\" rel=\"noopener noreferrer\" target=\"_blank\">mikerogers0</a></p></li><li><p>GitHub: <a href=\"https://github.com/MikeRogers0\" rel=\"noopener noreferrer\" target=\"_blank\">MikeRogers0</a></p></li><li><p>YouTube: <a href=\"https://www.youtube.com/c/MikeRogers0\" rel=\"noopener noreferrer\" target=\"_blank\">MikeRogers0</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0307-mike.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Aurelie Verrot - Learning and Working Remotely",
-    "slug": "0308-aurelie-verrot",
-    "id": "494",
-    "metaDescription": "Season Three, Episode Eight of the Virtual Coffee Podcast",
-    "season": 3,
-    "episode": 8,
-    "buzzsproutId": "9080882",
-    "publishDate": "2021-08-24T04:00:00+00:00",
-    "shortDescription": "<p>In this episode of the podcast, Dan and Bekah are joined by Aurelie Verrot to talk about working through bootcamp during the pandemic, remote work, and how to \"just be cool\" when you're dealing with challenges like the pandemic, virtual school, and remote work.</p>",
-    "showNotes": "<p>In this episode, Dan and Bekah talk to Aurelie Verrot, a Software Engineer from the San Francisco Bay Area, who's originally from France, about the importance of relationships in team-building--whether as part of the learning process or in a work environment--and the benefits of being able to work from home. She talks about the importance of clear communication, creating boundaries, and maintaining flexibility as key habits to build.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Twitter: <a href=\"https://twitter.com/LiliVerrot\" rel=\"noopener noreferrer\" target=\"_blank\">LiliVerrot</a></p></li><li><p>GitHub: <a href=\"https://github.com/aurelieverrot\" rel=\"noopener noreferrer\" target=\"_blank\">aurelieverrot</a></p></li><li><p>LinkedIn: <a href=\"https://www.linkedin.com/in/aurelieverrot/\" rel=\"noopener noreferrer\" target=\"_blank\">aurelieverrot</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0308-aurelie-episode.jpg",
-    "guests": [
-      {
-        "name": "Aurelie Verrot",
-        "bio": "<p>Aurelie Verrot is a software engineer from the San Francisco Bay Area, originally from France. After moving to the US and taking care of her children for 4 years, she decided to make a career change in 2019 to work in tech. She started her first dev job in May as a Software Engineer working mostly with Ruby on Rails.</p><ul><li><p>Twitter: <a href=\"https://twitter.com/LiliVerrot\" rel=\"noopener noreferrer\" target=\"_blank\">LiliVerrot</a></p></li><li><p>GitHub: <a href=\"https://github.com/aurelieverrot\" rel=\"noopener noreferrer\" target=\"_blank\">aurelieverrot</a></p></li><li><p>LinkedIn: <a href=\"https://www.linkedin.com/in/aurelieverrot/\" rel=\"noopener noreferrer\" target=\"_blank\">aurelieverrot</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0308-aurelie.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Season 3 Wrap Up: Hacktoberfest is Coming!",
-    "slug": "0309-season-three-wrap-up",
-    "id": "503",
-    "metaDescription": "Season Three, Episode Nine of the Virtual Coffee Podcast",
-    "season": 3,
-    "episode": 9,
-    "buzzsproutId": "9124000",
-    "publishDate": "2021-09-01T04:00:00+00:00",
-    "shortDescription": "<p>Community Maintainer Kirk joins us (again) for our Season 3 wrap up and Hacktoberfest preview!</p>",
-    "showNotes": "<p>Community Maintainer Kirk joins us (again) for our Season 3 wrap up! We review what Virtual Coffee did last year for Hacktoberfest, and talk about a lot of the exciting things we have coming up this year! We also shared some fun things from the last year at Virtual Coffee, like our Virtual Coffee Co-Working Room!</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p><a href=\"https://apps.apple.com/us/app/classic-sudoku/id1488838275\" rel=\"noopener noreferrer\" target=\"_blank\">Classic Sudoku</a></p></li><li><p><a href=\"https://www.youtube.com/channel/UCC-UOdK8-mIjxBQm_ot1T-Q\" rel=\"noopener noreferrer\" target=\"_blank\">Cracking the Cryptic</a></p></li><li><p><a href=\"https://twitter.com/MarieAntons\" rel=\"noopener noreferrer\" target=\"_blank\">@MarieAntons</a></p></li><li><p>Tatiana Mac - <a href=\"https://github.com/selfdefined\" rel=\"noopener noreferrer\" target=\"_blank\">selfdefined</a></p></li><li><p><a href=\"https://github.com/dominicduffin1/Quarto\" rel=\"noopener noreferrer\" target=\"_blank\">Quarto by Dominic Duffin</a></p></li><li><p><a href=\"https://github.com/BekahHW/postpartum-wellness-app\" rel=\"noopener noreferrer\" target=\"_blank\">Bekah's postpartum wellness app</a></p></li><li><p><a href=\"https://github.com/Virtual-Coffee/virtualcoffee.io\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee's GitHub Org</a></p></li><li><p><a href=\"https://hacktoberfest.digitalocean.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Hacktoberfest on Digital Ocean</a></p></li><li><p>shoutout to our Monthly Challenge team: Adam, Andrew, Aurelie, Chris, Courtney, Dominic, Kevin, Luis, Vanessa, and Yolanda!</p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0309-hacktoberfest.jpg",
-    "guests": [
-      {
-        "name": "Kirk Shillingford",
-        "bio": "<p>Software Developer, and Community Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://twitter.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0108-kirk.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Jessi Shakarian - You aren't your tech stack: sharing your passion",
-    "slug": "0401-jessi-shakarian",
-    "id": "510",
-    "metaDescription": "Season Four, Episode One of the Virtual Coffee Podcast",
-    "season": 4,
-    "episode": 1,
-    "buzzsproutId": "9322612",
-    "publishDate": "2021-10-06T04:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Jessi Shakarian about her journey into UX/UI and how that lead to the big energy she needed to find her place in tech.</p>",
-    "showNotes": "<p>We welcome Jessi Shakarian to the show today to talk about her journey into UX/UI!</p><p class=\"text-left\">Jessi talks about how passion can be your motivation, and how valuable it is to be able to share what you're excited about: you aren't your tech stack. Sometimes finding that passion can lead you to new and interesting places like Jessi's change in focus from web dev to design.</p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0401-jessi-episode.png",
-    "guests": [
-      {
-        "name": "Jessi Shakarian",
-        "bio": "<p>Jessi Shakarian got her start in tech as a developer, but also she loved everything that happened before it was time to build a website. She is currently a UX designer at DIA Design Guild in Los Angeles and a python developer interested in machine learning.</p><ul><li><p><a href=\"https://www.jessishakarian.com/\" rel=\"noopener noreferrer\" target=\"_blank\">jessishakarian.com</a></p></li><li><p><a href=\"https://twitter.com/jessishakarian\" rel=\"noopener noreferrer\" target=\"_blank\">@jessishakarian</a> on Twitter</p></li><li><p><a href=\"https://www.polywork.com/jessishakarian\" rel=\"noopener noreferrer\" target=\"_blank\">jessishakarian</a> on PolyWork</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0401-jessi.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Todd Libby - Making the web equal and accessible",
-    "slug": "0402-todd-libby",
-    "id": "517",
-    "metaDescription": "Season Four, Episode Two of the Virtual Coffee Podcast",
-    "season": 4,
-    "episode": 2,
-    "buzzsproutId": "9355176",
-    "publishDate": "2021-10-12T04:00:00+00:00",
-    "shortDescription": "<p>This week on the podcast, we have Todd Libby talking about his work making the web equal and accessible for everyone. He drops a ton of resources (check the show notes!) tips on how to get started, and talks about how he's continually learning on the job.</p>",
-    "showNotes": "<p>We're welcoming Todd Libby to give us an intro to accessibility and what it means to make the web equal. Todd, a professional web developer, designer, and accessibility advocate for 22 years, provides a plethora of resources that can help everyone to get started and talks about how to advocate for accessibility and equality on projects.</p><h3><strong>Show Notes:</strong></h3><h4 class=\"text-left\"><strong>Things/People mentioned in the episode:</strong></h4><ul><li><p><a href=\"https://www.smashingmagazine.com/2021/07/strong-case-for-accessibility/\" rel=\"noopener noreferrer\" target=\"_blank\">Making A Strong Case for Accessibility</a> by Todd Libby</p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Microsoft_FrontPage\" rel=\"noopener noreferrer\" target=\"_blank\">Front Page Express</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Designing_with_Web_Standards\" rel=\"noopener noreferrer\" target=\"_blank\">Designing with Web Standards</a></p></li><li><p><a href=\"https://www.w3.org/WAI/standards-guidelines/wcag/\" rel=\"noopener noreferrer\" target=\"_blank\">Web Content Accessibility Guidelines (WCAG)</a></p></li><li><p><a href=\"https://twitter.com/cassandrafaris\" rel=\"noopener noreferrer\" target=\"_blank\">Cass Faris</a></p></li><li><p><a href=\"https://twitter.com/saltnburnem\" rel=\"noopener noreferrer\" target=\"_blank\">Chris DeMars</a></p></li></ul><h4 class=\"text-left\"><strong>A11y Learning Resources:</strong></h4><ul><li><p><a href=\"https://www.edx.org/course/web-accessibility-introduction\" rel=\"noopener noreferrer\" target=\"_blank\">Introduction to Web Accessibility</a> on edX</p></li><li><p><a href=\"https://webaim.org/\" rel=\"noopener noreferrer\" target=\"_blank\">WebAIM</a></p></li><li><p><a href=\"https://www.tpgi.com/\" rel=\"noopener noreferrer\" target=\"_blank\">TPGi</a></p></li></ul><h4 class=\"text-left\"><strong>Tools:</strong></h4><ul><li><p><a href=\"https://wave.webaim.org/extension/\" rel=\"noopener noreferrer\" target=\"_blank\">WAVE Web Accessibility Evaluation Tool</a></p></li><li><p><a href=\"https://www.deque.com/axe/\" rel=\"noopener noreferrer\" target=\"_blank\">axe accessibility toolkit</a></p></li><li><p><a href=\"https://pa11y.org/\" rel=\"noopener noreferrer\" target=\"_blank\">pa11y command line</a></p></li><li><p><a href=\"https://pauljadam.com/bookmarklets/tables.html\" rel=\"noopener noreferrer\" target=\"_blank\">Bookmarklets by Ian Loyyd and Paul J Adams</a></p></li><li><p><a href=\"https://github.com/microsoft/accessibility-insights-web\" rel=\"noopener noreferrer\" target=\"_blank\">Microsoft a11y insights</a></p></li><li><p><a href=\"https://developer.mozilla.org/en-US/docs/Tools/Accessibility_inspector\" rel=\"noopener noreferrer\" target=\"_blank\">Firefox a11y devtools</a></p></li><li><p><a href=\"https://developers.google.com/web/tools/lighthouse\" rel=\"noopener noreferrer\" target=\"_blank\">Lighthouse automated testing</a></p></li><li><p><a href=\"https://contrast-ratio.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Contrast Ratio tool by Lea Verou</a></p></li><li><p><a href=\"https://www.tpgi.com/color-contrast-checker/\" rel=\"noopener noreferrer\" target=\"_blank\">Colour Contrast Analyser</a></p></li></ul><h4 class=\"text-left\"><strong>Todd's steps for manual testing:</strong></h4><ol start=\"1\"><li><p>Mouse only</p></li><li><p>Keyboard only</p></li><li><p>Squint test</p></li><li><p><a href=\"https://www.afb.org/blindness-and-low-vision/using-technology/assistive-technology-products/screen-readers\" rel=\"noopener noreferrer\" target=\"_blank\">Screen readers</a></p></li><li><p><a href=\"https://webaim.org/articles/voiceover/\" rel=\"noopener noreferrer\" target=\"_blank\">Voice over in Safari</a></p></li><li><p><a href=\"https://www.nvaccess.org/\" rel=\"noopener noreferrer\" target=\"_blank\">NVDA</a> and <a href=\"https://www.freedomscientific.com/products/software/jaws/\" rel=\"noopener noreferrer\" target=\"_blank\">JAWS</a> on Windows</p></li><li><p><a href=\"https://help.gnome.org/users/orca/stable/introduction.html.en\" rel=\"noopener noreferrer\" target=\"_blank\">Orca</a> on Linux</p></li></ol>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0402-todd-episode.jpg",
-    "guests": [
-      {
-        "name": "Todd Libby",
-        "bio": "<p>Todd is a professional web developer, designer, and accessibility advocate for 22 years under many different technologies starting with HTML/CSS, Perl, and PHP, Todd has been an avid learner of web technologies for over 40 years starting with many flavors of BASIC all the way to React/Vue. Todd is also a member of the W3C working with groups on WCAG Silver (3.0). When not coding or advocating accessibility, you'll usually find Todd tweeting about (or eating) lobster rolls and accessibility.</p><ul><li><p><a href=\"https://toddl.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">toddl.dev</a></p></li><li><p><a href=\"https://twitter.com/toddlibby\" rel=\"noopener noreferrer\" target=\"_blank\">@toddlibby</a> on Twitter</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0402-todd.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Jennifer Konikowski - Hot Takes on Being a Woman in Tech",
-    "slug": "0403-jennifer-konikowski",
-    "id": "524",
-    "metaDescription": "Season Four, Episode Three of the Virtual Coffee Podcast",
-    "season": 4,
-    "episode": 3,
-    "buzzsproutId": "9396120",
-    "publishDate": "2021-10-19T04:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Jennifer Konikowski about building community for women in tech and her own experience as a woman in tech. She gives us some of her hot takes, and we are here for it 🔥</p>",
-    "showNotes": "<p>This week we welcome Jennifer Konikowski to the show to talk about being a woman in tech and building community for women in tech!</p><p class=\"text-left\">Jennifer brings her experience creating communities like <a href=\"http://www.meetup.com/pyladies-boston/\" rel=\"noopener noreferrer\" target=\"_blank\">Py Ladies Boston</a> and <a href=\"https://www.meetup.com/Boston-Ruby-Women/\" rel=\"noopener noreferrer\" target=\"_blank\">Boston Ruby Women</a> to the podcast, and talks about the value of learning to code even if you don't want to be a developer. She also talks about getting through toxic work environments, moving forward, and her hot takes on community and being a woman in tech.</p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0403-jennifer-episode.jpg",
-    "guests": [
-      {
-        "name": "Jennifer Konikowski",
-        "bio": "<p>Jennifer has 10 years of experience as a software engineer, working in Ruby and Rails, Go, Swift, Scala, Rust, PHP, Javascript, Java, Perl, and Python. She was the founder and organizer of PyLadies Boston and a founding member of Boston Ruby Women. She currently resides in Pittsburgh and works remotely at Splice. She also really loves Negronis.</p><ul><li><p><a href=\"https://jenniferkonikowski.com/\" rel=\"noopener noreferrer\" target=\"_blank\">jenniferkonikowski.com</a></p></li><li><p><a href=\"https://twitter.com/jenkoni\" rel=\"noopener noreferrer\" target=\"_blank\">@jenkoni</a> on Twitter</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0403-jennifer.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Mark Noonan - Civic tech, accessibility, holding the door open for other career changers",
-    "slug": "0404-mark-noonan",
-    "id": "531",
-    "metaDescription": "Season Four, Episode Four of the Virtual Coffee Podcast",
-    "season": 4,
-    "episode": 4,
-    "buzzsproutId": "9442638",
-    "publishDate": "2021-10-27T04:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Mark Noonan about how we can make space for career changers through Civic Tech while we make an impact on our communities.</p>",
-    "showNotes": "<p>This week we welcome Mark Noonan to the show to talk about how becoming a part of Civic Tech initiatives can help career changers to grow and help existing developers create opportunities for mentorship, support, and connection for those coming into tech.</p><p class=\"text-left\">Mark talks about his experience with <a href=\"https://www.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">FreeCodeCamp</a> as well as <a href=\"https://www.codeforatlanta.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Code for Atlanta</a>, and the $40,000 Hackathon his group won and donated to charity! He brings his experience as a career transitioner to the conversation and we look at how participating in Civic Tech can help you develop skills to be a better communicator and programmer. And you might hear a little bit about how we prefer our breakfast foods too 🥞</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://www.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">FreeCodeCamp</a></p></li><li><p><a href=\"https://www.codeforatlanta.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Code for Atlanta</a></p></li><li><p><a href=\"https://www.codeforamerica.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Code for America</a></p></li><li><p><a href=\"https://medium.com/paratransit-pal/paratransit-pal-won-40-000-at-at-ts-atlanta-civic-coding-challenge-and-gave-it-all-to-charity-30bba157d92d\" rel=\"noopener noreferrer\" target=\"_blank\">Marta Hackathon</a></p></li><li><p><a href=\"https://brigade.codeforamerica.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Code for America Brigades</a></p></li><li><p><a href=\"http://peoplemakingprogress.org/\" rel=\"noopener noreferrer\" target=\"_blank\">People Making Progress</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0404-mark-episode.jpg",
-    "guests": [
-      {
-        "name": "Mark Noonan",
-        "bio": "<p>Mark is a senior engineer at Cypress.io and is a co-organizer at Code for Atlanta. He also works as a program developer for People Making Progress, an Atlanta-based nonprofit serving adults with developmental disabilities at home, work, and in the community.</p><ul><li><p><a href=\"https://twitter.com/marktnoonan\" rel=\"noopener noreferrer\" target=\"_blank\">@marktnoonan</a> on Twitter</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0404-mark.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Suze Shardlow - Creating welcoming spaces in dev communities",
-    "slug": "0405-suze-shardlow",
-    "id": "540",
-    "metaDescription": "Season Four, Episode Five of the Virtual Coffee Podcast",
-    "season": 4,
-    "episode": 5,
-    "buzzsproutId": "9487228",
-    "publishDate": "2021-11-03T04:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Suze Shardlow about how she approaches creating welcoming spaces in dev communities.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Suze Shardlow. Suze is an award winning community manager, coder, tech writer and tech event MC and she currently leads the developer community at <a href=\"https://redis.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Redis</a>. We had a really interesting conversation with Suze! She's done a million different things throughout her life and her career and she shared with us how her experiences have informed her time as a software developer and a community leader.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://www.goodreads.com/book/show/56638386-30-second-coding?from_search=true&amp;from_srp=true&amp;qid=kCeXU2k1Tx&amp;rank=1\" rel=\"noopener noreferrer\" target=\"_blank\">30-second-coding</a></p></li><li><p><a href=\"https://twitter.com/SuzeShardlow/status/1445413709891973121?s=20\" rel=\"noopener noreferrer\" target=\"_blank\">On being a published author</a></p></li><li><p><a href=\"https://www.twitch.tv/redislabs\" rel=\"noopener noreferrer\" target=\"_blank\">redislabs on Twitch</a></p></li><li><p><a href=\"https://suze.dev/blog/im-a-techwomen100-2020-winner/\" rel=\"noopener noreferrer\" target=\"_blank\">One of the top 100 women in tech in 2020</a></p></li><li><p><a href=\"https://university.redis.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Redis University</a></p></li><li><p><a href=\"https://hacktoberfest.digitalocean.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Hacktoberfest</a></p></li><li><p><a href=\"https://codelandconf.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Codeland</a></p></li><li><p><a href=\"https://t.co/G0RN3vx2Gd?amp=1\" rel=\"noopener noreferrer\" target=\"_blank\">global diversity CFP day</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0405-suze-episode.jpg",
-    "guests": [
-      {
-        "name": "Suze Shardlow",
-        "bio": "<p>Suze Shardlow is a published tech author, developer community manager and event MC. Before retraining as a software engineer, she worked in marketing and management for 20 years in the engineering, technology, law enforcement, education and economic development sectors. Currently the head of developer community at Redis, Suze has won numerous awards including Rising Star In Tech 2021, TechWomen100 2020, Women In Software Power List 2020 and is a finalist in the Women In Tech Excellence Awards 2021.</p><ul><li><p><a href=\"https://suze.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">suze.dev</a></p></li><li><p><a href=\"https://twitter.com/SuzeShardlow\" rel=\"noopener noreferrer\" target=\"_blank\">@SuzeShardlow</a> on Twitter</p></li><li><p><a href=\"https://github.com/SuzeShardlow\" rel=\"noopener noreferrer\" target=\"_blank\">@SuzeShardlow</a> on GitHub</p></li><li><p><a href=\"https://www.linkedin.com/in/SuzeShardlow\" rel=\"noopener noreferrer\" target=\"_blank\">SuzeShardlow</a> on LinkedIn</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0405-suze.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Bryan Healey - The Entrepreneurial Journey of a Startup Founder",
-    "slug": "0406-bryan-healey",
-    "id": "547",
-    "metaDescription": "Season Four, Episode Six of the Virtual Coffee Podcast",
-    "season": 4,
-    "episode": 6,
-    "buzzsproutId": "9522643",
-    "publishDate": "2021-11-10T05:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Bryan Healey about how to kickoff your career as a start-up founder and the lessons he's learned along the way.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Bryan Healey, an entrepreneur, tech leader, data scientist / ML engineer, and biz developer. Bryan talks about gaining experience as an entrepreneur, how to get started in the start-up life, and how the entrepreneurial spirit has always been in his blood.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a></p></li><li><p><a href=\"https://virtualcoffee.io/podcast/0401-jessi-shakarian/\" rel=\"noopener noreferrer\" target=\"_blank\">Jessi's VC Podcast episode</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0406-bryan-episode.jpg",
-    "guests": [
-      {
-        "name": "Bryan Healey",
-        "bio": "<p>Bryan Healey is an entrepreneur, tech leader, data scientist / ML engineer, and biz developer. He's helped create or grow several start-ups, raised money, and built/managed teams of varying sizes, small to large. Currently co-founder and CTO at <a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a>.</p><ul><li><p><a href=\"https://twitter.com/Bryan_Healey\" rel=\"noopener noreferrer\" target=\"_blank\">@Bryan_Healey</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/bryanhealey\" rel=\"noopener noreferrer\" target=\"_blank\">bryanhealey</a> on LinkedIn</p></li><li><p><a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0406-bryan.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Jessica Wilkins - Growing your tech career through writing",
-    "slug": "0407-jessica-wilkins",
-    "id": "554",
-    "metaDescription": "Season Four, Episode Seven of the Virtual Coffee Podcast",
-    "season": 4,
-    "episode": 7,
-    "buzzsproutId": "9566513",
-    "publishDate": "2021-11-17T05:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Jessica Wilkins about how writing can help you to grow your tech career. She gives us tips on getting started and on taking feedback.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Jessica Wilkins, a self-taught developer and a staff author for the freeCodeCamp News publication. Jessica talks about how to get started with tech writing, how to differentiate between constructive criticism and negative feedback, and how to avoid gatekeeping by eliminating assumptions from your writing, avoiding terms and phrases like \"it's so easy!\", and sometimes adding prerequisites to your posts.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://www.esm.rochester.edu/\" rel=\"noopener noreferrer\" target=\"_blank\">Eastman School of Music</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=hD6uRvCtA_0&amp;t=70s\" rel=\"noopener noreferrer\" target=\"_blank\">Jessica's Lunch & Learn: How to grow your tech career through writing</a></p></li><li><p><a href=\"https://www.freecodecamp.org/news/author/jessica-wilkins/\" rel=\"noopener noreferrer\" target=\"_blank\">Freecodecamp news</a></p></li><li><p><a href=\"https://forum.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Freecodecamp forum</a></p></li><li><p><a href=\"https://www.freecodecamp.org/news/author/quincylarson/\" rel=\"noopener noreferrer\" target=\"_blank\">Quincy Larson</a></p></li><li><p><a href=\"https://www.history.com/this-day-in-history/george-floyd-killed-by-police-officer\" rel=\"noopener noreferrer\" target=\"_blank\">George Floyd murder</a></p></li><li><p><a href=\"https://blackexcellencemusicproject.com/\" rel=\"noopener noreferrer\" target=\"_blank\">The Black Excellence Music Project</a></p></li><li><p><a href=\"https://github.com/jdwilkin4/Black_Excellence_Project\" rel=\"noopener noreferrer\" target=\"_blank\">Github for it</a></p></li><li><p><a href=\"https://virtualcoffee.io/monthlychallenges/nov-2021/\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee November Monthly Challenge</a></p></li><li><p><a href=\"https://www.gatsbyjs.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Gatsby</a></p></li><li><p><a href=\"https://www.gatsbyjs.com/blog/gatsby-voices-jessica-wilkins/\" rel=\"noopener noreferrer\" target=\"_blank\">Voices of Gatsby: Fighting Back Against Imposter Syndrome</a></p></li><li><p><a href=\"https://www.freecodecamp.org/news/how-to-use-replit/\" rel=\"noopener noreferrer\" target=\"_blank\">How to Use Repl.it: a beginner's guide</a></p></li><li><p><a href=\"https://www.freecodecamp.org/news/how-to-use-codepen/\" rel=\"noopener noreferrer\" target=\"_blank\">How to Use Codepen: a beginner's guide</a></p></li><li><p><a href=\"https://dev.to/codergirl1991/how-to-create-a-node-bot-that-sends-happy-emails-throughout-the-year-25nj\" rel=\"noopener noreferrer\" target=\"_blank\">NodeMailer</a></p></li></ul><p><br></p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0407-jessica-episode.jpg",
-    "guests": [
-      {
-        "name": "Jessica Wilkins",
-        "bio": "<p>Jessica Wilkins is a self taught developer and technical writer from Los Angeles, California.</p><p class=\"text-left\">In her previous career, she was a professional oboist, educator and owner of JDW Sheet Music.</p><p class=\"text-left\">Jessica's interest in programming came during the pandemic when she wanted to build the Black Excellence Music Project which celebrates black artists from the jazz and classical fields.</p><p class=\"text-left\">She now works part-time as a junior developer for a small tech company and is a staff author for the freeCodeCamp News publication.</p><ul><li><p><a href=\"https://dev.to/codergirl1991\" rel=\"noopener noreferrer\" target=\"_blank\">Dev.to profile</a></p></li><li><p><a href=\"https://twitter.com/codergirl1991\" rel=\"noopener noreferrer\" target=\"_blank\">@codergirl1991 on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/jessica-wilkins-developer\" rel=\"noopener noreferrer\" target=\"_blank\">@jessica-wilkins-developer on LinkedIn</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0407-jessica.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Maeling Murphy - Transitioning to tech, and taking notes along the way",
-    "slug": "0408-maeling-murphy",
-    "id": "561",
-    "metaDescription": "Season Four, Episode Eight of the Virtual Coffee Podcast",
-    "season": 4,
-    "episode": 8,
-    "buzzsproutId": "9600325",
-    "publishDate": "2021-11-23T05:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Maeling Murphy about her journey from Material Science and Engineering to Software Engineering, including her personal documentation of her tech journey, work culture, and the big surprises when starting her job.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Dr. Maeling Murphy, a software engineer who recently transitioned into tech. Maeling shared the importance of connecting with potential employers to see if they would fit her values, how contributing to open source projects can help prepare you for your first job, and the value of developing the connection to community and being able to grow alongside others. Oh, and did we mention we talked a lot about Notion? She takes us through her notetaking journey and answers all our questions about finding the right approach.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://cs50.harvard.edu/\" rel=\"noopener noreferrer\" target=\"_blank\">Harvard's CS50</a></p></li><li><p><a href=\"https://www.100daysofcode.com/\" rel=\"noopener noreferrer\" target=\"_blank\">100 days of code</a></p></li><li><p><a href=\"https://virtualcoffee.io/monthlychallenges/july-2021/\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee Demo Monthly Challenge</a></p></li><li><p><a href=\"https://homeschool-journal.herokuapp.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Homeschool journal</a></p></li><li><p><a href=\"https://github.com/maelingmurphy\" rel=\"noopener noreferrer\" target=\"_blank\">Github</a></p></li><li><p><a href=\"https://github.com/maelingmurphy/My-Learning-Path/blob/main/log.md\" rel=\"noopener noreferrer\" target=\"_blank\">Learning Path log</a></p></li><li><p><a href=\"https://www.notion.so/templates/job-applications\" rel=\"noopener noreferrer\" target=\"_blank\">Karen's Notion for job searches</a></p></li><li><p><a href=\"https://docs.google.com/spreadsheets/d/1ZP0u5MjRiCOaYWuLoRTYr4BvB91M76ZCjkCYPuSePJc/edit?usp=sharing\" rel=\"noopener noreferrer\" target=\"_blank\">Karen's Job Application Details Spreadsheet</a></p></li><li><p><a href=\"https://www.notion.so/Thomas-Frank-s-Note-Taking-System-67924a5a25934f0fbe2f154cffcd8f97\" rel=\"noopener noreferrer\" target=\"_blank\">Frank's Notetaking System</a></p></li><li><p><a href=\"https://www.keyvalues.com/\" rel=\"noopener noreferrer\" target=\"_blank\">KeyValues: Find engineering teams that share your values</a></p></li><li><p><a href=\"https://pinboard.in/u:danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">Dan's Pinboard bookmarks</a></p></li><li><p><a href=\"https://github.com/forem/forem\" rel=\"noopener noreferrer\" target=\"_blank\">Forem</a> - Open source project that Nick Taylor helps maintain</p></li></ul><p><br></p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0408-maeling-episode.jpg",
-    "guests": [
-      {
-        "name": "Maeling Murphy",
-        "bio": "<p>Dr. Maeling Murphy is a software engineer who recently transitioned into tech, coming from an 8+ year entrepreneurial journey as a digital content creator and as a Ph.D. research scientist in Materials Science & Engineering.</p><p class=\"text-left\">Maeling identifies as a multi-passionate creative soul, finding expression through gardening, programming, brush-lettering and other mediums that cross her path.</p><p class=\"text-left\">She lets her love for exploration, learning and sharing with others lead her in all aspects of life and is enjoying this journey with her husband and son.</p><ul><li><p><a href=\"https://github.com/maelingmurphy\" rel=\"noopener noreferrer\" target=\"_blank\">maelingmurphy</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/maelingcodes\" rel=\"noopener noreferrer\" target=\"_blank\">@maelingcodes on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/maeling-murphy\" rel=\"noopener noreferrer\" target=\"_blank\">@maeling-murphy on LinkedIn</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0408-maeling.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Season 4 Wrap Up - Reviewing the year and celebrating our community",
-    "slug": "0409-season-four-wrapup",
-    "id": "568",
-    "metaDescription": "Season 4 Wrap Up - Reviewing the year and celebrating our community",
-    "season": 4,
-    "episode": 9,
-    "buzzsproutId": "9650635",
-    "publishDate": "2021-12-02T05:00:00+00:00",
-    "shortDescription": "<p>In this final episode of season 4 of the podcast, Bekah and Dan bring back special guest and community maintainer, Kirk Shillingford to retro our Virtual Coffee Hacktoberfest Initiative, talk about our monthly challenges and our excitement of going into year 2 of the challenges, and we even throw in some amazing and/or awful jokes at the end.</p>",
-    "showNotes": "<p>Kirk, Dan, and Bekah are back again to wrap up Season 4 of the podcast. We talk about Hacktoberfest and how proud we are of what our community did over the month of Hacktoberfest:</p><ul><li><p>100 members signed up,</p></li><li><p>66 members merged at least 1 pr,</p></li><li><p>336 collectively we merged 336 PRs were merged by these members across 129 repos.</p></li></ul><p class=\"text-left\">On the <a href=\"https://virtualcoffee.io/\" rel=\"noopener noreferrer\" target=\"_blank\">virtualcoffee.io</a> site: 81 PRs merged, 50 were new member profiles, 31 others.</p><p class=\"text-left\">We talk about the monthly challenges, including already surpassing the monthly goal for blogging half way through <a href=\"https://virtualcoffee.io/monthlychallenges/nov-2021/\" rel=\"noopener noreferrer\" target=\"_blank\">November</a>, and what we're looking forward to doing in the next 12 months.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://hacktoberfest.digitalocean.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Digital Ocean Hacktoberfest</a></p></li><li><p><a href=\"https://virtualcoffee.io/podcast/0406-bryan-healey/\" rel=\"noopener noreferrer\" target=\"_blank\">Bryan's Episode</a></p></li><li><p><a href=\"https://github.com/colabottles/\" rel=\"noopener noreferrer\" target=\"_blank\">Todd Libby</a></p></li><li><p><a href=\"https://github.com/abbeyperini\" rel=\"noopener noreferrer\" target=\"_blank\">Abbey Perini</a></p></li><li><p><a href=\"https://github.com/MattyMc\" rel=\"noopener noreferrer\" target=\"_blank\">Matt McInnis</a></p></li><li><p><a href=\"https://prettier.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Prettier</a></p></li><li><p><a href=\"https://virtualcoffee.io/podcast/0407-jessica-wilkins/\" rel=\"noopener noreferrer\" target=\"_blank\">Jessica's Episode</a></p></li><li><p><a href=\"https://chrisbrogan.com/stories/community/audience-or-community/\" rel=\"noopener noreferrer\" target=\"_blank\">Audience or Community by Chris Brogan</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-episode.jpg",
-    "guests": [
-      {
-        "name": "Kirk Shillingford",
-        "bio": "<p>Software Developer, and Community Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://github.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-kirk.jpg"
-      },
-      {
-        "name": "Bekah Hawrot Weigel",
-        "bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dev.to/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/bekahhw</a></p></li><li><p><a href=\"https://twitter.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">@bekahhw</a> on Twitter</p></li><li><p><a href=\"https://www.instagram.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">bekahhw</a> on Instagram</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0209-bekah.jpg"
-      },
-      {
-        "name": "Dan Ott",
-        "bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dtott.com/\" rel=\"noopener noreferrer\" target=\"_blank\">dtott.com</a></p></li><li><p><a href=\"https://twitter.com/danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">@danieltott</a> on Twitter</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-dan.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Brian Rinaldi - Developer Advocacy and Fostering Community",
-    "slug": "0501-brian-rinaldi",
-    "id": "180",
-    "metaDescription": "Season Five, Episode One of the Virtual Coffee Podcast",
-    "season": 5,
-    "episode": 1,
-    "buzzsproutId": "10297519",
-    "publishDate": "2022-03-22T04:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Brian Rinaldi about doing DevRel (Developer Relations) right and playing to your team's strengths. We also talk about the importance of connection and why we as developers need to support each other.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Brian Rinaldi, a Developer Experience Engineer at LaunchDarkly with over 20 years of experience as a developer for the web, about how Developer Relationships has changed over the years and why need not just remote community experiences but also in-person opportunities. We talk about the value of different types of communities and how each is necessary to support developers.</p><h3>Links</h3><ul><li><p><a href=\"https://launchdarkly.com/\" rel=\"noopener noreferrer\" target=\"_blank\">LaunchDarkly</a></p></li><li><p><a href=\"https://CFE.dev\" rel=\"noopener noreferrer\" target=\"_blank\">CFE.dev</a></p></li><li><p><a href=\"https://thejam.dev\" rel=\"noopener noreferrer\" target=\"_blank\">TheJam.dev</a></p></li><li><p><a href=\"https://www.manning.com/books/the-jamstack-book\" rel=\"noopener noreferrer\" target=\"_blank\">The Jamstack Book</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0501-brian-episode.jpg",
-    "guests": [
-      {
-        "name": "Brian Rinaldi",
-        "bio": "<p>Brian Rinaldi is a Developer Experience Engineer at LaunchDarkly with over 20 years experience as a developer for the web. Brian is actively involved in the community running developer meetups via CFE.dev and Orlando Devs. He's the editor of the Jamstacked newsletter and co-author of The Jamstack Book from Manning.</p><ul><li><p><a href=\"http://remotesynthesis.com\" rel=\"noopener noreferrer\" target=\"_blank\">remotesynthesis.com</a></p></li><li><p><a href=\"https://github.com/remotesynth\" rel=\"noopener noreferrer\" target=\"_blank\">remotesynth</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/remotesynth\" rel=\"noopener noreferrer\" target=\"_blank\">@remotesynth on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/brianrinaldi\" rel=\"noopener noreferrer\" target=\"_blank\">@brianrinaldi on LinkedIn</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0501-brian.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Amy Shackles - Finding a job you love",
-    "slug": "amy-shackles-finding-a-job-you-love",
-    "id": "767",
-    "metaDescription": "Season Five, Episode Two of the Virtual Coffee Podcast",
-    "season": 5,
-    "episode": 2,
-    "buzzsproutId": "10353204",
-    "publishDate": "2022-03-31T04:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Amy Shackles about the importance of good communication in finding a job you love and defining your career path.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Amy Shackles, a Senior Software Engineer at MURAL, about how she made her way from being a Psychology and Anthropology double major to being a Senior Software Engineer. She shares what’s made her experience at MURAL a great one and the importance of openness in communication.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://amyshackles.com/\" rel=\"noopener noreferrer\" target=\"_blank\">amyshackles.com</a></p></li><li><p><a href=\"https://github.com/AmyShackles/regex_parser\" rel=\"noopener noreferrer\" target=\"_blank\">Amy's regular expression parser</a></p></li><li><p><a href=\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions\" rel=\"noopener noreferrer\" target=\"_blank\">MDN article on regular expressions</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0502-amy-episode.jpg",
-    "guests": [
-      {
-        "name": "Amy Shackles",
-        "bio": "<p>Amy is a Senior Software Engineer currently working at <a href=\"https://mural.co/\" rel=\"noopener noreferrer\" target=\"_blank\">MURAL</a>. She loves information, human interaction, solving problems, helping people, and cats - not in that order. She spends most of her free time lately learning Spanish, practicing calligraphy, singing, writing parody songs, and crocheting.</p><ul><li><p><a href=\"https://amyshackles.com/\" rel=\"noopener noreferrer\" target=\"_blank\">amyshackles.com</a></p></li><li><p><a href=\"https://github.com/AmyShackles\" rel=\"noopener noreferrer\" target=\"_blank\">AmyShackles</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/AmyShackles\" rel=\"noopener noreferrer\" target=\"_blank\">@AmyShackles on Twitter</a></p></li><li><p><a href=\"https://dev.to/amyshackles\" rel=\"noopener noreferrer\" target=\"_blank\">@AmyShackles on DEV.to</a></p></li><li><p><a href=\"https://www.linkedin.com/in/AmyShackles\" rel=\"noopener noreferrer\" target=\"_blank\">@AmyShackles on LinkedIn</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0502-amy.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Helen Griffin - Multi-passionate in tech",
-    "slug": "helen-griffin-multi-passionate-in-tech",
-    "id": "781",
-    "metaDescription": "Season Five, Episode Three of the Virtual Coffee Podcast",
-    "season": 5,
-    "episode": 3,
-    "buzzsproutId": "10397152",
-    "publishDate": "2022-04-07T04:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Helen Griffin about what she’s learned from her journey going from tech to founder and back to tech again.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Helen Griffin, a full-stack developer and founder, about how the tech industry changed during the time she was a founder, how what she’s learned as a founder has helped her to have a broader perspective about the tech industry, and what she’s doing with her companies Jovial and State of Developers to support developers in their career journeys.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://stateofdevs.com/\" rel=\"noopener noreferrer\" target=\"_blank\">The State of Developers</a></p></li><li><p><a href=\"https://jovial.work/\" rel=\"noopener noreferrer\" target=\"_blank\">Jovial</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0503-helen-episode.jpg",
-    "guests": [
-      {
-        "name": "Helen Griffin",
-        "bio": "<p>Helen started her career as a web developer. Now, as a full-stack dev & founder, she enjoys helping developers build products & a life they love. Today, she spends her time building developer tools, like State of Developers & Jovial. Helen is on a campaign to help her peers recover from burnout.</p><ul><li><p><a href=\"https://helenjr.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">HelenJr.dev</a></p></li><li><p><a href=\"https://github.com/helengriffinjr\" rel=\"noopener noreferrer\" target=\"_blank\">helengriffinjr</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/helengriffinjr\" rel=\"noopener noreferrer\" target=\"_blank\">@helengriffinjr</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/hgriffinjr\" rel=\"noopener noreferrer\" target=\"_blank\">@hgriffinjr</a> on LinkedIn</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0503-helen.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Yolanda Haynes - Breaking into Tech: It Takes Time",
-    "slug": "yolanda-haynes-breaking-into-tech-it-takes-time",
-    "id": "790",
-    "metaDescription": "Season Five, Episode Four of the Virtual Coffee Podcast",
-    "season": 5,
-    "episode": 4,
-    "buzzsproutId": "10431216",
-    "publishDate": "2022-04-13T04:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Yolanda Haynes about her journey into tech and how she created her own path and experiences, including joining Virtual Coffee, 100devs, and Collab Lab.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Yolanda Haynes, a career changer who went from working as a certified occupational therapy assistant to a Software Engineer, about the importance of finding community during your learning journey, and remembering that you shouldn’t judge your journey based on anyone else’s; focus on the learning journey, absorbing what you can, and preparing yourself for your future.</p><h3>Links:</h3><ul><li><p><a href=\"https://leonnoel.com/100devs/\" rel=\"noopener noreferrer\" target=\"_blank\">100devs</a></p></li><li><p><a href=\"https://the-collab-lab.codes/\" rel=\"noopener noreferrer\" target=\"_blank\">The Collab Lab</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0504-yolanda.jpg",
-    "guests": [
-      {
-        "name": "Yolanda Haynes",
-        "bio": "<p>A career changer from working in healthcare as a COTA (certified occupational therapy assistant) to a Software Engineer.</p><ul><li><p><a href=\"https://www.yhaynes.com/\" rel=\"noopener noreferrer\" target=\"_blank\">yhaynes.com</a></p></li><li><p><a href=\"https://github.com/YolandaHaynes\" rel=\"noopener noreferrer\" target=\"_blank\">@YolandaHaynes on GitHub</a></p></li><li><p><a href=\"https://twitter.com/_YolandaHaynes\" rel=\"noopener noreferrer\" target=\"_blank\">@_YolandaHaynes on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/yolanda-haynes/\" rel=\"noopener noreferrer\" target=\"_blank\">@yolanda-haynes on LinkedIn</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Profile.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Roger Gentry - Perseverance and  Problem Solving",
-    "slug": "roger-gentry-perseverance-and-problem-solving",
-    "id": "814",
-    "metaDescription": "Season 5, Episode 5 of the Virtual Coffee Podcast",
-    "season": 5,
-    "episode": 5,
-    "buzzsproutId": "10480828",
-    "publishDate": "2022-04-21T04:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Roger Gentry about his love of solving problems and how he's brought that with him into tech.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Roger Gentry, who has spent a lot of his career managing security and compliance for clients across the United States, about his passion for problem-solving and what to do when you get stuck. We're all going to run into frustrations during our tech journeys, but knowing how to navigate through them is one of the key skills you'll need.</p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0505-roger-episode.jpg",
-    "guests": [
-      {
-        "name": "Roger Gentry",
-        "bio": "<p>Roger has managed the security and compliance for clients across the United States. Providing CTO/CSO level consulting to a variety of industries, Roger has worked with customers to achieve successful compliance certifications from PCI, ISO, SOC, and more.</p><p><a href=\"http://r-o-g-e-r.com/\" rel=\"noopener noreferrer\" target=\"_blank\">http://r-o-g-e-r.com/</a></p>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0505-roger.jpeg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Special Kirk Day Bonus Episode (Live)",
-    "slug": "special-kirk-day-bonus-episode",
-    "id": "825",
-    "metaDescription": "Happy Kirk Day!",
-    "season": 5,
-    "episode": 999,
-    "buzzsproutId": "10509803",
-    "publishDate": "2022-04-26T04:00:00+00:00",
-    "shortDescription": "<p>A special live episode of the Virtual Coffee Podcast - Bekah and Dan meet for the first time in real life, and get to hang out with Kirk on Kirk Day!</p>",
-    "showNotes": "<p>A special live episode of the Virtual Coffee Podcast - Bekah and Dan meet for the first time in real life, and get to hang out with Kirk on Kirk Day! Also Dan fires Bekah (for the first time).</p><p><a href=\"https://youtu.be/uh-oA8czBVo\">Watch the stream on YouTube!</a></p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/05-bonus-kirk-day.jpg",
-    "guests": [],
-    "sponsors": []
-  },
-  {
-    "title": "Andrew Bush - Mobile Development and Giving Back to Community",
-    "slug": "andrew-bush-mobile-development-and-giving-back-to-community",
-    "id": "828",
-    "metaDescription": "Season 5, Episode 6 of the Virtual Coffee Podcast",
-    "season": 5,
-    "episode": 6,
-    "buzzsproutId": "10565670",
-    "publishDate": "2022-05-05T04:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Andrew Bush about his experiences with mobile development, and his thoughts on community and what it means to give back.</p>",
-    "showNotes": "<p>In today's episode, Dan and Bekah talk to Andrew Bush, a Mobile Engineer Specializing in React Native. One of the updates we've made to our site is to have tags on our <a href=\"https://virtualcoffee.io/members\">members page</a> to indicate what volunteer roles they have. Andrew is one of our Monthly Challenge team leads, and he shared with us his experiences helping to facilitate the challenges, keeping our community motivated, and the processes we go through. We also go into what it's like to be a mobile developer, and the learning path he's been on throughout his career.</p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0506-andrew-episode.jpg",
-    "guests": [
-      {
-        "name": "Andrew Bush",
-        "bio": "<p>Andrew is a mobile developer specializing in React Native based out of Wisconsin in the US. He has been developing professionally for 3 years and has really found his passion in mobile apps and accessibility. Being legally blind himself, he recognizes the need for inclusion in software development so that EVERYONE can use the applications we create.</p><p>Outside of his professional life, Andrew is a dedicated amateur runner with a love for the sport that rivals his love of Swedish Fish candy. You can also find him participating as a co-lead of the Virtual Coffee monthly challenges where he strives to create engagement and growth combined with the feeling of an intimate community.</p>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0506-andrew.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Meg Gutshall - Building accountability into Community",
-    "slug": "meg-gutshall-building-accountability-into-community",
-    "id": "840",
-    "metaDescription": "Season 5, Episode 7 of the Virtual Coffee Podcast",
-    "season": 5,
-    "episode": 7,
-    "buzzsproutId": "10613498",
-    "publishDate": "2022-05-13T04:00:00+00:00",
-    "shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk with Meg Gutshall about accountability and how to bring that to your community. She shares some of her memorable experiences with community and she does it all with Philly flair.</p>",
-    "showNotes": "<p>In today's episode, Bekah and Dan talk to Meg Gutshall, a Ruby on Rails Developer, and community volunteer at Virtual Coffee. She shared all things Philly and some memorable stories of how she's supported others--including Bekah--in their journeys into tech. Meg talks about her Accountabilibuddies group at Virtual Coffee and how she chose Ruby after graduating from a full stack bootcamp.</p><p></p><img src=\"http://storage.googleapis.com/virtualcoffeeio-assets/images/_podcastShowNotesImage/gritty.jpg\" alt=\"Gritty, the Fliers Mascot\" title=\"Gritty, the Fliers Mascot\"><p></p><h3>Links</h3><ul><li><p><a href=\"https://en.wikipedia.org/wiki/Gritty\" rel=\"noopener noreferrer\" target=\"_blank\">Gritty</a></p></li><li><p><a href=\"https://freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">freeCodeCamp</a></p></li><li><p><a href=\"https://www.pennmedicine.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Penn medicine</a></p></li><li><p><a href=\"https://www.urbandictionary.com/define.php?term=Jawn\" rel=\"noopener noreferrer\" target=\"_blank\">jawn</a></p></li><li><p>Meg's blog post on code and Spanish: <a href=\"https://meghangutshall.com/2018/07/21/the_little_things_matter/\" rel=\"noopener noreferrer\" target=\"_blank\">The Little Things Matter</a></p></li><li><p><a href=\"https://rubyforgood.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Ruby for Good</a></p></li><li><p><a href=\"https://humanessentials.app/\" rel=\"noopener noreferrer\" target=\"_blank\">HumanEssentials.app</a></p></li><li><p><a href=\"https://nationalcasagal.org/\" rel=\"noopener noreferrer\" target=\"_blank\">CASA</a></p></li><li><p><a href=\"https://2022.phillytechweek.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Philly Tech Week</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0507-meg-episode.jpg",
-    "guests": [
-      {
-        "name": "Meg Gutshall",
-        "bio": "<p>Meg is a Ruby on Rails developer with a passion for open source and tech for good. She's always smiling, continuously learning, and quick to strike up a conversation. She takes her advice with a grain of salt & a shot of tequila.</p>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0507-meg.png"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Matt McInnis - Go Make Stuff!",
-    "slug": "matt-mcinnis-go-make-stuff",
-    "id": "860",
-    "metaDescription": "Season 5, Episode 8 of the Virtual Coffee Podcast",
-    "season": 5,
-    "episode": 8,
-    "buzzsproutId": "10680520",
-    "publishDate": "2022-05-25T04:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Matt McInnis about his incredible journey through tech from math professor, to self-taught data-scientist working with IBM and Microsoft, to founder.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Matt McInnis a former Math Professor, and current data scientist, full-stack engineer, and founder, about his journey through tech as a self-taught engineer. He shares his insight into building personal projects and creating value in the projects you work on, even if those projects are just for you.</p><h3>Links</h3><ul><li><p><a href=\"https://typistapp.ca/\">Typist</a></p></li><li><p><a href=\"https://www.littlebrown.com/titles/malcolm-gladwell/the-tipping-point/9780759574731/\">Malcolm Gladwell's Tipping Point</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Kidstreet\" rel=\"noopener noreferrer\" target=\"_blank\">Kidstreet</a></p></li><li><p><a href=\"https://www.hackerparadise.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Hacker Paradise</a></p></li><li><p><a href=\"https://ologicinc.com/portfolio/star-wars-science-force-trainer/\" rel=\"noopener noreferrer\" target=\"_blank\">Star Wars Force Trainer</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0508-matt-episode.jpg",
-    "guests": [
-      {
-        "name": "Matt McInnis",
-        "bio": "<p>Matt is a full-stack developer (Rails+React) at <a href=\"https://typistapp.ca/\">Typist</a> based in Toronto, Canada. Former artificial intelligence lead at IBM and Microsoft, mathematics professor at Centennial College and Saskatchewan Polytechnic. Matt really loves brunch.</p><ul><li><p><a href=\"https://github.com/MattyMc\">MattyMc on GitHub</a></p></li><li><p><a href=\"https://twitter.com/MattLovesMath\">MattLovesMath on Twitter</a></p></li><li><p><a href=\"http://linkedin.com/in/mattmcinnis\">mattmcinnis on LinkedIn</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0508-matt.jpeg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Season 5 Wrap-Up: Working to Empower the Virtual Coffee Community",
-    "slug": "season-5-wrap-up-working-to-empower-the-virtual-coffee-community",
-    "id": "876",
-    "metaDescription": "Season 5 Finale of the Virtual Coffee Podcast",
-    "season": 5,
-    "episode": 9,
-    "buzzsproutId": "10720878",
-    "publishDate": "2022-06-01T04:00:00+00:00",
-    "shortDescription": "<p>In this season finale of the podcast, Dan, Kirk, and Bekah come together to talk about making hard decisions to ensure community support and stability. They also share how they're navigating technical and community challenges as the community grows.</p>",
-    "showNotes": "<p>In this episode of the podcast, Bekah, Kirk, and Dan discuss the decision to pause new membership and what the maintainers are doing to progress towards opening the community up again. We share what we think makes our community special, how we're working to preserve that, and some of the challenges we're figuring out as we take steps towards reopening membership. What goes into the long-term strategy of making Virtual Coffee <em>an intimate group of devs, optimized for you</em>? You'll find out in this episode.</p><h3>Links:</h3><ul><li><p><a href=\"https://gamesnostalgia.com/game/dx-ball\" rel=\"noopener noreferrer\" target=\"_blank\">DX Ball</a></p></li><li><p><a href=\"https://boardgamegeek.com/boardgame/3086/omega-virus\" rel=\"noopener noreferrer\" target=\"_blank\">Omega Virus</a></p></li><li><p><a href=\"https://www.ultraboardgames.com/othello/game-rules.php\" rel=\"noopener noreferrer\" target=\"_blank\">Othello</a></p></li><li><p><a href=\"http://virtualcoffee.io/members\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee Members</a></p></li><li><p><a href=\"https://virtualcoffee.io/resources/virtual-coffee/get-involved/paths-to-leadership\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee Paths to Leadership</a></p></li><li><p><a href=\"https://twitter.com/SuzeShardlow\" rel=\"noopener noreferrer\" target=\"_blank\">Suze Shardlow</a></p></li><li><p><a href=\"https://www.bbc.com/future/article/20191001-dunbars-number-why-we-can-only-maintain-150-relationships\" rel=\"noopener noreferrer\" target=\"_blank\">Dunbar's Number</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0509-finale-episode.jpg",
-    "guests": [
-      {
-        "name": "Kirk Shillingford",
-        "bio": "<p>Software Developer, and Community Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://github.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-kirk.jpg"
-      },
-      {
-        "name": "Bekah Hawrot Weigel",
-        "bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dev.to/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/bekahhw</a></p></li><li><p><a href=\"https://twitter.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">@bekahhw</a> on Twitter</p></li><li><p><a href=\"https://www.instagram.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">bekahhw</a> on Instagram</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/T014AAKN3KP-U014HT3RNCU-f7cccf369940-512.png"
-      },
-      {
-        "name": "Dan Ott",
-        "bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dtott.com/\" rel=\"noopener noreferrer\" target=\"_blank\">dtott.com</a></p></li><li><p><a href=\"https://twitter.com/danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">@danieltott</a> on Twitter</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-dan.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "David Alpert - On pairing and providing support",
-    "slug": "david-alpert-on-pairing-and-providing-support",
-    "id": "913",
-    "metaDescription": "Season 6, Episode 1 of the Virtual Coffee Podcast",
-    "season": 6,
-    "episode": 1,
-    "buzzsproutId": "10964411",
-    "publishDate": "2022-07-15T04:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to David Alpert about supporting others in their tech journey, asking the right questions, and leading with empathy.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with David Alpert, Director of Engineering at Northfield IT, about taking a personalized approach to helping others as they ask coding questions and navigate career paths. David shares the importance of bringing empathy to every situation and gives tips on how to handle challenging situations.</p><h3>Links:</h3><ul><li><p><a href=\"https://en.wikipedia.org/wiki/Logo_(programming_language)\">Logo (the programming turtle)</a></p></li><li><p><a href=\"https://dev.to/virtualcoffee/how-the-virtual-coffee-coworking-room-works-2a89\">Virtual Coffee Co-Working Room</a></p></li><li><p><a href=\"https://agilemanifesto.org/\">The Agile Manifesto</a></p></li><li><p><a href=\"https://www.twitch.tv/virtualcoffeeio\">Typescript Tuesdays</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0601-david-episode.jpg",
-    "guests": [
-      {
-        "name": "David Alpert",
-        "bio": "<p>David Alpert is a collaborative leader and agile coach striving to reduce friction between people and software. Based in Winnipeg, Manitoba, David has over 20 years of professional IT experience in software development, system design, and project and people management spanning the finance, manufacturing, and sports entertainment industries. David is passionate about test-driven development, refactoring, pair programming, and helping people become better developers.</p><ul><li><p>Website: <a href=\"https://blog.spinthemoose.com\">Spin the Moose</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/davidalpert\">@davidalpert</a></p></li><li><p>GitHub: <a href=\"https://github.com/davidalpert\">davidalpert</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0601-david.jpeg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Bogdan Covrig - Navigating Tech Career Paths",
-    "slug": "bogdan-covrig-navigating-tech-career-paths",
-    "id": "933",
-    "metaDescription": "Season Six, Episode Two of the Virtual Coffee Podcast",
-    "season": 6,
-    "episode": 2,
-    "buzzsproutId": "11044164",
-    "publishDate": "2022-07-28T04:00:00+00:00",
-    "shortDescription": "<p>In this episode, Dan and Bekah talk to Bogdan Covrig about finding the right career path within tech and searching for what gets you excited.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Bogdan Covrig, a Software Engineer in the Netherlands who's into Typescript, React and Node, about navigating different learning and career paths in tech before landing a job that fulfills his interests to see the changes he's making and provides a dynamic work environment. He also drops his tips on the most important things you can do if you're starting your journey into tech.</p><h3>Links</h3><ul><li><p><a href=\"https://p5js.org/\">p5.js</a></p></li><li><p><a href=\"https://www.arduino.cc/\">Arduino</a></p></li><li><p><a href=\"https://www.twitch.tv/virtualcoffeeio/schedule\">Twitch TypeScript Tuesdays</a></p></li><li><p>Nick and Bekah's Lunch & Learn <a href=\"https://youtu.be/DVqtr3iwkwQ\">Coding questions: Problem-solving and working through challenges</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0602-bogdan-episode.png",
-    "guests": [
-      {
-        "name": "Bogdan Covrig",
-        "bio": "<p>Bogdan is a Software Engineer in the Netherlands. He’s passionate about privacy, automation and infrastructure. He’s into Typescript, React and Node, currently building and working with CMS. He’s usually busy with movies, concerts or sitting in the park for no reason.</p><ul><li><p><a href=\"https://github.com/BogDAAAMN\">@BogDAAAMN</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/BogdanCovrig\">@BogdanCovrig</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/BogdanCovrig\">@BogdanCovrig</a> on LinkedIn</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0602-bogdan.jpeg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Seth Hall - From Film Production to Technical Product Owner: A Career Changer's Story",
-    "slug": "seth-hall-from-film-production-to-technical-product-owner-a-career-changers-story",
-    "id": "954",
-    "metaDescription": "Season 6, Episode 3 of the Virtual Coffee Podcast",
-    "season": 6,
-    "episode": 3,
-    "buzzsproutId": "11103329",
-    "publishDate": "2022-08-09T04:00:00+00:00",
-    "shortDescription": "<p>Bekah and Dan talk to Seth Hall, a Technical Product Owner at Uniform. He talks about the importance of fostering authentic company culture, as well as how his search to find a challenging, fun, and flexible job led him from Film Production, to Frontend Developer, to his current role.</p>",
-    "showNotes": "<p>In today's episode, Dan and Bekah talk with Seth Hall about the importance of intimate collaboration, advocating for yourself, and transferable skills as part of his job as a Technical Product Owner at <a href=\"https://uniform.dev/\">Uniform</a>. He shares how his background as a creative producer informs how he guides demo initiatives, creates roadmaps, and collaborates with other departments.</p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0603-seth-hall-episode.jpg",
-    "guests": [
-      {
-        "name": "Seth Hall",
-        "bio": "<p>Seth is a Technical Product Owner at <a href=\"https://uniform.dev/\">Uniform</a></p><ul><li><p>Website: <a href=\"https://sethhall.dev/\">sethhall.dev</a></p></li><li><p>Dev.to: <a href=\"https://dev.to/sethburtonhall\"><u>dev.to/sethburtonhall</u></a></p></li><li><p>Polywork: <a href=\"https://www.polywork.com/sethhall\"><u>polywork.com/sethhall</u></a></p></li><li><p>Twitter: <a href=\"https://twitter.com/sethburtonhall\">@sethburtonhall</a></p></li><li><p>GitHub: <a href=\"https://github.com/sethburtonhall\">@sethburtonhall</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0603-seth-hall.png"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "50th Episode Special - Live at KCDC 2022",
-    "slug": "50th-episode-special-live-at-kcdc-2022",
-    "id": "987",
-    "metaDescription": "Season Six Special Edition",
-    "season": 6,
-    "episode": 999,
-    "buzzsproutId": "11127313",
-    "publishDate": "2022-08-12T04:00:00+00:00",
-    "shortDescription": "<p>For the 50th episode of the podcast, Dan and Bekah are live at KCDC 2022 answering listener questions and practicing their accents.</p>",
-    "showNotes": "<p>For the 50th episode of the podcast, Dan and Bekah are live at the Kansas City Developer Conference 2022 answering listener questions and practicing their accents.</p><p><a href=\"https://www.youtube.com/watch?v=_fqFv1joZ3A\"><strong>Check out the video version on YouTube!</strong></a></p><h4>Listener questions:</h4><ul><li><p>What time do you go to sleep? (2:19)</p></li><li><p>How does a computer get drunk? (12:42)</p></li><li><p>What's the hardest part of community? (22:20)</p></li><li><p>Ayu would like to hear the history of how Virtual Coffee was founded. (31:57)</p></li><li><p>What does community mean to you? (38:01)</p></li><li><p>At in-person events, what are some techniques or tactics you used for starting a conversation with a stranger? (41:00)</p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/06-special.png",
-    "guests": [],
-    "sponsors": []
-  },
-  {
-    "title": "Sadie Jay - Technical Interviews for Bootcamp Grads",
-    "slug": "sadie-jay-technical-interview-for-bootcamp-grads",
-    "id": "990",
-    "metaDescription": "Season 6, Episode 4 of the Virtual Coffee Podcast",
-    "season": 6,
-    "episode": 4,
-    "buzzsproutId": "11204579",
-    "publishDate": "2022-08-30T04:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Sadie about technical interviewing after bootcamp. She shares her tips for landing interviews, prepping, and interviewing your interviewers.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Sadie a frontend developer for a federal agency, to chat about her experience navigating the interview process and how she found success after giving tech a second shot. She shares tips on how to avoid burnout both during the interview process and while you're working in tech.</p><h3>Links:</h3><ul><li><p><a href=\"https://18f.gsa.gov/\">18f</a></p></li><li><p><a href=\"https://skillcrush.com/\">Skill Crush</a></p></li><li><p><a href=\"https://leetcode.com/explore/challenge/\">Leet Code Challenge</a></p></li><li><p><a href=\"https://github.com/jmkoni/interview-questions\"><u>Jennifer's List of Interview Questions</u></a></p></li><li><p><a href=\"https://skillcrush.com/blog/technical-test-preparation-advice/\">Technical Test Preparation Advice</a> post by Sadie</p></li><li><p><a href=\"https://www.wordsofmouth.org/\">Words of Mouth job email</a></p></li><li><p><a href=\"https://designsystem.digital.gov/\">US Web Design Standards</a></p></li><li><p><a href=\"https://jekyllrb.com/\">Jekyll</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0604-sadie-episode.png",
-    "guests": [
-      {
-        "name": "Sadie Jay",
-        "bio": "<p>Sadie is a Front-end Developer and bootcamp alum. In 2016, Sadie started her journey into tech with web design courses. Along the way, she graduated with a Masters specializing in Web Design and Online Communication, taught yoga, searched for cheap flights at a travel startup, volunteered as a writer and proofreader for various non-profits, and contributed to a number of open source projects. Outside of coding and writing, Sadie can be found petting her cat Maxie, hanging out with her mom, or looking up the next vegan restaurant to check out.</p><ul><li><p><a href=\"https://sadiejay.github.io/portfolio/\">Sadie's Portfolio Site</a></p></li><li><p><a href=\"https://github.com/sadiejay\">@sadiejay on GitHub</a></p></li><li><p><a href=\"https://www.linkedin.com/in/sadiej/\">@sadiej on LinkedIn</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0604-sadie.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Chad Stewart - OSS and #TechisHiring",
-    "slug": "chad-stewart-oss-and-techishiring",
-    "id": "1026",
-    "metaDescription": "Season 6, Episode 5 of the Virtual Coffee Podcast",
-    "season": 6,
-    "episode": 5,
-    "buzzsproutId": "11269316",
-    "publishDate": "2022-09-06T04:00:00+00:00",
-    "shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk with Chad Stewart about getting started in open source, finding a project with a supportive community, and his project #TechIsHiring.</p>",
-    "showNotes": "<p>In today's episode, Bekah and Dan talk to Chad Stewart, a Software Engineer from Kingston, Jamaica, about his journey into contributing to Open Source projects like Open Sauced and how to find your way to your first contribution. He shares the inspiration behind his <a href=\"https://www.getrevue.co/profile/techishiring\">#TechIsHiring project</a>, which helps to identify tech jobs and resources, but more importantly, to connect people in the wider tech community.</p><h3>Links</h3><ul><li><p><a href=\"https://www.amazon.com/Side-Mountain-Jean-Craighead-George/dp/0141312424\">My Side of the Mountain</a></p></li><li><p><a href=\"https://twitter.com/bdougieYO\">Brian Douglas, aka Bdougie</a></p></li><li><p><a href=\"https://opensauced.pizza/\">Open Sauced</a></p></li><li><p><a href=\"https://github.com/yangshun/tech-interview-handbook\">Tech Interview Handbook</a></p></li><li><p><a href=\"https://github.com/TheAlgorithms\">The Algorithms</a></p></li><li><p><a href=\"https://twitter.com/AdiatiAyu\">Ayu</a></p></li><li><p><a href=\"https://twitter.com/TechIsHiring\">Tech is Hiring</a></p></li><li><p><a href=\"https://github.com/Virtual-Coffee/virtualcoffee.io/blob/main/CONTRIBUTING.md\">Virtual Coffee Contributors Guide</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0605-chad-episode.jpg",
-    "guests": [
-      {
-        "name": "Chad Stewart",
-        "bio": "<p>Software Engineer from Kingston, Jamaica. Founder of <a href=\"https://www.getrevue.co/profile/techishiring\">TechIsHiring</a>.</p><ul><li><p><a href=\"https://twitter.com/Chad_R_Stewart\">@Chad_R_Stewart on Twitter</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0605-chad.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Julia Seidman - Embracing the Careen Over the Career",
-    "slug": "julia-seidman-embracing-the-careen-over-the-career",
-    "id": "1049",
-    "metaDescription": "Season Six, Episode Six, of the Virtual Coffee Podcast",
-    "season": 6,
-    "episode": 6,
-    "buzzsproutId": "11351419",
-    "publishDate": "2022-09-20T04:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Julia about learning how to learn as a Technical Writer, the importance of teaching as a tool for learning, and her approach to writing about new technologies.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Julia Seidman, a technical marketing consultant and developer in the Seattle area, and talked about her work writing about different technologies, learning by teaching, and embracing the careen over the career. She talks about her career journey from studying anthropology to financial analysis to teaching high school English, ESL and Debate, before landing her current role as a technical writer.</p><h3>Links</h3><ul><li><p><a href=\"https://en.wikipedia.org/wiki/Krugerrand\">Krugerrand</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Doubloon\">Gold Doubloons</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Rhodium\">Rhodium</a></p></li><li><p><a href=\"https://flutter.dev/\">Flutter</a></p></li><li><p><a href=\"https://www.amazon.com/Developer-Marketing-Does-Not-Exist-ebook/dp/B091NK954H\">Developer Marketing Does Not Exist</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0606-julia-episode.jpg",
-    "guests": [
-      {
-        "name": "Julia Seidman",
-        "bio": "<p>Julia Seidman is a technical marketing consultant and developer in the Seattle area. She has 2 terrific kids and a wonderful partner, and her family cos-plays as a “normal” family.</p><p class=\"text-left\">Julia is a believer in the careen, rather than the career.</p><p class=\"text-left\">After studying anthropology and writing a senior thesis on the ethics of museum collections of human skeletal remains, she took the job she could get, which was fundraising for a hospital.</p><p class=\"text-left\">From there, she became a financial analyst and employee educator for 401(k) and pension plans. After that, she got a Master’s in Teaching, and taught high school English, ESL and Debate for most of a decade.</p><p class=\"text-left\">Now, she works as a freelance technical writer and software developer, specializing in technical content marketing.</p><p class=\"text-left\">Along the way, she has learned a lot about a lot of things, including the Python ecosystem.</p>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0606-juila.JPG"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Ryan Kahn - Building Better Teams",
-    "slug": "ryan-kahn-building-better-teams",
-    "id": "1091",
-    "metaDescription": "Season 6, Episode 7 of the Virtual Coffee Podcast",
-    "season": 6,
-    "episode": 7,
-    "buzzsproutId": "11407929",
-    "publishDate": "2022-09-29T04:00:00+00:00",
-    "shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk with Ryan Kahn about building better teams to deliver quality software by practicing empathy and knowledge sharing.</p>",
-    "showNotes": "<p>In today's episode, Bekah and Dan talk to Ryan Kahn, a developer experience and productivity consultant from New York City, about his work as a consultant helping companies to build better software teams. He emphasizes the importance of recognizing that teams are made up of individuals who have different needs and approaches. He also breaks down the difference between quality, technical, knowledge, and innovation debt and the need to identify which most impacts teams as they seek better communication to build a stronger team.</p><h3>Links:</h3><ul><li><p><a href=\"http://adr.github.io\">ADR GitHub organization</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Oblique_Strategies\">Oblique Strategies</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0607-ryan-episode.jpg",
-    "guests": [
-      {
-        "name": "Ryan Kahn",
-        "bio": "<p>Ryan loves solving the human and technical problems of software development, and works on both as a developer experience and productivity consultant. He lives in New York City with his partner, daughter, and dog. Outside of his work he loves Astronomy and Amateur Radio.</p>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0607-ryan.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Shelley McHardy: Junior Dev life",
-    "slug": "shelley-mchardy-junior-dev-life",
-    "id": "1101",
-    "metaDescription": "Season Six, Episode Eight of the Virtual Coffee Podcast",
-    "season": 6,
-    "episode": 8,
-    "buzzsproutId": "11445606",
-    "publishDate": "2022-10-05T04:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Shelley McHardy about navigating a career transition and the challenges of interviewing for your first developer role.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Shelley McHardy, a former chemistry teacher turned front end developer at <a href=\"https://www.rightpoint.com/\">Rightpoint</a>, and talked about the early career developer's journey. She gave insight into what her seven-month interview process looked like, forcing interviewers to interview you, the importance of finding \"your people\", and being picky in your job search.</p><h3>Links:</h3><ul><li><p><a href=\"https://www.edx.org/\">edX</a></p></li><li><p><a href=\"https://the-collab-lab.codes/\">Collab Lab</a></p></li><li><p><a href=\"https://www.studentachievementsolutions.com/what-are-professional-learning-communities-plcs/\">PLCs- Professional learning communities</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0608-shelley-episode.jpg",
-    "guests": [
-      {
-        "name": "Shelley McHardy",
-        "bio": "<p>Shelley is a former chemistry teacher turned front end developer at Rightpoint. A native San Franciscan, she is currently doing her best to stay cool in Atlanta, Georgia. When not crocheting, she and her wife love hiking the Georgia State Parks, geocaching, cooking, baking, and video games.</p><ul><li><p>GitHub: <a href=\"https://github.com/shelleymcq\">@shelleymcq</a></p></li><li><p>Twitter <a href=\"https://twitter.com/shelleymcqDev\">@shelleymcqDev</a></p></li><li><p>LinkedIn <a href=\"https://www.linkedin.com/in/shelleymchardy/\">shelleymchardy</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0608-shelley.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Season Six Finale - Talking Hacktoberfest with Bekah, Dan, and Kirk",
-    "slug": "season-six-finale-talking-hacktoberfest-with-bekah-dan-and-kirk",
-    "id": "1132",
-    "metaDescription": "Season Six, Episode Nine of the Virtual Coffee Podcast",
-    "season": 6,
-    "episode": 9,
-    "buzzsproutId": "11496083",
-    "publishDate": "2022-10-13T04:00:00+00:00",
-    "shortDescription": "<p>It’s the final episode of season six of the podcast and we’re bringing it to you live with Bekah, Dan, and Kirk!</p>",
-    "showNotes": "<p>It’s the final episode of season six of the podcast and we’re bringing it to you live with Bekah, Dan, and Kirk! We talked a lot about Hacktoberfest with many side-tracks and segues in between.</p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0609-finale.jpg",
-    "guests": [],
-    "sponsors": []
-  },
-  {
-    "title": "Jörn Bernhardt - Becoming a Founder",
-    "slug": "jörn-bernhardt-becoming-a-founder",
-    "id": "1626",
-    "metaDescription": "Season Seven, Episode One of the Virtual Coffee Podcast",
-    "season": 7,
-    "episode": 1,
-    "buzzsproutId": "12164997",
-    "publishDate": "2023-02-02T05:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Jörn Bernhardt about his journey as a 2x founder and his lifelong interest in technology.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Jörn Bernhardt, a 2x founder in Germany, about his career path, the challenges of being a founder, and the key traits that have led to his success.</p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Jörn.png",
-    "guests": [
-      {
-        "name": "Jörn Bernhardt",
-        "bio": "<p>Jörn started developing web-based software in the last century when he was still in school. In 2018, he founded his second company <a href=\"http://compose.us\">compose.us</a> where they implement digital solutions and share their knowledge with public administrations. In his spare time Jörn organizes local meetups in Germany and creates at least one open source commit per day to push his side projects.</p><ul><li><p><a href=\"https://compose.us/\">compose.us</a></p></li><li><p><a href=\"https://github.com/Narigo\">Jörn on GitHub</a></p></li><li><p><a href=\"NarigoDF\">Jörn on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/j%C3%B6rn-bernhardt-a04225104/\">Jörn on LinkedIn</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/joern.png"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Joe Karow - Career Transitions and the ADHD Experience",
-    "slug": "joe-karow-career-transitions-and-the-adhd-experience",
-    "id": "1655",
-    "metaDescription": "Season Seven, Episode Two of the Virtual Coffee Podcast",
-    "season": 7,
-    "episode": 2,
-    "buzzsproutId": "12213630",
-    "publishDate": "2023-02-09T05:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Joe Karow about his journey as into tech with 100devs and about his ADHD journey.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Joe Karow, the Lead Engineer at a nonprofit, about his career change from the hospitality industry, his experience with the online bootcamp, 100devs, and about the ADHD experience.</p><h3>Links</h3><ul><li><p><a href=\"https://jobs.all-hands.us/jobs\">All Hands Job Board</a></p></li><li><p><a href=\"https://leonnoel.com/100devs/\">100devs</a></p></li><li><p><a href=\"https://www.resilientcoders.org/\">Resilient Coders</a></p></li><li><p><a href=\"https://twitter.com/leonnoel\">Leon Noel</a></p></li><li><p><a href=\"https://www.cedarpoint.com/\">Cedar Point</a></p></li><li><p><a href=\"https://buschgardens.com/\">Busch Gardens</a></p></li><li><p><a href=\"https://www.kennywood.com/\">Kennywood</a></p></li><li><p><a href=\"https://cssbattle.dev/\">cssbattle.dev</a></p></li><li><p><a href=\"https://remo.co/\">remo</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0702-joe-episode.jpg",
-    "guests": [
-      {
-        "name": "Joe Karow",
-        "bio": "<p>Joe is the Lead Engineer at InReach, a 501(c)3 registered non-profit building world’s first tech platform matching LGBTQ+ people facing discrimination and persecution with safe, verified resources. Formerly a Director of Finance for a large hotel chain, he made the leap in to tech in 2022. Tech was always a part of Joe's life, it just took a global pandemic for him to decide to start getting paid for it.</p><ul><li><p><a href=\"https://joekarow.dev\"><u>joekarow.dev</u></a></p></li><li><p><a href=\"https://github.com/JoeKarow\">@JoeKarow</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/JoeKarow\">@JoeKarow</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/jkarow/\">@jkarow</a> on LinkedIn</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0702-joe.jpeg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Kai Katschthaler - Technical Writing &  Neurodiverse Learning",
-    "slug": "kai-katschthaler-technical-writing-neurodiverse-learning",
-    "id": "1680",
-    "metaDescription": "Season Seven, Episode Three of the Virtual Coffee Podcast",
-    "season": 7,
-    "episode": 3,
-    "buzzsproutId": "12263721",
-    "publishDate": "2023-02-16T05:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Kai Katschthaler about their experience growing their technical writing career and creating content.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Kai Katschthaler, a technical writer and content creator, about their creation process, finding learning approaches that work for them, and mentoring others.</p><h3>Links:</h3><ul><li><p><a href=\"https://www.spreaker.com/user/15541131/kai-ep-final\">Kai's appearance on the Coming Out Pod</a></p></li><li><p><a href=\"https://bau.edu/blog/kinesthetic-learner/\">Kinesthetic Learning</a></p></li><li><p><a href=\"https://www.freecodecamp.org/\">Freecodecamp</a></p></li><li><p><a href=\"https://www.codecademy.com/\">Codecademy</a></p></li><li><p><a href=\"https://learn.co/\">Flatironschool</a></p></li><li><p><a href=\"https://exercism.org/\">Exercism</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0703-kai-episode.jpg",
-    "guests": [
-      {
-        "name": "Kai Katschthaler",
-        "bio": "<p>Kai is a tech content specialist and mental health advocate. They run Taboola Rasa, a mental health awareness project that seeks to erase the stigma connected to mental health.</p><ul><li><p><a href=\"https://linktr.ee/thegrumpyenby\">linktr.ee/thegrumpyenby</a></p></li><li><p><a href=\"https://github.com/thegrumpyenby\">@thegrumpyenby</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/thegrumpyenby\">@thegrumpyenby</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/kaikatschthaler/\">@kaikatschthaler</a> on LinkedIn</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0703-kai.jpeg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Aishwarya Mali - A Journey into Open Source",
-    "slug": "aishwarya-mali-a-journey-into-open-source",
-    "id": "1695",
-    "metaDescription": "Season Seven, Episode Four of the Virtual Coffee Podcast",
-    "season": 7,
-    "episode": 4,
-    "buzzsproutId": "12315603",
-    "publishDate": "2023-02-23T05:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Aishwarya about her journey as a first time contributer during the 2022 Hacktoberfest.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Aishwarya, front-end developer from India, about her first open source contributions and how her perspective on open source changed after her fourth (of ten!) Pull Request during Hacktoberfest.</p><ul><li><p>One word to describe you - <strong>Dedicated</strong></p></li><li><p>One word to describe your developer journey - <strong>Evolving</strong></p></li><li><p><a href=\"https://www.amazon.com/Me-Before-You-Novel-Tie/dp/0143130153\"><em><u>Me Before You</u></em><u> by Jojo Moyes</u></a></p></li><li><p>Open-Source YouTube Videos:</p><ul><li><p><a href=\"https://www.youtube.com/watch?v=yfopPq4354o\">How to Find Beginner-Friendly Open Source Projects</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=_uetV0wZyXM\">4 Beginner Friendly Open Source Projects to Contribute before 2023</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=lnLiD0GfCRE\">5 Beginner friendly Open Source Organisations to start your Open source journey</a></p></li></ul></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0704-aishwara-episode.jpg",
-    "guests": [
-      {
-        "name": "Aishwarya Mali",
-        "bio": "<p>Aishwarya Mali is a front-end developer (React+XState+Redux) based in Pune, India. She loves to read!</p><ul><li><p><a href=\"https://github.com/aishwarya-mali\">@aishwarya-mali</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/aishwaryamali24\">@aishwaryamali24</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/aishwaryamali24/\">@aishwaryamali24</a> on LinkedIn</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0704-aishwara.jpeg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Rebecca Key - From PhD to Frontend",
-    "slug": "rebecca-key-from-phd-to-frontend",
-    "id": "1711",
-    "metaDescription": "Season Seven, Episode Five of the Virtual Coffee Podcast",
-    "season": 7,
-    "episode": 5,
-    "buzzsproutId": "12363084",
-    "publishDate": "2023-03-02T05:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Rebecca Key about her journey from a career in chemistry to Software Engineer and the hobbies that she finds exciting.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Rebecca Key, a PhD in Organic Chemistry and now Software Engineer, and chatted about her career journey, Ham radios, being left-handed, taking notes, and the importance of consistency.</p><h3>Links:</h3><ul><li><p><a href=\"https://en.wikipedia.org/wiki/Brassica_oleracea\">Brassica oleracea</a> (the plant Dan was talking about)</p></li><li><p><a href=\"https://www.sota-at.com/\">SOTA-AT</a>: An interactive map that displays and provides information for peaks along the GA section of the Appalachian Trail that count toward activations for “Summits on the Air”, a ham radio contest.</p></li><li><p><a href=\"https://github.com/rek990/crochet-counter\">Row Counter</a>: A tool to help fiber artists (crocheters, knitters, rug makers, basket weavers, etc.) keep track of the row they are on with a given project. <a href=\"https://dev.to/rek990/virtual-coffees-july-monthly-challenge-live-demo-of-the-progress-toward-my-row-counter-app-3jd7\">Live Demo of the Progress Toward my Row Counter App</a></p></li><li><p>Rebecca's RF Quests: <a href=\"https://www.rfquests.com/\">Blog</a> and <a href=\"https://www.youtube.com/channel/UC5Rtn09KIdwsySkf7B-DPsw\">YouTube Channel</a></p></li><li><p><a href=\"https://parksontheair.com/\">Parks on the Air (POTA)</a></p></li><li><p><a href=\"https://www.sota.org.uk/\">Summits on the Air (SOTA)</a></p></li><li><p><a href=\"https://www.sota.org.uk/Joining-In/Awards\">SOTA Mountain goat award</a></p></li><li><p><a href=\"https://orgmode.org/\">Emacs Org Mode</a></p></li></ul><h4>Left-handed Deep Dive</h4><ul><li><p><a href=\"https://kids.frontiersin.org/articles/10.3389/frym.2014.00013\">Your Left-Handed Brain</a></p></li><li><p><a href=\"https://www.bbc.com/news/health-49579810\">Left-handed DNA found - and it changes brain structure</a></p></li><li><p><a href=\"https://pubmed.ncbi.nlm.nih.gov/1839378/#:~:text=Left%2Dhandedness%20occurs%20in%20about,monozygotic%20twins%20show%20substantial%20discordance\">The inheritance of left-handedness</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0705-rebecca-episode.png",
-    "guests": [
-      {
-        "name": "Rebecca Key",
-        "bio": "<p>Rebecca Key is a Software Engineer based out of Atlanta, GA. She is a first-generation college graduate that went on to obtain a PhD in Organic Chemistry from Georgia Tech. After many years in research (roles ranging from Laboratory Technician to Research Director), she made a career change into the tech field, where she currently works as an Independent Front-End Engineer. When not coding, she enjoys mountain biking, running, weightlifting, crocheting, and knitting!</p><ul><li><p><a href=\"http://rebeccakeyphd.com/\">rebeccakeyphd.com</a></p></li><li><p><a href=\"https://github.com/rek990\">@rek990</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/rebeccakeyphd\">@rebeccakeyphd</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/rebecca-key/\">@rebecca-key</a> on LinkedIn</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0705-rebecca.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Arthur Doler - The Human Side of Tech",
-    "slug": "arthur-doler-the-human-side-of-tech",
-    "id": "1727",
-    "metaDescription": "Season Seven, Episode Six of the Virtual Coffee Podcast",
-    "season": 7,
-    "episode": 6,
-    "buzzsproutId": "12407750",
-    "publishDate": "2023-03-09T05:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Arthur Doler about team dynamics, motivation, and how to identify problematic situations.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Arthur Doler, a Software Engineer and Community and Culture Steward, and chatted about the human side of tech, the importance of recognizing our emotions, communication styles, and the dynamics of the environments we're working in.</p><h3>Links:</h3><ul><li><p><a href=\"https://www.danpink.com/books/drive/\">Daniel Pink's Drive</a></p></li><li><p><a href=\"https://youtu.be/-XYK8ulQId0\">Arthur's talk: You're Not Just Tired: The Psychology of Burnout</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Aikido\">Aikido</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/List_of_disc_golf_players\">Pro Disc Golfers</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0706-arthur-episode.jpg",
-    "guests": [
-      {
-        "name": "Arthur Doler",
-        "bio": "<p>Arthur (or Art, take your pick) has been a software engineer for 19 years and has worked on things as exciting as analysis software for casinos and things as boring as banking websites. He is an advocate for talking openly about mental health and psychology in the technical world, and he spends a lot of time thinking about <em>how</em> we program and <em>why</em> we program, and about the tools, structures, cultures, and mental processes that help and hinder us from our ultimate goal of writing amazing things. His hair is brown and his thorax is a shiny blue color.</p><ul><li><p><a href=\"https://arthurdoler.com\">arthurdoler.com</a></p></li><li><p><a href=\"https://github.com/doleraj\">@doleraj</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/arthurdoler\">@arthurdoler</a> on Twitter</p></li><li><p><a href=\"https://mastodon.sandwich.net/@arthurdoler\">@arthurdoler</a> on Mastodon</p></li><li><p><a href=\"https://www.linkedin.com/in/arthurdoler/\">@arthurdoler</a> on LinkedIn</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0706-arthur.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Dominic Duffin - Finding value in challenging ourselves",
-    "slug": "dominic-duffin-finding-value-in-challenging-ourselves",
-    "id": "1740",
-    "metaDescription": "Season Seven, Episode Seven of the Virtual Coffee Podcast",
-    "season": 7,
-    "episode": 7,
-    "buzzsproutId": "12453805",
-    "publishDate": "2023-03-16T04:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Dominic Duffin about the impact of non-traditional learning experiences and the importance of community collaboration.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Dominic Duffin, a Full-Stack Developer, Co-founder of ArtTechChat Twitter chat, Salon Host at The Interintellect, and Open Source contributor, and chatted about the the value gained in creating a learning environment wherever you go and the importance of participating in community experiences.</p><ul><li><p>Pass the Pen: <a href=\"https://codepen.io/collection/nZrZLy\">https://codepen.io/collection/nZrZLy</a></p></li><li><p><a href=\"@ArtTechChat on Twitter\"><u>https://twitter.com/arttechchat</u></a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0707-dominic-episode.jpg",
-    "guests": [
-      {
-        "name": "Dominic Duffin",
-        "bio": "<p>Full Stack Developer, community builder, remote worker and aspiring polymath. Passionate about open source everything, decentralization, peer-to-peer tech and cryptocurrency. Also to be found playing board games, studying paper maps and riding public transport.</p><ul><li><p><a href=\"https://dominicduffin.uk\">dominicduffin.uk</a></p></li><li><p><a href=\"https://github.com/dominicduffin1\">@dominicduffin1</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/DominicDuffin1\">@DominicDuffin1</a> on Twitter</p></li><li><p><a href=\"https://toot.cafe/@dominicduffin1\">@dominicduffin1</a> on Mastadon</p></li><li><p><a href=\"https://www.linkedin.com/in/dominic-duffin-a992b0225\">@dominic-duffin</a> on LinkedIn</p></li><li><p><a href=\"https://www.polywork.com/dominic\">@dominic</a> on Polywork</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0707-dominic.png"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Ramón Huidobro - Thoughtful Learning",
-    "slug": "ramón-huidobro-thoughtful-learning",
-    "id": "1756",
-    "metaDescription": "Season Seven, Episode Eight of the Virtual Coffee Podcast",
-    "season": 7,
-    "episode": 8,
-    "buzzsproutId": "12503114",
-    "publishDate": "2023-03-23T04:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Ramón Huidobro about asking good questions about your code and how to ask for help.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Ramón Huidobro, a developer advocate and DevEd enthusiast, and chatted about the process of learning and growing and how asking questions and knowing what questions to ask is an important part of the tech experience.</p><p>Check out Ramón's article <a href=\"https://ramonh.dev/2022/11/13/asking-for-help/\">about reaching out for help</a>!</p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0708-ramon-episode.jpg",
-    "guests": [
-      {
-        "name": "Ramón Huidobro",
-        "bio": "<p>Ramón Huidobro is a developer advocate and DevEd enthusiast. He thrives on lifting others up in their tech careers and loves a good CSS challenge. Always excited to talk about teaching tech, especialmente en Español, oder auf Deutsch.</p><ul><li><p><a href=\"https://https://ramonh.dev\">ramonh.dev</a></p></li><li><p><a href=\"https://github.com/hola-soy-milk\">@hola-soy-milk</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/hola_soy_milk\">@hola_soy_milk</a> on Twitter</p></li><li><p><a href=\"https://hachyderm.io/@hola_soy_milk\">@hola_soy_milk</a> on Mastadon</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0708-ramon.jpg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Season Seven Finale - Live with Nick Taylor",
-    "slug": "season-seven-finale-live-with-nick-taylor",
-    "id": "1772",
-    "metaDescription": "Season Seven, Episode Nine of the Virtual Coffee Podcast",
-    "season": 7,
-    "episode": 9,
-    "buzzsproutId": "12558497",
-    "publishDate": "2023-03-31T04:00:00+00:00",
-    "shortDescription": "<p>Join Bekah, Dan, and Special Guest Nick Taylor for a live-streamed episode of the Season Seven Finale!</p>",
-    "showNotes": "<p>Join Bekah, Dan, and Special Guest Nick Taylor for a live-streamed episode of the Season Seven Finale!</p><p>Watch the video replay here: <a href=\"https://www.youtube.com/watch?v=0Wj-zlORvm8\">https://www.youtube.com/watch?v=0Wj-zlORvm8</a></p><p>Watch our 2023 Spring Lightning Talks here: <a href=\"https://www.youtube.com/watch?v=O2CsTN-WEZ0\">https://www.youtube.com/watch?v=O2CsTN-WEZ0</a></p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0709-finale.png",
-    "guests": [],
-    "sponsors": []
-  },
-  {
-    "title": "VC Maintainers - Importance of Culture Citizenship",
-    "slug": "vc-maintainers-importance-of-culture-citizenship",
-    "id": "1796",
-    "metaDescription": "Season Eight, Episode One of the Virtual Coffee Podcast",
-    "season": 8,
-    "episode": 1,
-    "buzzsproutId": "12988617",
-    "publishDate": "2023-06-07T04:00:00+00:00",
-    "shortDescription": "<p><span>We're starting the new season with a conversation with our maintainers, including our new maintainer, Julia Seidman! We share our thought process for adding a maintainer and walk through our culture citizenship statement to share how we intend to create a positive community.</span></p>",
-    "showNotes": "<p><span>Starting off this new season, we're bringing in all of our maintainers, Bekah Hawrot Weigel, Dan Ott, Kirk Shillingford, and Julia Seidman. We walk through the importance of understanding communities, members, and how to create a positive community experience.</span></p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0801-Cover.jpeg",
-    "guests": [
-      {
-        "name": "Julia Seidman",
-        "bio": "<p><span>Julia Seidman is a developer education consultant based in the Seattle area. Julia is a believer in embracing the 'careen' over the career. </span></p>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Julia-Headshot.jpeg"
-      },
-      {
-        "name": "Kirk Shillingford",
-        "bio": "<p><span>A full stack developer in the Caribbean interested in Functional Programming, Domain Driven Development, and Security.</span></p>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Kirk-Headshot.jpeg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Alex Curtis-Slep - Enriching Your Life as a Developer",
-    "slug": "alex-curtis-slep-enriching-your-life-as-a-developer",
-    "id": "1827",
-    "metaDescription": "Season Eight, Episode Two of the Virtual Coffee Podcast",
-    "season": 8,
-    "episode": 2,
-    "buzzsproutId": "13038514",
-    "publishDate": "2023-06-15T04:00:00+00:00",
-    "shortDescription": "<p><span>In today's episode, Dan and Bekah talk to Alex about his gratifying journey as a self-taught developer and tools you can use to maintain a positive attitude, create balance, decrease stress, and form good habits to enrich your life.</span></p>",
-    "showNotes": "<p><span>This week Bekah and Dan sat down with Alex Curtis-Slep, long time member and volunteer and self-taught developer, about documenting the small wins, falling in love with the process, and aligning your goals to maintain a healthy life while job searching and during your tech career.</span></p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe.png",
-    "guests": [
-      {
-        "name": "Alex Curtis-Slep",
-        "bio": "<p>Alex Curtis-Slep is a self taught software developer. After getting his initial tastes of HTML and CSS in the early 2000’s on his basketball blog, Alex jumped into coding in early 2019. He heard about a course Madison Kanna created on roadmapping to become a developer and took the plunge. Following a few years of learning, creating, contributing to open source, and much more, Alex landed his first job in tech at Paypixl. When he’s not coding and hyping up his developer friends, he loves everything basketball, tropical fruit, vegan, travel, family, friend, and foreign language related!</p><ul><li><p><a href=\"http://alexcurtisslep.com\">alexcurtisslep.com</a></p></li><li><p><a href=\"https://github.com/AlexVCS\" rel=\"noopener noreferrer\" target=\"_blank\">@AlexVCS</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/AlexCurtisSlep\" rel=\"noopener noreferrer\" target=\"_blank\">@AlexCurtisSlep</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/alexcurtisslep/\" rel=\"noopener noreferrer\" target=\"_blank\">@alexcurtisslep</a> on LinkedIn</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Alex-Curtis.jpeg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Carmen - Tech Industry Friendships: Leveraging Connections for Growth, Challenges, and Opportunities and DevOps!",
-    "slug": "carmen-tech-industry-friendships-leveraging-connections-for-growth-challenges-and-opportunities-and-devops",
-    "id": "1841",
-    "metaDescription": "Season Eight, Episode Three of the Virtual Coffee Podcast",
-    "season": 8,
-    "episode": 3,
-    "buzzsproutId": "13047459",
-    "publishDate": "2023-06-21T04:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Carmen about the impactful role of friendships in the tech industry. We talked about how these connections positively influenced her professional journeys, helped her overcome challenges, and contributed to career growth in DevOps.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Carmen Kohole, a DevOps Engineer based in Portland, Oregon, to chat about the benefits of collaboration and the valuable opportunities you can gain just by asking for help. We also discussed the benefits of fostering strong relationships in the tech industry, and what it means to be a DevOps engineer.</p><h3>Links:</h3><ul><li><p><a href=\"https://twitter.com/thejonanshow\">Jonan Scheffler</a></p></li><li><p><a href=\"https://twitter.com/nickytonline\">Nick Taylor</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0803-Carmen.png",
-    "guests": [
-      {
-        "name": "Carmen",
-        "bio": "<p>DevOps Engineer based in Portland, Oregon. Big fan of house plants, hiking, hats and cats. Here to help build stuff, break stuff, learn stuff and make friends.</p><ul><li><p><a href=\"https://github.com/carmenkolohe\" rel=\"noopener noreferrer\" target=\"_blank\">@carmenkolohe</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/carmenkolohe\" rel=\"noopener noreferrer\" target=\"_blank\">@carmenkolohe</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/carmenkolohe/\" rel=\"noopener noreferrer\" target=\"_blank\">@carmenkolohe</a> on LinkedIn</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Carmen.jpeg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Caitlin Floyd - Mentorship",
-    "slug": "caitlin-floyd",
-    "id": "1855",
-    "metaDescription": "Season Eight, Episode Four of the Virtual Coffee Podcast",
-    "season": 8,
-    "episode": 4,
-    "buzzsproutId": "13121425",
-    "publishDate": "2023-06-28T04:00:00+00:00",
-    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Caitlin about expanding the definition of tech mentorship. We challenge the traditional one-on-one approach and delve into group and community mentorship, where learning, growth, and curiosity thrive collectively. We discuss how active and empathetic listening fosters understanding and knowledge exchange.</p>",
-    "showNotes": "<p>This week Bekah and Dan sat down with Caitlin Floyd, a front-end developer, to chat about the concept of collective learning and explore new possibilities in the evolving landscape of tech mentorship. Discover firsthand how Caitlin's experiences highlight the power of collaboration, breaking down silos, and leveraging collective knowledge to drive innovation and success.</p><h3>Links:</h3><ul><li><p><a href=\"https://the-collab-lab.codes/\">Collab Lab</a></p></li><li><p><a href=\"https://dev.to/the-collab-lab/tcl-22-recap-211m/\">Recap of a Collab Lab cohort that Caitlin participated in</a></p></li><li><p><a href=\"https://leaddev.com/mentoring-coaching-feedback/mentor-coach-sponsor-guide-developing-engineers\">Mentor, coach, sponsor: a guide to developing engineers</a> by Neha Batra</p></li><li><p><a href=\"https://kwugirl.blogspot.com/2020/10/secrets-of-stealth-mentee.html?m=1\">Secrets of a Stealth Mentee</a> by KWu</p></li><li><p><a href=\"https://larahogan.me/sponsors/\">Mentorship and Sponsorship</a> by Lara Hogan</p></li><li><p><a href=\"https://cate.blog/2017/03/21/sponsorship-can-start-small/\">Sponsorship Can Start Small</a> by Cate</p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe_2023-06-28-031129_uyfo.png",
-    "guests": [
-      {
-        "name": "Caitlin Floyd",
-        "bio": "<p>Caitlin is a front-end developer driven by the power of technology as a force for good. Before entering tech, she worked in linguistics, education, and nonprofit management. When not coding, she loves reading, studying languages, traveling, and most of all doting on her puppy.</p><ul><li><p><a href=\"https://caitlinfoyd.com\">caitlinfoyd.com</a></p></li><li><p><a href=\"https://github.com/cafloyd\" rel=\"noopener noreferrer\" target=\"_blank\">@cafloyd</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/caitlinfloyd\" rel=\"noopener noreferrer\" target=\"_blank\">@caitlinfloyd</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/caitlinfloyd/\" rel=\"noopener noreferrer\" target=\"_blank\">@caitlinfloyd</a> on LinkedIn</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Caitlin.jpeg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Reda - From Maritime Engineer to Self-Taught Front-End Developer",
-    "slug": "reda-from-maritime-engineer-to-self-taught-front-end-developer",
-    "id": "1880",
-    "metaDescription": "Season Eight, Episode Five of the Virtual Coffee Podcast",
-    "season": 8,
-    "episode": 5,
-    "buzzsproutId": "13204285",
-    "publishDate": "2023-07-12T04:00:00+00:00",
-    "shortDescription": "<p>Join hosts Bekah and Dan in this inspiring episode as they talk through the captivating journey of Reda, a self-taught developer. Discover the challenges and triumphs of the world of programming solo, and gain valuable insights on the optimal timing for job applications—because as Reda shares the advice he was given, \"When should you start applying for jobs? Yesterday.\"</p>",
-    "showNotes": "<p><span>Join Bekah and Dan in this week's episode, where they dive into the transformative journey of Reda, a self-taught developer. Hear about the unique challenges and victories Reda faced as he navigated the journey to becoming a front-end developer. Gain valuable advice on the ideal timing for job applications, as Reda shares advice he heard along his journey: \"When should you start applying for jobs? Yesterday.\" Tune in for an enriching conversation that will inspire aspiring self-taught developers and offer practical insights for your career paths.</span></p><h3>Links: </h3><ul><li><p><a href=\"https://www.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Free Code Camp</a></p></li><li><p><a href=\"https://the-collab-lab.codes/\" rel=\"noopener noreferrer\" target=\"_blank\">Collab Lab</a></p></li><li><p><a href=\"https://www.coursera.org/specializations/python\" rel=\"noopener noreferrer\" target=\"_blank\">Python Course</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe_2023-07-11-193524_yhob.png",
-    "guests": [
-      {
-        "name": "Reda",
-        "bio": "<p>I'm a self-taught front-end developer based in Morocco, with a background in Marine Mechanics.</p><ul><li><p><a href=\"https://github.com/redapy\" rel=\"noopener noreferrer\" target=\"_blank\">redapy</a> on GitHub</p></li><li><p><a href=\"https://www.google.com/url?sa=t&amp;rct=j&amp;q=&amp;esrc=s&amp;source=web&amp;cd=&amp;cad=rja&amp;uact=8&amp;ved=2ahUKEwjSsLzRsYeAAxVBmGoFHUEQDNUQFnoECBAQAQ&amp;url=https%3A%2F%2Ftwitter.com%2Fredabaha12&amp;usg=AOvVaw2LtVxW6oDxwQ_Aq1KKL3ik&amp;opi=89978449\" rel=\"noopener noreferrer\" target=\"_blank\">redabaha12</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/redabaha/\" rel=\"noopener noreferrer\" target=\"_blank\">redabaha</a> on LinkedIn</p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Reda.jpeg"
-      }
-    ],
-    "sponsors": []
-  },
-  {
-    "title": "Josh - The Life of a Full Time Open Source Developer",
-    "slug": "josh-the-life-of-a-full-time-open-source-developer",
-    "id": "1895",
-    "metaDescription": "Season Eight, Episode Six of the Virtual Coffee Podcast",
-    "season": 8,
-    "episode": 6,
-    "buzzsproutId": "13247190",
-    "publishDate": "2023-07-19T04:00:00+00:00",
-    "shortDescription": "<p>In this episode, Dan and Bekah explore the fascinating journey of being a full-time open source contributor with Josh Goldberg. We discuss the challenges and rewards of dedicating yourself to the open source ecosystem, TypeScript's growing popularity, and how Josh supports the tech community.</p>",
-    "showNotes": "<p>Join Bekah and Dan in this week's episode, where they talk with Josh Goldberg, an independent full time open source developer working on projects in the TypeScript ecosystem, where he shares valuable tips and insights on how you can get started with contributing to open source, whether you're a seasoned developer or just dipping your toes into OSS. Josh also shares the story of his prolific speaking journey over the last couple of years and how staying involved in the tech community has been a rewarding experience.</p><p><strong>Links:</strong></p><ul><li><p><a href=\"https://typescript-eslint.io/\" rel=\"noopener noreferrer\" target=\"_blank\">typescript-eslint</a></p></li><li><p><a href=\"https://github.com/typescript-eslint/typescript-eslint\" rel=\"noopener noreferrer\" target=\"_blank\">typescript-eslint GitHub</a></p></li><li><p><a href=\"https://www.codecademy.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Code Academy</a></p></li><li><p><a href=\"https://sway.office.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Microsoft Sway</a> </p></li><li><p>Josh's Blog posts about applying to conferences:</p><ul><li><p><a href=\"https://blog.joshuakgoldberg.com/how-i-apply-to-conferences/\" rel=\"noopener noreferrer\" target=\"_blank\">How I Apply to Conferences</a></p></li><li><p><a href=\"https://blog.joshuakgoldberg.com/how-i-apply-to-conferences-faqs/\" rel=\"noopener noreferrer\" target=\"_blank\">How I Apply to Conferences: FAQs</a></p></li></ul></li><li><p>Josh's Book: <a href=\"https://www.learningtypescript.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Learning Typescript</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe_2023-07-19-033240_jrwt.png",
-    "guests": [
-      {
-        "name": "Josh Golberg",
-        "bio": "<p>Hi, I’m Josh! I’m an independent full time open source developer. I work on projects in the TypeScript ecosystem, most notably typescript-eslint: the tooling that enables ESLint and Prettier to run on TypeScript code. I’m also the author of the O’Reilly Learning TypeScript book, a Microsoft MVP for developer technologies, and an active conference speaker.</p>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Josh.jpeg"
-      }
-    ],
-    "sponsors": [
-      {
-        "title": "LevelUP Financial planning",
-        "url": "https://www.levelupfinancialplanning.com/?vc",
-        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
-        "logoWidth": 679,
-        "logoHeight": 525,
-        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
-      }
-    ]
-  },
-  {
-    "title": "Taiwo Yusuf - The Importance of Having a Learning Mindset",
-    "slug": "taiwo-yusuf-the-importance-of-having-a-learning-mindset",
-    "id": "1910",
-    "metaDescription": "Season Eight, Episode Seven of the Virtual Coffee Podcast",
-    "season": 8,
-    "episode": 7,
-    "buzzsproutId": "13295814",
-    "publishDate": "2023-07-26T04:00:00+00:00",
-    "shortDescription": "<p>In this episode, Dan and Bekah chat with Taiwo, a backend developer from Nigeria. He shares his journey from Electrical Engineering Major to backend development, and the importance of staying motivated and always being hungry to learn and grow.</p>",
-    "showNotes": "<p>Join Bekah and Dan in this week's episode,  where they talk with Taiwo Yusuf, a back-end engineer with a passion for developing innovative solutions.  Despite being the top of his class in Electrical Engineering, he found his passion in backend development. He shares the importance of always learning, growing, and surrounding yourself with people who are more skilled than you are to find inspiration, support, and motivation.</p><p><strong>Links:</strong></p><ul><li><p><a href=\"https://www.grace.health/\" rel=\"noopener noreferrer\" target=\"_blank\">Grace Health</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe-1.png",
-    "guests": [
-      {
-        "name": "Taiwo Yusuf",
-        "bio": "<p>I'm Taiwo Yusuf, a back-end engineer with a passion for developing innovative solutions. I've been fortunate enough to work with amazing companies like Grace Health, LogicShift, and JufoPay. When I'm not busy coding, I'm an avid fan of generative art, and I adore cats. So, whether you want to talk about tech, art, or felines, let's connect and have a chat!</p>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/3bmcquEcQTRCESX5KIOTJO-AvdRCqPIKvQDtqprXWGY.png"
-      }
-    ],
-    "sponsors": [
-      {
-        "title": "LevelUP Financial planning",
-        "url": "https://www.levelupfinancialplanning.com/?vc",
-        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
-        "logoWidth": 679,
-        "logoHeight": 525,
-        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
-      }
-    ]
-  },
-  {
-    "title": "Rafi - Exploring Side Projects and AI",
-    "slug": "rafi-exploring-side-projects-and-ai",
-    "id": "1919",
-    "metaDescription": "Season Eight, Episode Eight of the Virtual Coffee Podcast",
-    "season": 8,
-    "episode": 8,
-    "buzzsproutId": "13331830",
-    "publishDate": "2023-08-02T04:00:00+00:00",
-    "shortDescription": "<p>Join Bekah and Dan in this week's episode,  where they talk with Rafi, a full-stack engineer who develops his passion and motivation with side projects.  Rafi highlights the importance of focusing on developing side projects using a time limit and completing tasks. Learn Rafi's approach to using AI as a tool in his toolbox to accelerate the development process.</p>",
-    "showNotes": "<p>Join hosts Bekah and Dan in this episode featuring Rafi, a talented full-stack developer from Bangalore. In this episode, you'll discover how building new things  and making progress helps him find calmness and focus. Learn Rafi's approach to side projects, including his exploration of Blender, mobile development, Chrome extensions, and Ionic framework. Rafi also shares valuable tips on leveraging AI to enhance learning during project work</p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe.png",
-    "guests": [
-      {
-        "name": "Rafi",
-        "bio": "<p>I am a developer, hobbyist who loves JavaScript, Star trek and Cats. I build things, talk tech and write things.</p>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Rafi.png"
-      }
-    ],
-    "sponsors": [
-      {
-        "title": "LevelUP Financial planning",
-        "url": "https://www.levelupfinancialplanning.com/?vc",
-        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
-        "logoWidth": 679,
-        "logoHeight": 525,
-        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
-      }
-    ]
-  },
-  {
-    "title": "Ayu & Dominic - Hacktoberfest is Coming, Preptember is Here!",
-    "slug": "ayu-dominic-hacktoberfest-is-coming-preptember-is-here",
-    "id": "1940",
-    "metaDescription": "Season 9, Episode 1 of the Virtual Coffee Podcast",
-    "season": 9,
-    "episode": 1,
-    "buzzsproutId": "13611744",
-    "publishDate": "2023-09-18T04:00:00+00:00",
-    "shortDescription": "<p><span>Join hosts Bekah and Dan in this episode featuring Dominic and Ayu as we explore Preptember—the month where we prepare for Hacktoberfest—and the importance of taking the month to prepare, learn more about open source projects, and evaluate open source repositories to recommend to contributors.</span></p>",
-    "showNotes": "<p>Join hosts Bekah and Dan in this episode with monthly challenge Preptember leads, Dominic and Ayu. We talk about the importance of preparing both as a contributor and a maintainer,  some of the challenges you might face as someone new to those roles during Hacktoberfest, and some of the benefits you'll receive by participating in open source.</p><h3>Links</h3><ul><li><p><a href=\"https://virtualcoffee.io/podcast/0303-ayu-adiati\">Ayu's Episode: Working through burnout as a self-taught developer</a></p></li><li><p><a class=\"postlist-title\" href=\"https://virtualcoffee.io/podcast/dominic-duffin-finding-value-in-challenging-ourselves\">Dominic's Episode: Finding value in challenging ourselves</a></p></li><li><p><a href=\"https://github.com/issues\">Your GitHub Issues</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0901-ayu-dominic.png",
-    "guests": [
-      {
-        "name": "Dominic Duffin",
-        "bio": "<p>Dominic is a Full Stack Developer, community builder, remote worker and aspiring polymath. He's passionate about open source everything, decentralization, peer-to-peer tech and cryptocurrency. He's also to be found playing board games, studying paper maps and riding public transport.</p>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0707-dominic.png"
-      },
-      {
-        "name": "Ayu Adiati",
-        "bio": "<p>Ayu is a self-taught front-end developer and technical blogger based in The Netherlands.</p><p class=\"text-left\">She has a strong interest in building projects that are accessible to everyone.</p><p class=\"text-left\">Her passion for life-long learning is what motivates her open-source contributions, project collaboration, and community engagement.</p><p class=\"text-left\">Learning new things is something that fills her with excitement and she's eager to share her learning in public and pass on her knowledge through her blog and Twitter.</p>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0303-ayu.jpg"
-      }
-    ],
-    "sponsors": [
-      {
-        "title": "LevelUP Financial planning",
-        "url": "https://www.levelupfinancialplanning.com/?vc",
-        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
-        "logoWidth": 679,
-        "logoHeight": 525,
-        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
-      }
-    ]
-  },
-  {
-    "title": "OSS Book Review: Nadia Eghbal's Working in Public - The Making and Maintenance of Open Source Software",
-    "slug": "working-in-public-the-making-and-maintenance-of-open-source-software-book-review",
-    "id": "1967",
-    "metaDescription": "Season Nine, Episode Two of the Virtual Coffee Podcast",
-    "season": 9,
-    "episode": 2,
-    "buzzsproutId": "13668999",
-    "publishDate": "2023-09-26T04:00:00+00:00",
-    "shortDescription": "<p><span>Join hosts Bekah and Dan in this episode featuring Jessica Wilkins and Brian Meeker as we delve into the insights from </span>Nadia Eghbal's book \"Working in Public.\" Discover the intricacies of open source collaboration, the evolving dynamics of digital communities, and the profound impact of individual contributions.</p>",
-    "showNotes": "<p>Join hosts Bekah and Dan in this episode with Nadia Eghbal's \"Working in Public\" enthusiasts Jessica Wilkins and Brian Meeker. We discuss the nuances of open source collaboration highlighted in the book, the challenges and rewards of being both a contributor and a maintainer, and the profound impact of individual contributions in the open source community. Dive into the transformative journey of participating in open source and redefining its true meaning with OpenSauced.</p><h3>Links</h3><ul><li><p><a href=\"https://press.stripe.com/working-in-public\">Working in Public: The Making and Maintenance of Open Source Software by Nadia Eghbal</a></p></li><li><p><a href=\"https://github.com/orgs/Virtual-Coffee/discussions/932\">Virtual Coffee Book Club Discussion</a></p></li><li><p><a href=\"https://qz.com/646467/how-one-programmer-broke-the-internet-by-deleting-a-tiny-piece-of-code\">The left-pad story</a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0902.png",
-    "guests": [
-      {
-        "name": "Jessica Wilkins",
-        "bio": "<p>Jessica Wilkins is a self taught developer and technical writer from Los Angeles, California.</p><p class=\"text-left\">In her previous career, she was a professional oboist, educator and owner of JDW Sheet Music.</p><p class=\"text-left\">Jessica's interest in programming came during the pandemic when she wanted to build the Black Excellence Music Project which celebrates black artists from the jazz and classical fields.</p><p class=\"text-left\">She now works for freeCodeCamp on the curriculum team.</p><ul><li><p class=\"text-left\"><a href=\"https://github.com/jdwilkin4\"><u>@jdwilkin4 on GitHub</u></a></p></li><li><p class=\"text-left\"><a href=\"https://twitter.com/codergirl1991?lang=en\"><u>@codergirl1991 on Twitter</u></a></p></li><li><p class=\"text-left\"><a href=\"https://www.linkedin.com/in/jessica-wilkins-developer\"><u>@jessica-wilkins-developer on LinkedIn</u></a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0407-jessica.jpg"
-      },
-      {
-        "name": "Brian Meeker",
-        "bio": "<p>Brian Meeker is a full stack engineer who occasionally leaves his basement in Indiana. Currently, he works as a Senior Engineer at Online Rewards. He works mostly in Elixir these days, but has a past littered with a wide variety of technologies and platforms. Outside of work, Brian is a devoted father, avid nerd, and lover of metal.</p><ul><li><p><a href=\"https://brianmeeker.me/\"><u>brianmeeker.me</u></a></p></li><li><p><a href=\"https://github.com/CuriousCurmudgeon\"><span>@CuriousCurmudgeon on GitHub</span></a></p></li><li><p><a href=\"https://twitter.com/CuriousCurmudge\">@CuriousCurmudge on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/brianmeeker\">@brianmeeker on LinkedIn</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/headshot_cropped.png"
-      }
-    ],
-    "sponsors": [
-      {
-        "title": "LevelUP Financial planning",
-        "url": "https://www.levelupfinancialplanning.com/?vc",
-        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
-        "logoWidth": 679,
-        "logoHeight": 525,
-        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
-      }
-    ]
-  },
-  {
-    "title": "Open Source Licenses with Matt McInnis, Tom Cudd, and Ray Deck",
-    "slug": "open-source-licenses-with-matt-mcinnis-tom-cudd-and-ray-deck",
-    "id": "2044",
-    "metaDescription": "Season 9, Episode 3 of the Virtual Coffee Podcast",
-    "season": 9,
-    "episode": 3,
-    "buzzsproutId": "13757456",
-    "publishDate": "2023-10-11T04:00:00+00:00",
-    "shortDescription": "<p>Join hosts Bekah and Dan in this special episode where we sit down with Matt McInnis, Ray Deck, and Tom Cudd to explore the often overlooked but crucial topic of open source licenses. We'll discuss the nuances of choosing the right license for your project, the implications it has for contributors and maintainers, and the scenarios where leaving the license blank might actually be a strategic move.</p>",
-    "showNotes": "<p>Join hosts Bekah and Dan with guests Matt McInnis, Ray Deck, and Tom Cudd, as they chat about the complicated topic of open source software (OSS) licenses. They share insights into how to choose the appropriate license, how to understand licenses on other projects, and general guidelines for maintainers and contributors.</p><h3>Links:</h3><ul><li><p><a href=\"http://ChooseALicense.com\"><u>ChooseALicense.com</u></a> by GitHub</p></li><li><p>Example of clarifying subfolders in the LICENSE: <a href=\"https://github.com/tensorflow/models/blob/master/LICENSE\" rel=\"noopener noreferrer\" target=\"_blank\"><u>TensorFlow’s </u></a><code>models</code><a href=\"https://github.com/tensorflow/models/blob/master/LICENSE\" rel=\"noopener noreferrer\" target=\"_blank\"><u> repo</u></a>.</p></li><li><p>Example of a License section in the README indicating what parts of the repo the license applies to: <a href=\"https://github.com/openai/whisper/blob/e8622f9afc4eba139bf796c210f5c01081000472/README.md\" rel=\"noopener noreferrer\" target=\"_blank\"><u>OpenAI’s Whisper model</u></a>. “Whisper’s code and model weights are released under the MIT License.”</p></li><li><p>Example of a paid product with an open source license: <a href=\"https://github.com/craftcms/craft/blob/main/LICENSE.md\" rel=\"noopener noreferrer\" target=\"_blank\"><u>CraftCMS</u></a></p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0903.png",
-    "guests": [
-      {
-        "name": "Matt McInnis",
-        "bio": "<p>Full-stack developer (Rails+React) at Typist based in Toronto, Canada. Former artificial intelligence lead at IBM and Microsoft, mathematics professor at Centennial College and Saskatchewan Polytechnic. I really love brunch.</p><ul><li><p><a href=\"https://github.com/MattyMc\">@MattyMc on GitHub</a></p></li><li><p><a href=\"https://twitter.com/MattLovesMath\">@MattLovesMath on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/mattmcinnis\">mattmcinnis on LinkedIn</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/1581513771937-1.jpeg"
-      },
-      {
-        "name": "Tom Cudd",
-        "bio": "<p>As an advocate for DevOps within teams and communities, I strive to bring positive change in the way Development and Operations teams work together. I love to help people learn about teams, leadership, infrastructure, cloud, and automation.</p><ul><li><p><a href=\"https://tomcudd.com\">tomcudd.com</a></p></li><li><p><a href=\"https://github.com/tomcudd\">@tomcudd on GitHub</a></p></li><li><p><a href=\"https://twitter.com/tomcudd\">@tomcudd on Twitter</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/dZU1npoqScZd494fteFw.jpg"
-      },
-      {
-        "name": "Ray Deck",
-        "bio": "<p>Veteran leader of technology teams and startup companies over the last 20 years. Most recently founder of <a href=\"http://Statechange.ai\">Statechange.ai</a>, a learning community for solving the hardest 5% of no-code/low-code/AI-code challenges.</p><ul><li><p><a href=\"https://raydeck.com\">raydeck.com</a></p></li><li><p><a href=\"https://statechange.ai\">statechange.ai</a></p></li><li><p><a href=\"https://github.com/rhdeck\">@rhdeck on GitHub</a></p></li><li><p><a href=\"https://twitter.com/ray_deck\">@ray_deck on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/raydeck\">raydeck on LinkedIn</a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/2016-11-27-11.25.20-1.jpg"
-      }
-    ],
-    "sponsors": [
-      {
-        "title": "LevelUP Financial planning",
-        "url": "https://www.levelupfinancialplanning.com/?vc",
-        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
-        "logoWidth": 679,
-        "logoHeight": 525,
-        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
-      }
-    ]
-  },
-  {
-    "title": "Jessica Wilkins - Using Open Source to Create Connections",
-    "slug": "jessica-wilkins-using-open-source-to-create-connections",
-    "id": "2105",
-    "metaDescription": "Season 9, Episode 4 of the Virtual Coffee Podcast",
-    "season": 9,
-    "episode": 4,
-    "buzzsproutId": "13897541",
-    "publishDate": "2023-11-02T04:00:00+00:00",
-    "shortDescription": "<p>Join hosts Bekah and Dan in this enlightening episode with Jessica Wilkins. Dive deep into the art of nurturing relationships in the open source community. Learn the intricacies of collaborating with maintainers, the value of non-traditional skillsets, and the journey of personal growth as a contributor. </p>",
-    "showNotes": "<p>Join hosts Bekah and Dan as they engage in a captivating conversation with Jessica Wilkins, a prominent figure from freeCodeCamp. In this episode, Jessica shares her invaluable insights on nurturing and developing relationships within the open source community. Delve into the nuances of effective collaboration with maintainers, understand the significance of embracing non-traditional skillsets, and discover the pathways to flourish as a contributor. Jessica's experiences with freeCodeCamp provide a unique perspective on the human dynamics and interpersonal relationships that form the backbone of successful open source projects.</p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0904-jessica.png",
-    "guests": [
-      {
-        "name": "Jessica Wilkins",
-        "bio": "<p>Jessica Wilkins is a self taught developer and technical writer from Los Angeles, California.</p><p class=\"text-left\">In her previous career, she was a professional oboist, educator and owner of JDW Sheet Music.</p><p class=\"text-left\">Jessica's interest in programming came during the pandemic when she wanted to build the Black Excellence Music Project which celebrates black artists from the jazz and classical fields.</p><p class=\"text-left\">She now works for freeCodeCamp on the curriculum team.</p><ul><li><p class=\"text-left\"><a href=\"https://github.com/jdwilkin4\"><u>@jdwilkin4 on GitHub</u></a></p></li><li><p class=\"text-left\"><a href=\"https://twitter.com/codergirl1991?lang=en\"><u>@codergirl1991 on Twitter</u></a></p></li><li><p class=\"text-left\"><a href=\"https://www.linkedin.com/in/jessica-wilkins-developer\"><u>@jessica-wilkins-developer on LinkedIn</u></a></p></li></ul>",
-        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0904-jessica.png"
-      }
-    ],
-    "sponsors": [
-      {
-        "title": "LevelUP Financial planning",
-        "url": "https://www.levelupfinancialplanning.com/?vc",
-        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
-        "logoWidth": 679,
-        "logoHeight": 525,
-        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
-      }
-    ]
-  },
-  {
-    "title": "Remote Collaboration Tools and Techniques",
-    "slug": "remote-collaboration-tools-and-techniques",
-    "id": "2142",
-    "metaDescription": "Season 10, Episode 1 of the Virtual Coffee Podcast",
-    "season": 10,
-    "episode": 1,
-    "buzzsproutId": "15727596",
-    "publishDate": "2024-09-10T04:00:00+00:00",
-    "shortDescription": "<p><span>In the first episode of Season 10 of the Virtual Coffee Podcast, hosts Bekah and Dan introduce the new format focusing on </span>\"back pocket topics\" from Virtual Coffee <span>community discussions, beginning with a discussion on tools and techniques for remote collaboration.</span></p>",
-    "showNotes": "<p><span>In the first episode of Season 10 of the Virtual Coffee podcast, hosts Bekah and Dan introduce the new format focusing on \"back pocket topics\" from Virtual Coffee community discussions. They delve into common remote collaboration tools and techniques, sharing insights from their experiences in tech. Topics include effective communication, the importance of documentation, and how different company cultures influence remote work. The episode also touches on the role of community members in improving knowledge sharing, both in work settings and open-source projects.</span></p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E01.png",
-    "guests": [],
-    "sponsors": [
-      {
-        "title": "LevelUP Financial planning",
-        "url": "https://www.levelupfinancialplanning.com/?vc",
-        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
-        "logoWidth": 679,
-        "logoHeight": 525,
-        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
-      }
-    ]
-  },
-  {
-    "title": "How to Build Trust Capital",
-    "slug": "how-to-build-trust-capital",
-    "id": "2146",
-    "metaDescription": "Season 10, Episode 2 of the Virtual Coffee Podcast",
-    "season": 10,
-    "episode": 1,
-    "buzzsproutId": "15762421",
-    "publishDate": "2024-09-16T04:00:00+00:00",
-    "shortDescription": "<p>Bekah and Dan discuss the concept of 'trust capital' and its importance in tech communities.</p>",
-    "showNotes": "<p><span>In Episode 2 of Season 10 of the Virtual Coffee podcast, hosts Bekah and Dan discuss the concept of 'trust capital' and its importance in tech communities. They define trust capital as the value and trustworthiness one has with others. The hosts explore how to build trust through consistent actions, showing up, transparency, and effective communication. They highlight the difference between networking and building genuine relationships, emphasizing practical ways to accumulate trust capital, such as writing blog posts, mentoring, and being an active, dependable community member. The episode underscores the benefits of trust capital in fostering credibility, enhancing professional relationships, and reducing barriers to collaborative progress.</span></p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E02.png",
-    "guests": [],
-    "sponsors": [
-      {
-        "title": "LevelUP Financial planning",
-        "url": "https://www.levelupfinancialplanning.com/?vc",
-        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
-        "logoWidth": 679,
-        "logoHeight": 525,
-        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
-      }
-    ]
-  },
-  {
-    "title": "'Big M' versus 'Little m' Mentorship",
-    "slug": "big-m-versus-little-m-mentorship",
-    "id": "2154",
-    "metaDescription": "Season 10, Episode 3 of the Virtual Coffee Podcast",
-    "season": 10,
-    "episode": 3,
-    "buzzsproutId": "15809647",
-    "publishDate": "2024-09-24T04:00:00+00:00",
-    "shortDescription": "<p><span>Bekah and Dan discuss the differences between formal and informal mentorship, sharing insights on how community and personal connections play a role in effective mentorship.</span></p>",
-    "showNotes": "<p><span>In Season 10, Episode 3 of the Virtual Coffee Podcast, hosts Bekah and Dan explore the topic of 'Big M' versus 'Little m' Mentorship. They distinguish between formal, one-on-one mentorship ('Big M') and more informal, community-based mentorship ('Little M'). They discuss the advantages and potential pitfalls of each approach, emphasizing the importance of finding the right mentorship fit. They also touch on the role of coaches, the value of community support in events like Hacktoberfest, and the concept of a personal 'board of mentors.' </span></p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E03.png",
-    "guests": [],
-    "sponsors": [
-      {
-        "title": "LevelUP Financial planning",
-        "url": "https://www.levelupfinancialplanning.com/?vc",
-        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
-        "logoWidth": 679,
-        "logoHeight": 525,
-        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
-      }
-    ]
-  },
-  {
-    "title": "How to Make a Positive Impact during Hacktoberfest",
-    "slug": "how-to-make-a-positive-impact-during-hacktoberfest",
-    "id": "2161",
-    "metaDescription": "Season 10, Episode 4 of the Virtual Coffee Podcast",
-    "season": 10,
-    "episode": 4,
-    "buzzsproutId": "15841150",
-    "publishDate": "2024-09-30T04:00:00+00:00",
-    "shortDescription": "<p>Welcome to Hacktoberfest!</p>",
-    "showNotes": "<p>Bekah and Dan explore the community's engagement with Hacktoberfest, a month-long event encouraging open source contributions. They discuss what Hacktoberfest is and what it means to be a positive contributor in the open source community. They highlight the importance of meaningful contributions, respecting maintainers' time, and provides tips for navigating and contributing to open source projects, and touches on ways to be a good open source citizen and the benefits of contributing consistently to a single project or organization. The episode emphasizes understanding project documentation and being patient with maintainers, while exploring various ways to support open source initiatives beyond writing code.</p><ul><li><p><code>00:00</code> Welcome to the Virtual Coffee Podcast</p></li><li><p><code>00:25</code> Introduction to Hacktoberfest</p></li><li><p><code>00:45</code> Sponsorship Shoutout</p></li><li><p><code>01:08</code> Getting Started with Hacktoberfest</p></li><li><p><code>02:01</code> The Origins of Virtual Coffee and Hacktoberfest</p></li><li><p><code>05:01</code> How to Contribute Positively</p></li><li><p><code>13:02</code> The Importance of Documentation</p></li><li><p><code>18:04</code> Non-Code Contributions</p></li><li><p><code>24:02</code> Building Relationships in Open Source</p></li><li><p><code>26:25</code> Closing Remarks and Contact Information</p></li></ul>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E04.png",
-    "guests": [],
-    "sponsors": [
-      {
-        "title": "LevelUP Financial planning",
-        "url": "https://www.levelupfinancialplanning.com/?vc",
-        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
-        "logoWidth": 679,
-        "logoHeight": 525,
-        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
-      }
-    ]
-  },
-  {
-    "title": "Open Source Maintainer Challenges and Benefits",
-    "slug": "open-source-maintainer-challenges-and-benefits",
-    "id": "2167",
-    "metaDescription": "Season 10, Episode 5 of the Virtual Coffee Podcast",
-    "season": 10,
-    "episode": 5,
-    "buzzsproutId": "15891752",
-    "publishDate": "2024-10-08T04:00:00+00:00",
-    "shortDescription": "<p><span>Bekah and Dan share personal experiences of maintaining open source projects, highlight the benefits of creating a community of contributors, and offer insights into tools and strategies for effective project management and collaboration.</span></p>",
-    "showNotes": "<p>In this episode of the Virtual Coffee Podcast, hosts Bekah and Dan delve into the benefits and challenges of being a maintainer in open source projects, particularly during Hacktoberfest. They discuss the excitement and responsibility of maintaining projects, the joy of welcoming new contributors, and the importance of community building. The hosts also highlight the preparation involved in enhancing project onboarding and documentation, and the growth opportunities for maintainers. The episode also emphasizes strategies to attract contributors and the impact of efficiently managing open source projects.</p><h3>Links:</h3><ul><li><p><a href=\"https://opensauced.pizza/learn\">https://opensauced.pizza/learn</a></p></li><li><p>Becoming an Open Source Maintainer</p></li></ul><p></p><p>00:00 Welcome to Virtual Coffee Podcast</p><p>00:26 Hacktoberfest Excitement and Open Source</p><p>00:43 Sponsorship Shoutout</p><p>01:06 Grab Your Drink and Settle In</p><p>01:34 Maintainer Experiences and Challenges</p><p>03:44 The Joy of Hacktoberfest</p><p>05:08 Maintaining Beyond Hacktoberfest</p><p>08:13 The Importance of Onboarding</p><p>09:29 PrepTember and Readiness</p><p>11:01 Building Trust and Community</p><p>12:18 The Benefits of Being a Maintainer</p><p>17:32 Growing as a Maintainer</p><p>18:40 Marketing Your Open Source Project</p><p>21:06 Community Support and Resources</p><p>23:44 Wrapping Up and Final Thoughts</p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E05.png",
-    "guests": [],
-    "sponsors": [
-      {
-        "title": "LevelUP Financial planning",
-        "url": "https://www.levelupfinancialplanning.com/?vc",
-        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
-        "logoWidth": 679,
-        "logoHeight": 525,
-        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
-      }
-    ]
-  },
-  {
-    "title": "Building Relationships in Open Source",
-    "slug": "building-relationships-in-open-source",
-    "id": "2172",
-    "metaDescription": "Season 10, Episode 6 of the Virtual Coffee Podcast",
-    "season": 10,
-    "episode": 6,
-    "buzzsproutId": "15931952",
-    "publishDate": "2024-10-15T04:00:00+00:00",
-    "shortDescription": "<p>The Virtual Coffee Podcast explores the significance of relationship-building and mentorship in open-source communities during Hacktoberfest, underlining practical advice, effective communication, and providing support to foster a welcoming environment for contributors.</p>",
-    "showNotes": "<p><span>In Season 10, Episode 6 of the Virtual Coffee Podcast, hosts Bekah and Dan explore the multifaceted aspects of building and nurturing relationships within the open source community, particularly during Hacktoberfest. The episode highlights the significance of effective networking, making meaningful connections, and becoming a valued repeat contributor. The hosts provide practical advice for newcomers, stressing the importance of understanding projects, submitting quality pull requests, and contributing beyond code through community management and content creation. Emphasizing mentorship, they discuss how maintainers can aid first-time contributors via comprehensive readme files, contributing guides, and constructive feedback. The importance of communication, relationship-building, and the impact of small gestures like a simple thank you are also covered to foster a supportive and efficient open source community.</span></p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E06.png",
-    "guests": [],
-    "sponsors": [
-      {
-        "title": "LevelUP Financial planning",
-        "url": "https://www.levelupfinancialplanning.com/?vc",
-        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
-        "logoWidth": 679,
-        "logoHeight": 525,
-        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
-      }
-    ]
-  },
-  {
-    "title": "Climbing the Contributor Ladder",
-    "slug": "climbing-the-contributor-ladder",
-    "id": "2175",
-    "metaDescription": "Season 10, Episode 7 of the Virtual Coffee Podcast",
-    "season": 10,
-    "episode": 7,
-    "buzzsproutId": "15975962",
-    "publishDate": "2024-10-23T04:00:00+00:00",
-    "shortDescription": "<p><span>Dan and Bekah discuss strategies for advancing from contributor to maintainer in open source projects by engaging with the community, understanding contribution guidelines, handling issues effectively, and collaborating respectfully.</span></p>",
-    "showNotes": "<p><span>In this episode of the Virtual Coffee Podcast, hosts Bekah Hawrot Weigel and Dan Ott delve into the journey of climbing the contributor ladder in open-source projects. They explore the progression from contributor to maintainer, focusing on the importance of trust-building, consistent contributions, and respectful interactions within the community. Key strategies discussed include engaging with project documentation, reproducing bugs, and effective communication. The episode also highlights how projects like Astro and Nuxt guide contributors and the role of events like Hacktoberfest in encouraging new participation. Real-life examples illustrate how proactive engagement can lead to managing more complex tasks and even job opportunities. Sponsored by Level Up Financial Planning, this insightful episode is a must-listen for anyone looking to make significant strides in the open-source community.</span><br><br><span>Visit <a href=\"https://virtualcoffee.io/resources/developer-resources/open-source\">https://virtualcoffee.io/resources/developer-resources/open-source</a> for additional resources.</span></p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E07.png",
-    "guests": [],
-    "sponsors": [
-      {
-        "title": "LevelUP Financial planning",
-        "url": "https://www.levelupfinancialplanning.com/?vc",
-        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
-        "logoWidth": 679,
-        "logoHeight": 525,
-        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
-      }
-    ]
-  },
-  {
-    "title": "Open Sourcing a Private Repo",
-    "slug": "open-sourcing-a-private-repo",
-    "id": "2178",
-    "metaDescription": "Season 10, Episode 8 of the Virtual Coffee Podcast",
-    "season": 10,
-    "episode": 8,
-    "buzzsproutId": "16019031",
-    "publishDate": "2024-10-30T04:00:00+00:00",
-    "shortDescription": "<p><span>Bekah and Dan discuss the considerations and steps involved in open sourcing a private repository, sharing insights from their own experience with the Virtual Coffee community docs.</span></p>",
-    "showNotes": "<p><span>In Episode 8 of Season 10 of the Virtual Coffee Podcast, hosts Bekah and Dan delve into the intricate process of open sourcing a private repository. Drawing from their experience with Virtual Coffee's community docs, they discuss considerations like verifying the safety of repository content, ensuring appropriate permissions, and maintaining the privacy of sensitive discussions. They also touch on the importance of updating READEMEs, licensing, and providing clear guidelines for new contributors.</span></p>",
-    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E08.png",
-    "guests": [],
-    "sponsors": []
-  }
+	{
+		"title": "Virtual Coffee Podcast Trailer",
+		"slug": "0000-trailer",
+		"id": "271",
+		"metaDescription": "Welcome to the Virtual Coffee Podcast!",
+		"season": 1,
+		"episode": 0,
+		"buzzsproutId": "7119532",
+		"publishDate": "2021-01-04T05:00:00+00:00",
+		"shortDescription": "<p>Welcome to the Virtual Coffee Podcast!</p>",
+		"showNotes": "<p>This is the Virtual Coffee Podcast, hosted by Bekah Hawrot Weigel and Dan Ott. You'll find interviews with members of our community to learn more about their stories, who they are, how they found Virtual Coffee, and how it has influenced their lives as developers. We want to bring everything that's special about Virtual Coffee, the intimacy and the friendships we’ve built, and share that with everyone through the podcast. We’re always growing and learning together as a group, and there’s something really special about being able to do that knowing that you’ll have the full support of the community around you. And that’s what this podcast is about too.</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/virtual-coffee-mug-square.png",
+		"guests": [
+			{
+				"name": "Virtual Coffee IO",
+				"bio": "<ul><li><p><a href=\"https://virtualcoffee.io/podcast\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee Podcast</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/virtual-coffee-mug-square.png"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Nick Taylor: Open Source, Live Streaming, and Structured YOLO",
+		"slug": "0101-nickyt",
+		"id": "284",
+		"metaDescription": "Season One, Episode One of the Virtual Coffee Podcast",
+		"season": 1,
+		"episode": 1,
+		"buzzsproutId": "7238548",
+		"publishDate": "2021-01-11T05:00:00+00:00",
+		"shortDescription": "<p>Dan and Bekah welcome Nick Taylor (Senior Software Engineer at Forem/DEV) to talk about his journey into tech, open source, and the importance of community</p>",
+		"showNotes": "<p>Dan and Bekah welcome Nick Taylor (Senior Software Engineer at Forem/DEV) to talk about his journey into tech, open source, and the importance of community. Nick talks about his journey through University and into tech, how the landscape of tech has changed with increased resources and community, and how his idea of \"structured YOLO\" has lead him to this point in his career. He talks about how his job at Forem and how the pandemic led to his livestreaming, where he tries to make coding as realistic as possible. His hour and a half livestreams focus on one issue, but realistically those issues won't be solved during that time. And that's ok, because coding takes time, and working through issues won't always be a simple solution. His approach to teaching includes learning as you go, which made him an amazing contributor, mentor, and maintainer for the Virtual Coffee Hacktoberfest Initiative. Every conversation with Nick is an interesting one, and this one isn't an exception.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Nick: <a href=\"https://dev.to/nickytonline\" rel=\"noopener noreferrer\" target=\"_blank\">https://dev.to/nickytonline</a></p></li><li><p>Forem: <a href=\"https://www.forem.com/\" rel=\"noopener noreferrer\" target=\"_blank\">https://www.forem.com/</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0101-nickyt-episode.jpg",
+		"guests": [
+			{
+				"name": "Nick Taylor",
+				"bio": "<p>Senior Software Engineer at <a href=\"https://www.forem.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Forem</a>, the software that powers <a href=\"https://dev.to/\" rel=\"noopener noreferrer\" target=\"_blank\">DEV</a>, working on all things Forem.</p><ul><li><p><a href=\"https://iamdeveloper.com/\" rel=\"noopener noreferrer\" target=\"_blank\">iamdeveloper.com</a></p></li><li><p><a href=\"https://livecoding.ca/\" rel=\"noopener noreferrer\" target=\"_blank\">livecoding.ca</a></p></li><li><p><a href=\"https://twitter.com/nickytonline\" rel=\"noopener noreferrer\" target=\"_blank\">twitter.com/nickytonline</a></p></li><li><p><a href=\"https://dev.to/nickytonline\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/nickytonline</a></p></li><li><p><a href=\"https://iamdeveloper.com/hacktoberfest2020\" rel=\"noopener noreferrer\" target=\"_blank\">Getting the Most Out of Open Source</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0101-nickyt.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Marie Antons: From Chef to Tech",
+		"slug": "0102-marieantons",
+		"id": "291",
+		"metaDescription": "Season One, Episode Two of the Virtual Coffee Podcast",
+		"season": 1,
+		"episode": 2,
+		"buzzsproutId": "7323430",
+		"publishDate": "2021-01-18T05:00:00+00:00",
+		"shortDescription": "<p>In this episode, Marie Antons talks with Dan, Bekah, and Kirk about how she went from being a chef to a junior developer.</p>",
+		"showNotes": "<p>In this episode, Marie Antons talks with Dan, Bekah, and Kirk about how she went from being a chef to a junior developer. With more and more developers coming into tech from non-traditional backgrounds, Marie shares her own unique story and how taking her past experience as a chef allowed her to understand coding in her own way. There are ingredients and steps to follow with recipes, and similarly, as you learn to code, you'll find what you need to get your code to work and the process you need to take to get there. She also talks about the challenges of coming into her first job from a bootcamp, and what she wishes she would've known before starting that job.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p><a href=\"https://www.deltavcodeschool.com/\" rel=\"noopener noreferrer\" target=\"_blank\">DeltaV Code School</a></p></li><li><p><a href=\"https://stratafolio.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Stratafolio</a></p></li><li><p><a href=\"https://d3js.org/\" rel=\"noopener noreferrer\" target=\"_blank\">D3 javascript library</a></p></li><li><p><a href=\"https://wattenberger.com/blog/css-percents\" rel=\"noopener noreferrer\" target=\"_blank\">Amy Wattenberger</a> (the blogger Dan couldn't remember!)</p></li><li><p><a href=\"https://twitter.com/MarieAntons\" rel=\"noopener noreferrer\" target=\"_blank\">@MarieAntons</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/marie\" rel=\"noopener noreferrer\" target=\"_blank\">Marie Antons</a> on LinkedIn</p></li><li><p>Kirk: <a href=\"https://twitter.com/tkshillinz\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshillinz</a> on Twitter</p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0102-marie-episode.jpg",
+		"guests": [
+			{
+				"name": "Marie Antons",
+				"bio": "<p>Marie is a C#/.NET developer working for a small start-up called Stratafolio.</p><ul><li><p><a href=\"https://twitter.com/MarieAntons\" rel=\"noopener noreferrer\" target=\"_blank\">@MarieAntons</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/marie\" rel=\"noopener noreferrer\" target=\"_blank\">Marie Antons</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0102-marie.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Tori Crawford: Interviewing — If it's broke, fix it",
+		"slug": "0103-tori-crawford",
+		"id": "298",
+		"metaDescription": "Season One, Episode Three of the Virtual Coffee Podcast",
+		"season": 1,
+		"episode": 3,
+		"buzzsproutId": "7474594",
+		"publishDate": "2021-01-25T05:00:00+00:00",
+		"shortDescription": "<p>In this episode, Dan and Bekah welcome Tori Crawford to talk about her journey through the interview process that included about 53 interviews, 430 applications, and a pandemic offer that ultimately led to her being ghosted by the company.</p>",
+		"showNotes": "<p>In this episode, Dan and Bekah welcome Tori to talk about her journey through the interview process that included about 53 interviews, 430 applications, and a pandemic offer that ultimately led to her being ghosted by the company. She gives her tips and tricks, including recognizing that interviews are a two-way street; you should also be interviewing the companies that are interviewing you. She talks about the problems of technical interviewing, how she's hopeful that the industry can make changes, and how the job she ultimately landed has been a great experience, starting with the interview.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Tori: <a href=\"https://dev.to/torianne02\" rel=\"noopener noreferrer\" target=\"_blank\">DEV</a>, <a href=\"https://twitter.com/_torrborr\" rel=\"noopener noreferrer\" target=\"_blank\">Twitter</a></p></li><li><p>Article Tori wrote detailing her interview journey: <a href=\"https://dev.to/torianne02/444-days-later-tori-hit-the-jackpot-3o4p\" rel=\"noopener noreferrer\" target=\"_blank\">444 Days Later, Tori Hit the Jackpot</a></p></li><li><p>Udemy course mentioned: <a href=\"https://www.udemy.com/course/master-the-coding-interview-data-structures-algorithms/\" rel=\"noopener noreferrer\" target=\"_blank\">Master the Coding Interview: Data Structures + Algorithms</a></p></li><li><p><a href=\"https://flatironschool.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Flatiron School</a></p></li><li><p><a href=\"https://firehydrant.io/\" rel=\"noopener noreferrer\" target=\"_blank\">FireHydrant</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0103-tori-episode.jpg",
+		"guests": [
+			{
+				"name": "Tori Crawford",
+				"bio": "<p>Software Engineer at <a href=\"https://firehydrant.io/\" rel=\"noopener noreferrer\" target=\"_blank\">FireHydrant</a>.</p><ul><li><p><a href=\"https://twitter.com/_torrborr\" rel=\"noopener noreferrer\" target=\"_blank\">@_torrborr</a> on Twitter</p></li><li><p><a href=\"https://dev.to/torianne02\" rel=\"noopener noreferrer\" target=\"_blank\">torianne02</a> on DEV</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0103-tori.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Vic Vijayakumar: Indie Hacking",
+		"slug": "0104-vic-vijayakumar",
+		"id": "305",
+		"metaDescription": "Season One, Episode Four of the Virtual Coffee Podcast",
+		"season": 1,
+		"episode": 4,
+		"buzzsproutId": "7564483",
+		"publishDate": "2021-02-01T05:00:00+00:00",
+		"shortDescription": "<p>In this episode, Vic talks about Indie Hacking and gives us his take on when to ship, what to focus on, and the value of diverse opinions in your community.</p>",
+		"showNotes": "<p>In this episode, Vic talks about Indie Hacking and gives us his take on when to ship, what to focus on, and the value of diverse opinions in your community. He also talks about treating life as a lot of drafts and about building things that you're passionate about as well as things that others find valuable. He cautions against the danger of survivorship bias, recognizing that it's difficult to find a path in indie hacking and that many of the popular voices have worked through challenges and no longer effectively represent how difficult it is to create a product that's successful.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><h5 class=\"text-left\"><strong>Vic:</strong></h5><ul><li><p><a href=\"https://vicvijayakumar.com/\" rel=\"noopener noreferrer\" target=\"_blank\">vicvijayakumar.com</a></p></li><li><p><a href=\"https://twitter.com/vicvijayakumar\" rel=\"noopener noreferrer\" target=\"_blank\">@vicvijayakumar</a> on Twitter</p></li></ul><h5 class=\"text-left\"><strong>Vic's Projects:</strong></h5><ul><li><p><a href=\"https://www.everyoak.com/\" rel=\"noopener noreferrer\" target=\"_blank\">EveryOak</a></p></li><li><p><a href=\"https://meetsweats.com/\" rel=\"noopener noreferrer\" target=\"_blank\">MeetSweats.com</a></p></li><li><p><a href=\"https://dogears.xyz/\" rel=\"noopener noreferrer\" target=\"_blank\">Dog Ears</a></p></li></ul><h5 class=\"text-left\"><strong>Low-Code Tools:</strong></h5><ul><li><p><a href=\"https://carrd.co/\" rel=\"noopener noreferrer\" target=\"_blank\">Carrd</a></p></li><li><p><a href=\"https://zapier.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Zapier</a></p></li><li><p><a href=\"https://airtable.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Airtable</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0104-vic-episode.jpg",
+		"guests": [
+			{
+				"name": "Vic Vijayakumar",
+				"bio": "<p>Principal software engineer at <a href=\"https://www.researchsquare.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Research Square</a>, a preprint platform</p><ul><li><p><a href=\"https://vicvijayakumar.com/\" rel=\"noopener noreferrer\" target=\"_blank\">vicvijayakumar.com</a></p></li><li><p><a href=\"https://twitter.com/vicvijayakumar\" rel=\"noopener noreferrer\" target=\"_blank\">@vicvijayakumar</a> on Twitter</p></li><li><p><a href=\"https://www.everyoak.com/\" rel=\"noopener noreferrer\" target=\"_blank\">EveryOak</a></p></li><li><p><a href=\"https://meetsweats.com/\" rel=\"noopener noreferrer\" target=\"_blank\">MeetSweats.com</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0104-vic.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Cameron Bardell and Rahat Chowdhury: Mental Health & Tech",
+		"slug": "0105-cameron-rahat",
+		"id": "312",
+		"metaDescription": "Season One, Episode Five of the Virtual Coffee Podcast",
+		"season": 1,
+		"episode": 5,
+		"buzzsproutId": "7741411",
+		"publishDate": "2021-02-08T05:00:00+00:00",
+		"shortDescription": "<p>In this episode, Bekah and Dan talk about mental health with Cameron Bardell, an iOS developer in the healthcare industry, and Rahat Chowdhury, a mental health start-up founder.</p>",
+		"showNotes": "<p>In this episode, Bekah and Dan talk about mental health with Cameron Bardell, an iOS developer in the healthcare industry, and Rahat Chowdhury, a mental health start-up founder. We talk about how sometimes building a product to meet our own needs is a great place to start and the importance of prioritizing mental health, especially in a fast-paced industry like tech. We walk through our own experiences, how mental health recovery isn't linear, and how different approaches to mental health technology create support for more people.</p><p class=\"text-left\">If you or someone else is suffering from mental health issues, you aren't alone. Below are some links to help you find resources or to seek help:</p><ul><li><p><a href=\"https://suicidepreventionlifeline.org/\" rel=\"noopener noreferrer\" target=\"_blank\">National Suicide Prevention Lifeline</a> - 1-800-273-8255</p></li><li><p><a href=\"https://www.samhsa.gov/find-help/national-helpline\" rel=\"noopener noreferrer\" target=\"_blank\">SAMHSA’s National Helpline</a> - 1-800-662-HELP (4357)</p></li><li><p><a href=\"https://cmha.ca/\" rel=\"noopener noreferrer\" target=\"_blank\">CMHA National</a></p></li></ul><h4 class=\"text-left\"><strong>Links:</strong></h4><h5 class=\"text-left\"><strong>Cameron:</strong></h5><ul><li><p><a href=\"https://cambardell.github.io/\" rel=\"noopener noreferrer\" target=\"_blank\">cambardell.github.io</a></p></li><li><p><a href=\"https://twitter.com/cameronbardell\" rel=\"noopener noreferrer\" target=\"_blank\">@cameronbardell</a> on Twitter</p></li></ul><h5 class=\"text-left\"><strong>Rahat:</strong></h5><ul><li><p><a href=\"https://www.rahatcodes.com/\" rel=\"noopener noreferrer\" target=\"_blank\">rahatcodes.com</a></p></li><li><p><a href=\"https://twitter.com/Rahatcodes\" rel=\"noopener noreferrer\" target=\"_blank\">@Rahatcodes</a> on Twitter</p></li><li><p><a href=\"https://whimser.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Whimser</a></p></li><li><p>Open source mental health resources database: <a href=\"https://www.sylarproject.com/\" rel=\"noopener noreferrer\" target=\"_blank\">The Sylar Project</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0105-camrahat-episode.jpg",
+		"guests": [
+			{
+				"name": "Cameron Bardell",
+				"bio": "<p>iOS developer in the healthcare industry</p><ul><li><p><a href=\"https://cambardell.github.io/\" rel=\"noopener noreferrer\" target=\"_blank\">cambardell.github.io</a></p></li><li><p><a href=\"https://twitter.com/cameronbardell\" rel=\"noopener noreferrer\" target=\"_blank\">@cameronbardell</a> on Twitter</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0105-cameron.jpg"
+			},
+			{
+				"name": "Rahat Chowdhury",
+				"bio": "<p>Mental health start-up founder</p><ul><li><p><a href=\"https://www.rahatcodes.com/\" rel=\"noopener noreferrer\" target=\"_blank\">rahatcodes.com</a></p></li><li><p><a href=\"https://twitter.com/Rahatcodes\" rel=\"noopener noreferrer\" target=\"_blank\">@Rahatcodes</a> on Twitter</p></li><li><p><a href=\"https://whimser.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Whimser</a></p></li><li><p><a href=\"https://www.sylarproject.com/\" rel=\"noopener noreferrer\" target=\"_blank\">The Sylar Project</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0105-rahat.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Drew Clements: Building a career and community",
+		"slug": "0106-drew",
+		"id": "329",
+		"metaDescription": "Season One, Episode Six of the Virtual Coffee Podcast",
+		"season": 1,
+		"episode": 6,
+		"buzzsproutId": "7867681",
+		"publishDate": "2021-02-15T05:00:00+00:00",
+		"shortDescription": "<p>In this episode, Bekah and Dan are joined by Drew Clements to talk about the struggles of junior-level job searching, the importance of supportive company culture, and learning in public while building <a href=\"https://protege.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Protege.dev</a>.</p>",
+		"showNotes": "<p>In this episode, we talk to Drew Clements about the challenges junior developers face, learning through building Protege.dev, and the importance of community support. Drew is a career transitioner, father of two, and full-time developer who spends his spare time building Protege.dev, the platform curated with remote jobs for junior developers. We also talk about approaches to problem-solving, when to ask questions, and using live-streaming as an accountability tool.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><h5 class=\"text-left\"><strong>Drew:</strong></h5><ul><li><p><a href=\"https://twitter.com/drewclemcr8\" rel=\"noopener noreferrer\" target=\"_blank\">@drewclemcr8</a> on Twitter</p></li><li><p><a href=\"https://protege.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Protege.dev</a></p></li><li><p><a href=\"https://github.com/drewclem/\" rel=\"noopener noreferrer\" target=\"_blank\">drewclem</a> on GitHub</p></li><li><p><a href=\"https://dev.to/drewclem/\" rel=\"noopener noreferrer\" target=\"_blank\">drewclem</a> on DEV</p></li></ul><h5 class=\"text-left\"><strong>Stu the Rubber Duck!</strong></h5><p class=\"text-left\"></p><img src=\"http://storage.googleapis.com/virtualcoffeeio-assets/images/_podcastShowNotesImage/0106-drew-duck.jpg\" alt=\"Drew holding Stu the Rubber Duck!\" title=\"\">",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0106-drew-episode.jpg",
+		"guests": [
+			{
+				"name": "Drew Clements",
+				"bio": "<p>Frontend Engineer at <a href=\"https://www.fostercommerce.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Foster Commerce</a>, co-founder of <a href=\"https://protege.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Protege.dev</a></p><ul><li><p><a href=\"https://twitter.com/drewclemcr8\" rel=\"noopener noreferrer\" target=\"_blank\">@drewclemcr8</a> on Twitter</p></li><li><p><a href=\"https://protege.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Protege.dev</a></p></li><li><p><a href=\"https://github.com/drewclem/\" rel=\"noopener noreferrer\" target=\"_blank\">drewclem</a> on GitHub</p></li><li><p><a href=\"https://dev.to/drewclem/\" rel=\"noopener noreferrer\" target=\"_blank\">drewclem</a> on DEV</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0106-drew.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Colleen Schnettler -- Tech: It's hard, but it's worth it",
+		"slug": "0107-colleen",
+		"id": "337",
+		"metaDescription": "Season One, Episode Seven of the Virtual Coffee Podcast",
+		"season": 1,
+		"episode": 7,
+		"buzzsproutId": "8007425",
+		"publishDate": "2021-02-22T05:00:00+00:00",
+		"shortDescription": "<p>In this episode, Bekah and Dan are joined by Colleen Schnettler to talk about the challenges women face in the workplace, the benefits of working for yourself, and growing her SaaS business.</p>",
+		"showNotes": "<p>In this episode, we talk to Colleen Schnettler about the challenges of being a woman in the workplace, the benefits of working for yourself, and building her own SaaS business. Colleen is a Ruby on Rails consultant, who recently launched her <a href=\"https://www.simplefileupload.com/\" rel=\"noopener noreferrer\" target=\"_blank\">first product</a>, a career changer, and a mom. Colleen talks about how difficult it is to learn to code; it will take time and commitment, but when you get there, it will all be worth it.</p><h5 class=\"text-left\"><strong>Colleen:</strong></h5><ul><li><p><a href=\"https://twitter.com/leenyburger\" rel=\"noopener noreferrer\" target=\"_blank\">@leenyburger</a> on Twitter</p></li><li><p><a href=\"http://www.bitmappeddesigns.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Bitmapped Designs</a></p></li><li><p><a href=\"https://www.simplefileupload.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Simple File Upload</a></p></li><li><p><a href=\"https://twitter.com/softwaresocpod\" rel=\"noopener noreferrer\" target=\"_blank\">@softwaresocpod</a> - Software Social Podcast</p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0107-colleen-episode.jpg",
+		"guests": [
+			{
+				"name": "Colleen Schnettler",
+				"bio": "<p>Ruby on Rails consultant at <a href=\"http://www.bitmappeddesigns.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Bitmapped Designs</a>.</p><ul><li><p><a href=\"https://twitter.com/leenyburger\" rel=\"noopener noreferrer\" target=\"_blank\">@leenyburger</a> on Twitter</p></li><li><p><a href=\"http://www.bitmappeddesigns.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Bitmapped Designs</a></p></li><li><p><a href=\"https://www.simplefileupload.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Simple File Upload</a></p></li><li><p><a href=\"https://twitter.com/softwaresocpod\" rel=\"noopener noreferrer\" target=\"_blank\">@softwaresocpod</a> - Software Social Podcast</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0107-colleen.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Kirk Shillingford: On Making Mistakes, Growth, and the Importance of Community",
+		"slug": "0108-kirk",
+		"id": "344",
+		"metaDescription": "Season One, Episode Eight of the Virtual Coffee Podcast",
+		"season": 1,
+		"episode": 8,
+		"buzzsproutId": "8052553",
+		"publishDate": "2021-03-01T05:00:00+00:00",
+		"shortDescription": "<p>In this episode, Dan and Bekah talk to Kirk Shillingford, a software developer (and Community Maintainer at Virtual Coffee), about the importance of making mistakes and the growth that comes with it.</p>",
+		"showNotes": "<p>In this episode, Dan and Bekah talk to Kirk Shillingford, a software developer (and Community Maintainer at Virtual Coffee), who has been \"haphazardly writing code for about seven years,\" about the importance of making mistakes and the growth that comes with it. We also talk about empathy being a key indicator of a senior developer and the importance of having a supportive community.</p><h5 class=\"text-left\"><strong>Links:</strong></h5><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://twitter.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Neverwinter_Nights\" rel=\"noopener noreferrer\" target=\"_blank\">Never Winter Nights</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0108-kirk-episode.jpg",
+		"guests": [
+			{
+				"name": "Kirk Shillingford",
+				"bio": "<p>Software Developer, and Community Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://twitter.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0108-kirk.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Dan and Bekah: Season One Wrap-Up",
+		"slug": "0109-bekah-dan",
+		"id": "353",
+		"metaDescription": "Season One, Episode Nine of the Virtual Coffee Podcast",
+		"season": 1,
+		"episode": 9,
+		"buzzsproutId": "8096247",
+		"publishDate": "2021-03-07T05:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah switch things up. Since it's last episode of season one, they share a bit about their origin stories, when their paths connected, and how that led to where Virtual Coffee is today.</p>",
+		"showNotes": "<p>In this episode of the podcast, Dan and Bekah switch things up. Since it's last episode of season one, they share a bit about their origin stories, when their paths connected, and how that led to where Virtual Coffee is today. They talk about the challenges of the last year, how Virtual Coffee has been a light during dark times, and how growing can be painful, but also the process that allows you to become more than you could've imagined. And they also drop some of their favorite Virtual Coffee moments of the last year.</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0109-bekahdan-episode.jpg",
+		"guests": [
+			{
+				"name": "Bekah Hawrot Weigel",
+				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dev.to/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/bekahhw</a></p></li><li><p><a href=\"https://twitter.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">@bekahhw</a> on Twitter</p></li><li><p><a href=\"https://www.instagram.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">bekahhw</a> on Instagram</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0109-bekah.jpg"
+			},
+			{
+				"name": "Dan Ott",
+				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dtott.com/\" rel=\"noopener noreferrer\" target=\"_blank\">dtott.com</a></p></li><li><p><a href=\"https://twitter.com/danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">@danieltott</a> on Twitter</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0109-dan.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Gant Laborde: Finding your Voice",
+		"slug": "0201-gant",
+		"id": "370",
+		"metaDescription": "Season Two, Episode One of the Virtual Coffee Podcast",
+		"season": 2,
+		"episode": 1,
+		"buzzsproutId": "8281596",
+		"publishDate": "2021-04-06T04:00:00+00:00",
+		"shortDescription": "<p>We're back! In this episode of the Virtual Coffee podcast, Dan and Bekah talk to Gant Laborde, an owner of Infinite Red, mentor, adjunct professor, published author, and award-winning speaker, about overcoming challenges, being authentic, and finding your voice.</p>",
+		"showNotes": "<p>In this episode of the Virtual Coffee podcast, Dan and Bekah talk to Gant Laborde, an owner of Infinite Red, mentor, adjunct professor, published author, and award-winning speaker, about overcoming challenges, being authentic, and finding your voice. They share some of the struggles they've faced, talk about how practice can lead to growth, and the importance of recognizing your body's signals in the process.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Gant: <a href=\"https://gantlaborde.com/\" rel=\"noopener noreferrer\" target=\"_blank\">gantlaborde.com</a>, <a href=\"https://twitter.com/GantLaborde\" rel=\"noopener noreferrer\" target=\"_blank\">@GantLaborde</a></p></li><li><p>Some blog posts about public speaking by Gant:</p><ul><li><p><a href=\"https://gantlaborde.medium.com/open-your-speech-and-make-it-marvelous-e031cfa18858\" rel=\"noopener noreferrer\" target=\"_blank\">Open your speech, and make it marvelous</a></p></li><li><p><a href=\"https://medium.com/hackernoon/5-conference-speaking-tips-from-tech-gurus-2f7d1a250af3\" rel=\"noopener noreferrer\" target=\"_blank\">5 Conference Speaking Tips from Tech Gurus</a></p></li><li><p><a href=\"https://shift.infinite.red/the-road-to-distinguished-c9e458da091c\" rel=\"noopener noreferrer\" target=\"_blank\">The Road to Distinguished: From Afraid to Awarded — The path to public speaking success</a></p></li></ul></li><li><p><a href=\"https://cryptozombies.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Cryptozombies</a></p></li><li><p><a href=\"https://geddski.teachable.com/p/flexbox-zombies\" rel=\"noopener noreferrer\" target=\"_blank\">Flexbox zombies</a></p></li><li><p><a href=\"https://infinite.red/\" rel=\"noopener noreferrer\" target=\"_blank\">Infinite Red</a></p></li><li><p><a href=\"https://www.toastmasters.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Toastmasters</a></p></li><li><p><a href=\"https://www.amazon.com/gp/product/1492090794/ref=as_li_qf_asin_il_tl?ie=UTF8&amp;tag=gant0d-20&amp;creative=9325&amp;linkCode=as2&amp;creativeASIN=1492090794&amp;linkId=9b7b356b7b13efdaf9d34bfa47f7a6ee\" rel=\"noopener noreferrer\" target=\"_blank\">Learning TensorFlow.js: Powerful Machine Learning in JavaScript by Gant Laborde</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0201-gant-episode.jpg",
+		"guests": [
+			{
+				"name": "Gant Laborde",
+				"bio": "<p>Gant Laborde is an owner of Infinite Red, mentor, adjunct professor, published author, and award-winning speaker. For 20 years, he has been involved in software development and continues strong today. He is recognized as a Google Developer Expert in Web and Machine Learning, but informally he is an “open sourcerer” and aspires to one day become a mad scientist. He blogs, videos, and maintains popular repositories for the community. Follow Gant’s adventures at <a href=\"https://gantlaborde.com/\" rel=\"noopener noreferrer\" target=\"_blank\">gantlaborde.com</a>.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0201-gant.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Lucia Cerchie: Mom life and finding your confidence",
+		"slug": "0202-lucia",
+		"id": "377",
+		"metaDescription": "Season Two, Episode Two of the Virtual Coffee Podcast",
+		"season": 2,
+		"episode": 2,
+		"buzzsproutId": "8315337",
+		"publishDate": "2021-04-11T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk with Lucia Cercie, a Software Engineer, about the importance of having a growth-mindset, asking questions, and pair programming.</p>",
+		"showNotes": "<p>In this episode of the podcast, Dan and Bekah talk with Lucia Cercie, a Software Engineer at <a href=\"https://stepzen.com/\" rel=\"noopener noreferrer\" target=\"_blank\">StepZen</a>, mom, and Arizona transplant, about the importance of having a growth-mindset, asking questions, and pair programming. We also talk about the power of community and feeling comfortable asking questions and asking for help. When she's not coding, Lucia likes to make her baby laugh.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Lucia: <a href=\"https://luciacerchie.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">luciacerchie.dev</a>, <a href=\"https://twitter.com/CerchieLucia\" rel=\"noopener noreferrer\" target=\"_blank\">@CerchieLucia</a> on Twitter, <a href=\"https://dev.to/cerchie\" rel=\"noopener noreferrer\" target=\"_blank\">cerchi</a> on DEV</p></li><li><p><a href=\"https://stepzen.com/\" rel=\"noopener noreferrer\" target=\"_blank\">StepZen</a></p></li><li><p><a href=\"https://hbr.org/2016/01/what-having-a-growth-mindset-actually-means\" rel=\"noopener noreferrer\" target=\"_blank\"><em>What Having a “Growth Mindset” Actually Means</em></a><a href=\"https://hbr.org/2016/01/what-having-a-growth-mindset-actually-means\" rel=\"noopener noreferrer\" target=\"_blank\"> </a>by Carol Dweck</p></li><li><p><a href=\"https://martinfowler.com/articles/on-pair-programming.html\" rel=\"noopener noreferrer\" target=\"_blank\"><em>On Pair Programming</em></a> by Martin Fowler</p></li><li><p><a href=\"https://www.youtube.com/watch?v=u8qgehH3kEQ\" rel=\"noopener noreferrer\" target=\"_blank\">NCIS \"pair programming\"</a></p></li><li><p><a href=\"https://lindastone.net/2014/11/24/are-you-breathing-do-you-have-email-apnea/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Are You Breathing? Do You Have Email Apnea?</em></a> by Linda Stone</p></li><li><p><a href=\"https://oisinmoran.com/quinetweet\" rel=\"noopener noreferrer\" target=\"_blank\"><em>How I Made a Self-Quoting Tweet</em></a><a href=\"https://oisinmoran.com/quinetweet\" rel=\"noopener noreferrer\" target=\"_blank\"> </a>by Oisín Moran</p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0202-lucia-episode.jpg",
+		"guests": [
+			{
+				"name": "Lucia Cerchie",
+				"bio": "<p>Lucia Cerchie is a software engineer from Phoenix, AZ. She spends a lot of time orbiting outside her comfort zone and when she's not coding, she likes to make her baby laugh.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0202-lucia.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Glen McCallum: From IC to Engineering Manager, and the lessons learned along the way",
+		"slug": "0203-glen",
+		"id": "384",
+		"metaDescription": "Season Two, Episode Three of the Virtual Coffee Podcast",
+		"season": 2,
+		"episode": 3,
+		"buzzsproutId": "8370318",
+		"publishDate": "2021-04-20T04:00:00+00:00",
+		"shortDescription": "<p>In this episode, Dan and Bekah talk to Glen McCallum, a Software engineer and manager from Victoria, Canada, about his unexpected career journey, the hard decisions he's had to make, and using open-source software with his artificial pancreas.</p>",
+		"showNotes": "<p>In this episode, Dan and Bekah talk to Glen McCallum, a Software engineer from Victoria, Canada who manages a team of 8 engineers for the 2nd largest independent book distributor in the US, about his unexpected career journey, the hard decisions he's had to make, and using open-source software with his artificial pancreas. Glen also talks about his near-death experience in his first IT job and the decision to move from Independent Contributor to Management.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Glen: <a href=\"https://glenmccallum.com/\" rel=\"noopener noreferrer\" target=\"_blank\">glenmccallum.com</a>, <a href=\"https://twitter.com/glenmccallumcan\" rel=\"noopener noreferrer\" target=\"_blank\">@glenmccallumcan</a> on Twitter,</p></li><li><p>Glen's Lightning Talk: <a href=\"https://youtu.be/2hIBz5Ogi3o\" rel=\"noopener noreferrer\" target=\"_blank\">From independent contributor to engineering manager</a></p></li><li><p><a href=\"https://www.healthline.com/health/diabetesmine/innovation/we-are-not-waiting#About-the-#WeAreNotWaiting-Movement\" rel=\"noopener noreferrer\" target=\"_blank\">We are not waiting movement</a></p></li><li><p><a href=\"https://openaps.org/\" rel=\"noopener noreferrer\" target=\"_blank\">OpenAPS</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0203-glen-episode.jpg",
+		"guests": [
+			{
+				"name": "Glen McCallum",
+				"bio": "<p>Glen McCallum is a Software engineer from Victoria, Canada. For the past 7 years he's been doing backend development in C# and SQL. Earlier, he did projects in Java and Rails. He's always learning, currently exploring big data with hadoop, python, and spark. Day-to-day he manages a team of 8 engineers for the 2nd largest independent book distributor in the United States.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0203-glen.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Debra-Kaye Elliott: The Self-Taught Developer Journey",
+		"slug": "0204-debra-kaye",
+		"id": "391",
+		"metaDescription": "Season Two, Episode Four of the Virtual Coffee Podcast",
+		"season": 2,
+		"episode": 4,
+		"buzzsproutId": "8413543",
+		"publishDate": "2021-04-27T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, we talk to Debra-Kaye Elliott about what it's like to be on the self-taught developer journey, imposter syndrome, and some of the key things she's learned along the way.</p>",
+		"showNotes": "<p>In this episode of the podcast, we talk to Debra-Kaye Elliott, a self-taught frontend developer making her way through Frontend Masters Web Development Bootcamp, about what it's like to be on the self-taught developer journey, how she navigates imposter syndrome, and the lessons she's learned a long the way. She talks about the impact of being able to learn with support, choosing the resources that work best for you, and how blogging has been a part of her journey.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Debra-Kaye: <a href=\"https://twitter.com/debrakayelliott\" rel=\"noopener noreferrer\" target=\"_blank\">@debrakayelliott</a> on Twitter, <a href=\"https://www.linkedin.com/in/debrakayeelliott\" rel=\"noopener noreferrer\" target=\"_blank\">@debrakayeelliott</a> on LinkedIn, and <a href=\"https://dev.to/debrakayeelliott\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/debrakayeelliott</a>.</p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0204-debra-kaye-episode.jpg",
+		"guests": [
+			{
+				"name": "Debra-Kaye Elliott",
+				"bio": "<p>Debra-Kaye Elliott is a Front End Developer going through a bootcamp, who's adding community-learning to her learning process. She's a career changer from the administrative field and always wanted to be in tech.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0204-debra-kaye.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Tom Cudd - Psychological Safety and DevOps",
+		"slug": "0205-tom-cudd",
+		"id": "399",
+		"metaDescription": "Season Two, Episode Five of the Virtual Coffee Podcast",
+		"season": 2,
+		"episode": 5,
+		"buzzsproutId": "8456725",
+		"publishDate": "2021-05-04T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, we talk to Tom Cudd about his experiences with DevOps, the importance of building psychological safety in to your team building and workflows.</p>",
+		"showNotes": "<p>In this episode of the podcast, we talk to Tom Cudd, a systems architect and 20-year veteran in technology. We talked about his experiences with DevOps and how it has changed over the years, about psychological safety: what it means to Tom, and how important it is to build in to your team and workflows, and about the dangers of \"hero culture\" in the workplace.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Tom Cudd: <a href=\"https://twitter.com/tomcudd\" rel=\"noopener noreferrer\" target=\"_blank\">@tomcudd</a> on Twitter, <a href=\"https://tomcudd.com/\" rel=\"noopener noreferrer\" target=\"_blank\">tomcudd.com</a></p></li></ul><h5 class=\"text-left\"><strong>Mentioned in the Episode:</strong></h5><ul><li><p><a href=\"https://www.goodreads.com/book/show/17255186-the-phoenix-project\" rel=\"noopener noreferrer\" target=\"_blank\">The Phoenix Project</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/44333183-the-unicorn-project\" rel=\"noopener noreferrer\" target=\"_blank\">the Unicorn Project</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/18167218-lean-enterprise\" rel=\"noopener noreferrer\" target=\"_blank\">Lean Enterprise</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/35747076-accelerate\" rel=\"noopener noreferrer\" target=\"_blank\">Accelerate</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/29939161-radical-candor\" rel=\"noopener noreferrer\" target=\"_blank\">Radical Candor</a></p></li><li><p><a href=\"https://softwaresocial.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Software Social Podcast</a></p></li><li><p><a href=\"https://www.manager-tools.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Manager Tools</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0205-tomcudd-episode.jpg",
+		"guests": [
+			{
+				"name": "Tom Cudd",
+				"bio": "<p>Tom Cudd is a Systems Architect and a reformed Systems Administrator for an ad agency in the Kansas City area. He has been employed in technology for nearly 20 years, but has been using computers and the internet for most of his life. Tom is a huge fan of DevOps, lean processes, learning mindsets, and empathy with action. He also rabidly follows Husker football and the Chiefs.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0205-tomcudd.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Courtney Landau - On being quiet in a loud tech world",
+		"slug": "0206-courtney-landau",
+		"id": "406",
+		"metaDescription": "Season Two, Episode Six of the Virtual Coffee Podcast",
+		"season": 2,
+		"episode": 6,
+		"buzzsproutId": "8499055",
+		"publishDate": "2021-05-11T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, we talk to Courtney Landau about how the trend of constant self-marketing in tech has impacted her career, her experience as a developer, and what's it's been like to take on a variety of roles as a Virtual Coffee contributor.</p>",
+		"showNotes": "<p>In this episode of the podcast, we talk to Courtney Landau, a software engineer currently working at an early-stage startup in the Education Technology space. We talked about her experience with being quiet in tech with the constant push for self-marketing and how she learns new things. We also dive into her experience as a mentor, speaker, lightning talk team member, and the other roles she's played as part of Virtual Coffee.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Courtney Landau: <a href=\"https://twitter.com/sosuperc\" rel=\"noopener noreferrer\" target=\"_blank\">@sosuperc</a> on Twitter, <a href=\"http://www.celandau.com/\" rel=\"noopener noreferrer\" target=\"_blank\">celandau.com</a></p></li></ul><h5 class=\"text-left\"><strong>Mentioned in the Episode:</strong></h5><ul><li><p><a href=\"https://twitter.com/sosuperc/status/1372529647947288588?s=20\" rel=\"noopener noreferrer\" target=\"_blank\">Quiet & soft-spoken =/= inexperienced.</a></p></li><li><p>Courtney's Lightning Talk from 2021: <a href=\"https://www.youtube.com/watch?v=ghFNiCMy67M\" rel=\"noopener noreferrer\" target=\"_blank\">Breaking down coding problems in interviews</a></p></li><li><p><a href=\"https://chrome.google.com/webstore/detail/learnics-teacher-link/nhdacjmkhimeohpnahfmdmcknaneeffk\" rel=\"noopener noreferrer\" target=\"_blank\">Learnics Teacher Link Chrome Extension</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0206-courtney-episode.jpg",
+		"guests": [
+			{
+				"name": "Courtney Landau",
+				"bio": "<p>Courtney is a software engineer currently working at an early-stage startup in the Education Technology space. Previously in the medical imaging field, she’s been working in the industry since 2019 after obtaining her Master’s in Information Sciences. She works on full-stack web applications using primarily TypeScript and JavaScript, built on a cloud platform. For fun she likes to run, play board games with her family, and patronize local independent restaurants and breweries.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0206-courtney.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Nerando Johnson - Keeping Momentum, Community, and Socialization as a Service",
+		"slug": "0207-nerando-johnson",
+		"id": "413",
+		"metaDescription": "Season Two, Episode Seven of the Virtual Coffee Podcast",
+		"season": 2,
+		"episode": 7,
+		"buzzsproutId": "8542053",
+		"publishDate": "2021-05-18T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast we talk to Nerando Johnson, a full stack developer, about running freeCodeCamp meetups in Atlanta, learning through hackathons, and how his next endeavor should be socialization as a service for tech events.</p>",
+		"showNotes": "<p>In this episode of the podcast, Dan and Bekah talk with Nerando Johnson, a full stack developer looking for his next job, about running freeCodeCamp meetups in Atlanta, learning through hackathons (including that one time his team won the hackathon and donated the $40,000 in winnings to charity) and how his next endeavor should be socialization as a service for tech events. We also talk about the importance of having a solid support system and we laugh...a lot.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Nerando Johnson: <a href=\"https://twitter.com/nerajno\" rel=\"noopener noreferrer\" target=\"_blank\">@nerajno</a> on Twitter, <a href=\"https://dev.to/nerajno/\" rel=\"noopener noreferrer\" target=\"_blank\">nerajno</a> on DEV, <a href=\"https://github.com/Nerajno\" rel=\"noopener noreferrer\" target=\"_blank\">Nerajno</a> on GitHub</p></li></ul><h5 class=\"text-left\"><strong>Mentioned in the Episode:</strong></h5><ul><li><p><a href=\"https://www.itsmarta.com/marta-hackathon.aspx\" rel=\"noopener noreferrer\" target=\"_blank\">MARTA Hackathon</a></p></li><li><p>freeCodeCamp Atlanta - <a href=\"https://www.facebook.com/groups/free.code.camp.atlanta/\" rel=\"noopener noreferrer\" target=\"_blank\">Facebook</a> - <a href=\"https://study-group-directory.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Find your FCC Meetup</a>:</p></li><li><p>Reactadelphia - <a href=\"https://twitter.com/reactadelphia\" rel=\"noopener noreferrer\" target=\"_blank\">@reactadelphia</a></p></li><li><p><a href=\"https://connect.tech/\" rel=\"noopener noreferrer\" target=\"_blank\">Connect.Tech</a></p></li><li><p><a href=\"https://twitter.com/garyvee\" rel=\"noopener noreferrer\" target=\"_blank\">Gary Vee</a></p></li><li><p><a href=\"https://twitter.com/xirclebox\" rel=\"noopener noreferrer\" target=\"_blank\">Homer Gaines</a></p></li><li><p><a href=\"https://twitter.com/techieEliot\" rel=\"noopener noreferrer\" target=\"_blank\">Eliot Sanford</a></p></li><li><p><a href=\"https://twitter.com/DThompsonDev\" rel=\"noopener noreferrer\" target=\"_blank\">Danny Thompson</a></p></li><li><p><a href=\"https://twitter.com/Career_Karma\" rel=\"noopener noreferrer\" target=\"_blank\">Career Karma</a></p></li><li><p><a href=\"https://www.jim-butcher.com/books/Dresden\" rel=\"noopener noreferrer\" target=\"_blank\">Dresden Files</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/27213329-grit\" rel=\"noopener noreferrer\" target=\"_blank\">Grit: The Power of Passion and Perseverance</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0207-nerando-episode.jpg",
+		"guests": [
+			{
+				"name": "Nerando Johnson",
+				"bio": "<p>This is Nerando, he likes to use programming to solve problems, (Yup, he is a developer). Nerando has been a community organizer for <a href=\"https://www.facebook.com/groups/free.code.camp.atlanta/\" rel=\"noopener noreferrer\" target=\"_blank\">freeCodeCamp Atlanta</a> for over the last two years. He has been to a <a href=\"https://medium.com/paratransit-pal/paratransit-pal-won-40-000-at-at-ts-atlanta-civic-coding-challenge-and-gave-it-all-to-charity-30bba157d92d\" rel=\"noopener noreferrer\" target=\"_blank\">few hackathons</a> and is <a href=\"https://dev.to/nerajno\" rel=\"noopener noreferrer\" target=\"_blank\">an infrequent blogger</a>. When not coding, Nerando enjoys coding cooking, reading, the act of creating something from nothing and consuming the odd blog or podcast about the human mind (<a href=\"https://www.npr.org/programs/\" rel=\"noopener noreferrer\" target=\"_blank\">Hi, NPR</a>).</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0207-nerando.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Sara McCombs - Learning to leverage your past experience and embrace your whole self",
+		"slug": "0208-sara-mccombs",
+		"id": "420",
+		"metaDescription": "Season Two, Episode Eight of the Virtual Coffee Podcast",
+		"season": 2,
+		"episode": 8,
+		"buzzsproutId": "8584928",
+		"publishDate": "2021-05-25T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast we talk to Sara McCombs, a software engineer, team lead, and Community Maintainer at Virtual Coffee, about how to leverage your past experience, talk about transferable skills, and owning your wins as an early career developer.</p>",
+		"showNotes": "<p>In this episode of the podcast, Dan and Bekah talk with Sara McCombs. Sara is a software engineer and team lead at <a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a>, and also one of the original organizers, and a current Community Maintainer, at Virtual Coffee. Sara shared her thoughts on how to think and talk about transferable skills, leveraging past experience to differentiate yourself, and the importance of embracing that past experience as part of your journey and strengths. She also talked about the impact of career changes, promotions, and overcoming self-doubt.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Sara McCombs: <a href=\"https://twitter.com/dino_momma\" rel=\"noopener noreferrer\" target=\"_blank\">@dino_momma</a> on Twitter, <a href=\"https://dev.to/saramccombs/\" rel=\"noopener noreferrer\" target=\"_blank\">saramccombs</a> on DEV, <a href=\"https://github.com/saramccombs\" rel=\"noopener noreferrer\" target=\"_blank\">saramccombs</a> on GitHub</p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0208-sara-episode.jpg",
+		"guests": [
+			{
+				"name": "Sara McCombs",
+				"bio": "<p>Sara is a published former research director turned software engineer and team lead at <a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a>, as well as a community engagement leader at <a href=\"https://www.projectalloy.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Project Alloy</a>. She is also one of the original organizers, and a current community maintainer, at <a href=\"https://virtualcoffee.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee</a>. Sara is passionate about diversity and inclusion, and has written frequently about her journey into tech. She has an M.Ag and a B.S.Ag from West Virginia University, and is a 2020 graduate of Flatiron School.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0208-sara.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Season Two Wrap-Up: Code and Community",
+		"slug": "0209-season-two-wrapup",
+		"id": "427",
+		"metaDescription": "Season Two, Episode Nine of the Virtual Coffee Podcast",
+		"season": 2,
+		"episode": 9,
+		"buzzsproutId": "8625475",
+		"publishDate": "2021-06-01T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah wrap up season two by talking about what they've learned about community, supporting members, and trying to find the right tools to make it happen.</p>",
+		"showNotes": "<p>In this episode of the podcast, Dan and Bekah wrap up season two by talking about what they've learned about community building over the last year and some lessons they've learned along the way. They talk about Virtual Coffee's mission to support its members, and how Virtual Coffee's unique approach presents both challenges and opportunities when it comes to finding tools and guidance as the community grows.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p><a href=\"https://magnoliajs.com/\" rel=\"noopener noreferrer\" target=\"_blank\">MagnoliaJS</a></p></li><li><p><a href=\"https://www.radicalcandor.com/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Radical Candor</em></a> by Kim Scott</p></li><li><p><a href=\"https://twitter.com/kldickenson\" rel=\"noopener noreferrer\" target=\"_blank\">Karen Dickinson</a></p></li><li><p><a href=\"https://orbit.love/\" rel=\"noopener noreferrer\" target=\"_blank\">Orbit model</a></p></li><li><p><a href=\"https://twitter.com/MarieAntons\" rel=\"noopener noreferrer\" target=\"_blank\">Marie Antons</a></p></li><li><p><a href=\"https://twitter.com/ray_deck\" rel=\"noopener noreferrer\" target=\"_blank\">Ray Deck</a></p></li><li><p><a href=\"https://twitter.com/CerchieLucia\" rel=\"noopener noreferrer\" target=\"_blank\">Lucia Cerchie</a></p></li><li><p><a href=\"https://twitter.com/CerchieLucia/status/1397937325464723458\" rel=\"noopener noreferrer\" target=\"_blank\">Lucia's tweet about Hacktoberfest</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0209-season-2-wrapup.jpg",
+		"guests": [
+			{
+				"name": "Bekah Hawrot Weigel",
+				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dev.to/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/bekahhw</a></p></li><li><p><a href=\"https://twitter.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">@bekahhw</a> on Twitter</p></li><li><p><a href=\"https://www.instagram.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">bekahhw</a> on Instagram</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0209-bekah.jpg"
+			},
+			{
+				"name": "Dan Ott",
+				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dtott.com/\" rel=\"noopener noreferrer\" target=\"_blank\">dtott.com</a></p></li><li><p><a href=\"https://twitter.com/danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">@danieltott</a> on Twitter</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0209-dan.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Jono Yeong - Digital Gardening and Tim Tams",
+		"slug": "0301-jono-yeong",
+		"id": "444",
+		"metaDescription": "Season Three, Episode One of the Virtual Coffee Podcast",
+		"season": 3,
+		"episode": 1,
+		"buzzsproutId": "8821435",
+		"publishDate": "2021-07-06T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast Bekah and Dan talk to Jono Yeong about digital gardening, learning Elixir, and how he brings learning new things to what he's doing with Rails. And for a bonus, he even walks us through how to do a proper Tim Tam slam.</p>",
+		"showNotes": "<p>In this episode of the podcast Bekah and Dan talk to Jono Yeong, a senior software engineer originally from Australia, but currently based in Seattle, USA, about how digital gardening leaves room for growth, allows you to develop what you enjoy, and is an investment in communication skills. We also talk about learning Elixir, the process he goes through as he's learning something new, and how he brings learning new things to what he's doing with Rails. Bonus: he even walks us through how to do a proper Tim Tam slam.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p><a href=\"https://www.jonathanyeong.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Jono's website</a></p></li><li><p><a href=\"https://www.descript.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Descript</a></p></li><li><p><a href=\"https://maggieappleton.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Maggie Appleton</a></p></li><li><p><a href=\"https://www.jonathanyeong.com/garden/using-github-and-notion-to-organise-side-projects\" rel=\"noopener noreferrer\" target=\"_blank\">Github and notion blogpost</a></p></li><li><p><a href=\"https://twitter.com/VicVijayakumar\" rel=\"noopener noreferrer\" target=\"_blank\">Vic Vijayakumar</a></p></li><li><p><a href=\"https://twitter.com/nickytonline\" rel=\"noopener noreferrer\" target=\"_blank\">NickyT</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=jhXJCqQBz04\" rel=\"noopener noreferrer\" target=\"_blank\">Building a social network for puppies</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=k8hEo4N8Nhs\" rel=\"noopener noreferrer\" target=\"_blank\">TimTams slams</a></p></li><li><p><a href=\"https://www.arnotts.com/products/tim-tam\" rel=\"noopener noreferrer\" target=\"_blank\">TimTams</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0301-jono-episode.jpg",
+		"guests": [
+			{
+				"name": "Jonathan Yeong",
+				"bio": "<p>Jonathan Yeong is a senior developer at Shopify. Being from Australia, he often goes by Jono. A Rubyist at heart, he blogs and produces videos about all things programming. He’s passionate about the human connections in technology. And believes that being part of a community, a mentor, and a teacher is one of the most rewarding things you can do.</p><ul><li><p><a href=\"https://twitter.com/JonoYeong\" rel=\"noopener noreferrer\" target=\"_blank\">Twitter</a></p></li><li><p><a href=\"https://www.jonathanyeong.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Website</a></p></li><li><p><a href=\"https://www.youtube.com/c/jonathanyeong\" rel=\"noopener noreferrer\" target=\"_blank\">YouTube</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0301-jono.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Abbey Perini - Finding Confidence and Opportunities",
+		"slug": "0302-abbey-perini",
+		"id": "451",
+		"metaDescription": "Season Three, Episode Two of the Virtual Coffee Podcast",
+		"season": 3,
+		"episode": 2,
+		"buzzsproutId": "8858957",
+		"publishDate": "2021-07-13T04:00:00+00:00",
+		"shortDescription": "<p>On this episode of the podcast, we talk to Abbey Perini, a full-stack web developer, about the importance of practice, building in public, and sending thank you notes when you're interviewing for your first tech job.</p>",
+		"showNotes": "<p>On this episode of the podcast, we talk to Abbey Perini, a full-stack web developer, about the impact building in public has had on her developer journey, what her experience as a recruiting admin taught her as she sent out 160 applications before landing her dev role, and how rehearsing before an interview can make a big impact.</p><h4 class=\"text-left\"><strong>Links mentioned in the episode:</strong></h4><ul><li><p>Github: <a href=\"https://github.com/abbeyperini\" rel=\"noopener noreferrer\" target=\"_blank\">https://github.com/abbeyperini</a></p></li><li><p><a href=\"https://www.indeed.com/career/salaries\" rel=\"noopener noreferrer\" target=\"_blank\">Indeed job rate checker</a></p></li><li><p>Abbey's posts mentioned:</p><ul><li><p><a href=\"https://dev.to/abbeyperini/css-animated-button-with-offset-border-1ibi\" rel=\"noopener noreferrer\" target=\"_blank\">CSS Animated Button with Offset Border</a></p></li><li><p><a href=\"https://javascript.plainenglish.io/react-redux-reload-a-page-when-a-user-makes-a-change-7661a3e1b8ed\" rel=\"noopener noreferrer\" target=\"_blank\">Sheba Counter: How To Reload a Page Whenever a User Makes a Change with React/Redux</a></p></li><li><p><a href=\"https://dev.to/abbeyperini/toggle-dark-mode-in-react-28c9\" rel=\"noopener noreferrer\" target=\"_blank\">Toggle Dark Mode in React</a></p></li><li><p><a href=\"https://dev.to/abbeyperini/knitting-as-programming-3e5\" rel=\"noopener noreferrer\" target=\"_blank\">Knitting as Programming</a></p></li><li><p><a href=\"https://dev.to/abbeyperini/practicing-confidence-for-the-job-search-38nj\" rel=\"noopener noreferrer\" target=\"_blank\">Practicing Confidence for the Job Search</a></p></li></ul></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0302-abbey-episode.jpg",
+		"guests": [
+			{
+				"name": "Abbey Perini",
+				"bio": "<p>Abbey Perini is many things - a metro Atlanta native, a person of many hobbies, and a full-stack web developer. Currently ramping up in her first development role, she loves blogging about stupid Discord bots, animated CSS buttons, and other fun and useful things about programming. You can find her work and ways to connect with her at <a href=\"https://abbeyperini.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">abbeyperini.dev</a>.</p><ul><li><p><a href=\"https://abbeyperini.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">abbeyperini.dev</a></p></li><li><p><a href=\"https://twitter.com/AbbeyPerini\" rel=\"noopener noreferrer\" target=\"_blank\">@AbbeyPerini</a> on Twitter</p></li><li><p><a href=\"https://github.com/abbeyperini\" rel=\"noopener noreferrer\" target=\"_blank\">@abbeyperini</a> on GitHub</p></li><li><p><a href=\"https://dev.to/abbeyperini\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/abbeyperini</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0302-abbey.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Ayu Adiati - Working through burnout as a self-taught developer",
+		"slug": "0303-ayu-adiati",
+		"id": "458",
+		"metaDescription": "Season Three, Episode Three of the Virtual Coffee Podcast",
+		"season": 3,
+		"episode": 3,
+		"buzzsproutId": "8893503",
+		"publishDate": "2021-07-20T04:00:00+00:00",
+		"shortDescription": "<p>In this episode, Dan and Bekah talk to Ayu about the impact of community, being a prolific blogger, and the very real challenge of burnout.</p>",
+		"showNotes": "<p>In this episode, Dan and Bekah talk to Ayu about the impact of community, being a prolific blogger, and the very real challenge of burnout. Ayu's openness about the challenges of being a mom on the self-taught track into tech, isolation, and fears of not being good enough are the stories that we don't share enough of. Because when we share, we can all work through them together. Thank you, Ayu, for reminding us that it's ok to not be ok.</p><h4 class=\"text-left\"><strong>Links mentioned in the episode:</strong></h4><ul><li><p><a href=\"https://community.codenewbie.org/adiatiayu/lesson-learned-massive-burnout-in-learning-web-development-3b5g?signin=true\" rel=\"noopener noreferrer\" target=\"_blank\">Lesson Learned: Massive Burnout In Learning Web Development</a></p></li><li><p><a href=\"https://twitter.com/AdiatiAyu/status/1400833965293019138?s=19\" rel=\"noopener noreferrer\" target=\"_blank\">Ayu's twitter thread about struggling with learning to code</a></p></li><li><p><a href=\"https://www.freecodecamp.org/learn/responsive-web-design/\" rel=\"noopener noreferrer\" target=\"_blank\">Free Code Camp - web responsive design certification</a></p></li><li><p><a href=\"https://community.codenewbie.org/codenewbie/ayu-polyglot-latte-lover-codenewbie-149m\" rel=\"noopener noreferrer\" target=\"_blank\">Ayu's CodeNewbie Community Spotlight</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0303-ayu-episode.jpg",
+		"guests": [
+			{
+				"name": "Ayu Adiati",
+				"bio": "<p>Originally from Indonesia and now based in The Netherlands, Ayu Adiati is a self-taught Frontend Developer & Technical Blogger. She’s on her way to break into tech from being a stay-at-home-mom of now a 4 years old daughter.</p><p class=\"text-left\">When Ayu is not coding, you can find her with the DLSR camera on her hands, cuddling with her daughter, or enjoying her iced macchiato latte.</p><ul><li><p><a href=\"https://virtualcoffee.io/podcast/0303-ayu-adiati/@AdiatiAyu%20(https://twitter.com/AdiatiAyu)\" rel=\"noopener noreferrer\" target=\"_blank\">Twitter</a></p></li><li><p><a href=\"https://adiati.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Blog</a></p></li><li><p><a href=\"https://dev.to/adiatiayu\" rel=\"noopener noreferrer\" target=\"_blank\">DEV</a></p></li><li><p><a href=\"https://community.codenewbie.org/adiatiayu\" rel=\"noopener noreferrer\" target=\"_blank\">CodeNewbie</a></p></li><li><p><a href=\"https://hashnode.com/@ayuadiati\" rel=\"noopener noreferrer\" target=\"_blank\">Hashnode</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0303-ayu.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Joan Marie Verba - Keeping hope through decades of challenges",
+		"slug": "0304-joan-marie-verba",
+		"id": "465",
+		"metaDescription": "Season Three, Episode Four of the Virtual Coffee Podcast",
+		"season": 3,
+		"episode": 4,
+		"buzzsproutId": "8929061",
+		"publishDate": "2021-07-27T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk to Joan Marie Verba about her early days in tech using Fortran, and how refusal to accommodate her allergies has prevented her from having a lifelong career in tech. She talks about pushing forward and not taking no for an answer as she continues her decades-long journey into tech.</p>",
+		"showNotes": "<p>In this episode of the podcast, Dan and Bekah talk to Joan Marie Verba, a web developer, former astronomy teacher, and prolific science fiction writer, about her early days in tech using Fortran, and how refusal to accommodate her allergies has prevented her from having a lifelong career in tech. She shares the story of her recent job offer that actually turned out to be a scam that's being investigated by the FBI. But she's not done searching for her next place in tech. She's pushing past the challenges until she finds that next job.</p><h5 class=\"text-left\"><strong>Links:</strong></h5><ul><li><p><a href=\"https://www.ada.gov/\" rel=\"noopener noreferrer\" target=\"_blank\">Americans with Disabilities Act</a></p></li><li><p>Website: <a href=\"http://joanmarieverba.com/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.com</a></p></li><li><p>Blog: <a href=\"http://joanmarieverba.info/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.info</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/joanmarieverba\" rel=\"noopener noreferrer\" target=\"_blank\">@joanmarieverba</a></p></li><li><p>Web developer portfolio: <a href=\"http://joanmarieverba.co.technology/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.co.technology</a></p></li><li><p>Projects page: <a href=\"http://joanmarieverba.name/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.name</a></p></li><li><p>UX page: <a href=\"http://joanmarieverba.net/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.net</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0304-joan-episode.jpg",
+		"guests": [
+			{
+				"name": "Joan Marie Verba",
+				"bio": "<p>Joan Marie Verba earned a bachelor of physics degree from the University of Minnesota and attended the graduate school of astronomy at Indiana University, where she was an associate instructor of astronomy for one year. She has worked as a computer programmer and as an editor. She currently works as a writer, a publisher, and a web developer.</p><ul><li><p>Website: <a href=\"http://joanmarieverba.com/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.com</a></p></li><li><p>Blog: <a href=\"http://joanmarieverba.info/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.info</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/joanmarieverba\" rel=\"noopener noreferrer\" target=\"_blank\">@joanmarieverba</a></p></li><li><p>Web developer portfolio: <a href=\"http://joanmarieverba.co.technology/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.co.technology</a></p></li><li><p>Projects page: <a href=\"http://joanmarieverba.name/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.name</a></p></li><li><p>UX page: <a href=\"http://joanmarieverba.net/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.net</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0304-joan.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Kevin Truong - Tech Career Coaching",
+		"slug": "0305-kevin-truong",
+		"id": "472",
+		"metaDescription": "Season Three, Episode Five of the Virtual Coffee Podcast",
+		"season": 3,
+		"episode": 5,
+		"buzzsproutId": "8967149",
+		"publishDate": "2021-08-03T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk to Kevin, a senior software consultant at Test Double and a coding career coach at his company Tap into Tech, about his approach to interviewing and how to navigate some of the biggest challenges early-career devs face when trying to break into the industry.</p>",
+		"showNotes": "<p>In this episode of the podcast, Dan and Bekah talk to Kevin, a senior software consultant at Test Double and a coding career coach at his company Tap into Tech, about some of the most common challenges early-career developers face getting into tech and offers practical advice for working through those problems. We dive into visualization, personal support, and ways to change the interview process in tech.</p><h5 class=\"text-left\"><strong>Links:</strong></h5><ul><li><p>Kevin's Twitter: <a href=\"https://twitter.com/TheKevinTruong\" rel=\"noopener noreferrer\" target=\"_blank\">@TheKevinTruong</a></p></li><li><p>Kevin's LinkedIn: <a href=\"https://www.linkedin.com/in/thekevintruong/\" rel=\"noopener noreferrer\" target=\"_blank\">thekevintruong</a></p></li><li><p><a href=\"https://tapintotech.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Tap into Tech</a></p></li><li><p><a href=\"https://testdouble.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Test Double</a></p></li><li><p><a href=\"http://thekevintruong.com/\" rel=\"noopener noreferrer\" target=\"_blank\">thekevintruong.com</a></p></li><li><p><a href=\"https://www.loom.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Loom</a></p></li><li><p><a href=\"https://twitter.com/terribledustin/status/1405903173684850695?s=19\" rel=\"noopener noreferrer\" target=\"_blank\">Dustin McCaffree Upwork/Loom Tweet</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0305-kevin-episode.jpg",
+		"guests": [
+			{
+				"name": "Kevin Truong",
+				"bio": "<p>Kevin Truong is a senior software consultant at Test Double and a coding career coach at his company Tap into Tech. Previously a coding boot camp instructor and mentor, Kevin realized that boot camps were missing a lot of information when it came to the final steps of getting hired. With his years of experience, he has developed a program where he has coached dozens of early career devs on how to improve their results on getting a tech job.</p><ul><li><p>Twitter: <a href=\"https://twitter.com/TheKevinTruong\" rel=\"noopener noreferrer\" target=\"_blank\">@TheKevinTruong</a></p></li><li><p>LinkedIn: <a href=\"https://www.linkedin.com/in/thekevintruong/\" rel=\"noopener noreferrer\" target=\"_blank\">thekevintruong</a></p></li><li><p><a href=\"https://tapintotech.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Tap into Tech</a></p></li><li><p><a href=\"http://thekevintruong.com/\" rel=\"noopener noreferrer\" target=\"_blank\">thekevintruong.com</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0305-kevin.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Ray Deck - Rubber-Ducking your Life",
+		"slug": "0306-ray-deck",
+		"id": "479",
+		"metaDescription": "Season Three, Episode Six of the Virtual Coffee Podcast",
+		"season": 3,
+		"episode": 6,
+		"buzzsproutId": "9007249",
+		"publishDate": "2021-08-10T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk to Ray Deck about rubber ducking your career path, the importance of trust and relationships, and accepting that we're probably wrong more than we're right.</p>",
+		"showNotes": "<p>In this episode, Dan and Bekah talk to Ray Deck, a trained data scientist, occasional angel investor, and software entrepreneur, about finding the right career path through growth, learning, and motivation. We talk about the importance of trust and listening, and Ray drops a bunch of great resources to help everyone find their own path.</p><h5 class=\"text-left\"><strong>Favorite nonfiction books:</strong></h5><ul><li><p>Bekah's pick: <a href=\"https://allisonpataki.com/books/beauty-in-the-broken-places/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Beauty in the Broken Places</em></a><a href=\"https://allisonpataki.com/books/beauty-in-the-broken-places/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Allison Pataki</a></p></li><li><p>Bekah's second pick: <a href=\"https://drgabormate.com/book/scattered-minds/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Scattered Minds</em></a><a href=\"https://drgabormate.com/book/scattered-minds/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Dr. Gabor Maté</a></p></li><li><p>Dan's pick: <a href=\"https://www.hachettebooks.com/titles/lindy-west/shit-actually/9780316449847/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Shit, Actually</em></a><a href=\"https://www.hachettebooks.com/titles/lindy-west/shit-actually/9780316449847/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Lindy West</a></p></li><li><p>Ray's pick: <a href=\"https://www.edwardtufte.com/tufte/books_vdqi\" rel=\"noopener noreferrer\" target=\"_blank\"><em>The Visual Display of Quantitative Information</em></a><a href=\"https://www.edwardtufte.com/tufte/books_vdqi\" rel=\"noopener noreferrer\" target=\"_blank\"> by Edwarde Tufte</a></p></li></ul><h5 class=\"text-left\"><strong>Links to things mentioned in the episode:</strong></h5><ul><li><p><a href=\"https://simonsinek.com/product/start-with-why/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Start With Why</em></a><a href=\"https://simonsinek.com/product/start-with-why/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Simon Sinek</a></p></li><li><p><a href=\"https://www.franklincovey.com/the-7-habits/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>The 7 Habits of Highly Effective People</em></a><a href=\"https://www.franklincovey.com/the-7-habits/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Stephen R. Covey</a></p></li><li><p><a href=\"https://www.amazon.com/8th-Habit-Effectiveness-Greatness-Paperback/dp/B00GOHDKRI/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>The 8th Habit: From Effectiveness to Greatness</em></a><a href=\"https://www.amazon.com/8th-Habit-Effectiveness-Greatness-Paperback/dp/B00GOHDKRI/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Stephen R. Covey</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0306-ray-episode.jpg",
+		"guests": [
+			{
+				"name": "Ray Deck",
+				"bio": "<p>Ray is a trained data scientist, occasional angel investor, and software entrepreneur. His 25-year career spans industries from law to finance. Most recently, Ray is the founder of Sustained Ventures, a software product studio where he also publishes essays on technology and markets.</p><p class=\"text-left\">Ray's thoughts can be followed at <a href=\"https://sustainedventures.com/essays\" rel=\"noopener noreferrer\" target=\"_blank\">sustainedventures.com/essays</a>, and his less-thoughtful self is on Twitter <a href=\"https://twitter.com/ray_deck\" rel=\"noopener noreferrer\" target=\"_blank\">@ray_deck</a>.</p><ul><li><p><a href=\"https://sustainedventures.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Sustained Ventures</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/ray_deck\" rel=\"noopener noreferrer\" target=\"_blank\">@ray_deck</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0306-ray.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Mike Rogers - Tend Your Career like a Garden",
+		"slug": "0307-mike-rogers",
+		"id": "486",
+		"metaDescription": "Season Three, Episode Seven of the Virtual Coffee Podcast",
+		"season": 3,
+		"episode": 7,
+		"buzzsproutId": "9044559",
+		"publishDate": "2021-08-17T04:00:00+00:00",
+		"shortDescription": "<p>In this episode, Dan and Bekah are joined by Mike Rogers, to talk about changing course as a dev, and tending careers like gardens.</p>",
+		"showNotes": "<p>In this episode, Dan and Bekah are joined by Mike Rogers. Mike has had a long and successful career, but at one point he realized he no longer felt good or satisfied with where he was as a developer. He shared with us what he did to change course, and how he has learned to approach tending his career almost like a garden.</p><h5 class=\"text-left\"><strong>Links to things mentioned in the episode:</strong></h5><ul><li><p>Mike's YouTube: <a href=\"https://www.youtube.com/c/MikeRogers0\" rel=\"noopener noreferrer\" target=\"_blank\">MikeRogers0</a></p></li><li><p><a href=\"http://www.slate.com/articles/technology/technology/2012/03/ruby_ruby_on_rails_and__why_the_disappearance_of_one_of_the_world_s_most_beloved_computer_programmers_.html\" rel=\"noopener noreferrer\" target=\"_blank\">Where’s _why?</a> - What happened when one of the world’s most unusual, and beloved, computer programmers disappeared.</p></li><li><p>Meditation Minis podcast: <a href=\"https://www.meditationminis.com/\" rel=\"noopener noreferrer\" target=\"_blank\">meditationminis.com</a></p></li><li><p>Mike's Business Times cover:</p></li><li><p></p><img src=\"https://optimise2.assets-servd.host/virtual-coffee/production/images/0307-mike-bt-cover.jpg?w=378&amp;auto=compress%2Cformat&amp;fit=crop&amp;dm=1648577051&amp;s=3b73d41bc861dfe62cff7d45baac177b\" alt=\"Mike&#039;s cover on the Business Times\" title=\"\"></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0307-mike-episode.jpg",
+		"guests": [
+			{
+				"name": "Mike Rogers",
+				"bio": "<p>Mike Rogers is a Ruby developer from the UK. He made the chat bots for Virtual Coffee, has an awesome Ruby Event Calendar, and loves Docker.</p><ul><li><p><a href=\"https://mikerogers.io/\" rel=\"noopener noreferrer\" target=\"_blank\">mikerogers.io</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/mikerogers0\" rel=\"noopener noreferrer\" target=\"_blank\">mikerogers0</a></p></li><li><p>GitHub: <a href=\"https://github.com/MikeRogers0\" rel=\"noopener noreferrer\" target=\"_blank\">MikeRogers0</a></p></li><li><p>YouTube: <a href=\"https://www.youtube.com/c/MikeRogers0\" rel=\"noopener noreferrer\" target=\"_blank\">MikeRogers0</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0307-mike.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Aurelie Verrot - Learning and Working Remotely",
+		"slug": "0308-aurelie-verrot",
+		"id": "494",
+		"metaDescription": "Season Three, Episode Eight of the Virtual Coffee Podcast",
+		"season": 3,
+		"episode": 8,
+		"buzzsproutId": "9080882",
+		"publishDate": "2021-08-24T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah are joined by Aurelie Verrot to talk about working through bootcamp during the pandemic, remote work, and how to \"just be cool\" when you're dealing with challenges like the pandemic, virtual school, and remote work.</p>",
+		"showNotes": "<p>In this episode, Dan and Bekah talk to Aurelie Verrot, a Software Engineer from the San Francisco Bay Area, who's originally from France, about the importance of relationships in team-building--whether as part of the learning process or in a work environment--and the benefits of being able to work from home. She talks about the importance of clear communication, creating boundaries, and maintaining flexibility as key habits to build.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Twitter: <a href=\"https://twitter.com/LiliVerrot\" rel=\"noopener noreferrer\" target=\"_blank\">LiliVerrot</a></p></li><li><p>GitHub: <a href=\"https://github.com/aurelieverrot\" rel=\"noopener noreferrer\" target=\"_blank\">aurelieverrot</a></p></li><li><p>LinkedIn: <a href=\"https://www.linkedin.com/in/aurelieverrot/\" rel=\"noopener noreferrer\" target=\"_blank\">aurelieverrot</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0308-aurelie-episode.jpg",
+		"guests": [
+			{
+				"name": "Aurelie Verrot",
+				"bio": "<p>Aurelie Verrot is a software engineer from the San Francisco Bay Area, originally from France. After moving to the US and taking care of her children for 4 years, she decided to make a career change in 2019 to work in tech. She started her first dev job in May as a Software Engineer working mostly with Ruby on Rails.</p><ul><li><p>Twitter: <a href=\"https://twitter.com/LiliVerrot\" rel=\"noopener noreferrer\" target=\"_blank\">LiliVerrot</a></p></li><li><p>GitHub: <a href=\"https://github.com/aurelieverrot\" rel=\"noopener noreferrer\" target=\"_blank\">aurelieverrot</a></p></li><li><p>LinkedIn: <a href=\"https://www.linkedin.com/in/aurelieverrot/\" rel=\"noopener noreferrer\" target=\"_blank\">aurelieverrot</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0308-aurelie.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Season 3 Wrap Up: Hacktoberfest is Coming!",
+		"slug": "0309-season-three-wrap-up",
+		"id": "503",
+		"metaDescription": "Season Three, Episode Nine of the Virtual Coffee Podcast",
+		"season": 3,
+		"episode": 9,
+		"buzzsproutId": "9124000",
+		"publishDate": "2021-09-01T04:00:00+00:00",
+		"shortDescription": "<p>Community Maintainer Kirk joins us (again) for our Season 3 wrap up and Hacktoberfest preview!</p>",
+		"showNotes": "<p>Community Maintainer Kirk joins us (again) for our Season 3 wrap up! We review what Virtual Coffee did last year for Hacktoberfest, and talk about a lot of the exciting things we have coming up this year! We also shared some fun things from the last year at Virtual Coffee, like our Virtual Coffee Co-Working Room!</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p><a href=\"https://apps.apple.com/us/app/classic-sudoku/id1488838275\" rel=\"noopener noreferrer\" target=\"_blank\">Classic Sudoku</a></p></li><li><p><a href=\"https://www.youtube.com/channel/UCC-UOdK8-mIjxBQm_ot1T-Q\" rel=\"noopener noreferrer\" target=\"_blank\">Cracking the Cryptic</a></p></li><li><p><a href=\"https://twitter.com/MarieAntons\" rel=\"noopener noreferrer\" target=\"_blank\">@MarieAntons</a></p></li><li><p>Tatiana Mac - <a href=\"https://github.com/selfdefined\" rel=\"noopener noreferrer\" target=\"_blank\">selfdefined</a></p></li><li><p><a href=\"https://github.com/dominicduffin1/Quarto\" rel=\"noopener noreferrer\" target=\"_blank\">Quarto by Dominic Duffin</a></p></li><li><p><a href=\"https://github.com/BekahHW/postpartum-wellness-app\" rel=\"noopener noreferrer\" target=\"_blank\">Bekah's postpartum wellness app</a></p></li><li><p><a href=\"https://github.com/Virtual-Coffee/virtualcoffee.io\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee's GitHub Org</a></p></li><li><p><a href=\"https://hacktoberfest.digitalocean.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Hacktoberfest on Digital Ocean</a></p></li><li><p>shoutout to our Monthly Challenge team: Adam, Andrew, Aurelie, Chris, Courtney, Dominic, Kevin, Luis, Vanessa, and Yolanda!</p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0309-hacktoberfest.jpg",
+		"guests": [
+			{
+				"name": "Kirk Shillingford",
+				"bio": "<p>Software Developer, and Community Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://twitter.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0108-kirk.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Jessi Shakarian - You aren't your tech stack: sharing your passion",
+		"slug": "0401-jessi-shakarian",
+		"id": "510",
+		"metaDescription": "Season Four, Episode One of the Virtual Coffee Podcast",
+		"season": 4,
+		"episode": 1,
+		"buzzsproutId": "9322612",
+		"publishDate": "2021-10-06T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Jessi Shakarian about her journey into UX/UI and how that lead to the big energy she needed to find her place in tech.</p>",
+		"showNotes": "<p>We welcome Jessi Shakarian to the show today to talk about her journey into UX/UI!</p><p class=\"text-left\">Jessi talks about how passion can be your motivation, and how valuable it is to be able to share what you're excited about: you aren't your tech stack. Sometimes finding that passion can lead you to new and interesting places like Jessi's change in focus from web dev to design.</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0401-jessi-episode.png",
+		"guests": [
+			{
+				"name": "Jessi Shakarian",
+				"bio": "<p>Jessi Shakarian got her start in tech as a developer, but also she loved everything that happened before it was time to build a website. She is currently a UX designer at DIA Design Guild in Los Angeles and a python developer interested in machine learning.</p><ul><li><p><a href=\"https://www.jessishakarian.com/\" rel=\"noopener noreferrer\" target=\"_blank\">jessishakarian.com</a></p></li><li><p><a href=\"https://twitter.com/jessishakarian\" rel=\"noopener noreferrer\" target=\"_blank\">@jessishakarian</a> on Twitter</p></li><li><p><a href=\"https://www.polywork.com/jessishakarian\" rel=\"noopener noreferrer\" target=\"_blank\">jessishakarian</a> on PolyWork</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0401-jessi.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Todd Libby - Making the web equal and accessible",
+		"slug": "0402-todd-libby",
+		"id": "517",
+		"metaDescription": "Season Four, Episode Two of the Virtual Coffee Podcast",
+		"season": 4,
+		"episode": 2,
+		"buzzsproutId": "9355176",
+		"publishDate": "2021-10-12T04:00:00+00:00",
+		"shortDescription": "<p>This week on the podcast, we have Todd Libby talking about his work making the web equal and accessible for everyone. He drops a ton of resources (check the show notes!) tips on how to get started, and talks about how he's continually learning on the job.</p>",
+		"showNotes": "<p>We're welcoming Todd Libby to give us an intro to accessibility and what it means to make the web equal. Todd, a professional web developer, designer, and accessibility advocate for 22 years, provides a plethora of resources that can help everyone to get started and talks about how to advocate for accessibility and equality on projects.</p><h3><strong>Show Notes:</strong></h3><h4 class=\"text-left\"><strong>Things/People mentioned in the episode:</strong></h4><ul><li><p><a href=\"https://www.smashingmagazine.com/2021/07/strong-case-for-accessibility/\" rel=\"noopener noreferrer\" target=\"_blank\">Making A Strong Case for Accessibility</a> by Todd Libby</p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Microsoft_FrontPage\" rel=\"noopener noreferrer\" target=\"_blank\">Front Page Express</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Designing_with_Web_Standards\" rel=\"noopener noreferrer\" target=\"_blank\">Designing with Web Standards</a></p></li><li><p><a href=\"https://www.w3.org/WAI/standards-guidelines/wcag/\" rel=\"noopener noreferrer\" target=\"_blank\">Web Content Accessibility Guidelines (WCAG)</a></p></li><li><p><a href=\"https://twitter.com/cassandrafaris\" rel=\"noopener noreferrer\" target=\"_blank\">Cass Faris</a></p></li><li><p><a href=\"https://twitter.com/saltnburnem\" rel=\"noopener noreferrer\" target=\"_blank\">Chris DeMars</a></p></li></ul><h4 class=\"text-left\"><strong>A11y Learning Resources:</strong></h4><ul><li><p><a href=\"https://www.edx.org/course/web-accessibility-introduction\" rel=\"noopener noreferrer\" target=\"_blank\">Introduction to Web Accessibility</a> on edX</p></li><li><p><a href=\"https://webaim.org/\" rel=\"noopener noreferrer\" target=\"_blank\">WebAIM</a></p></li><li><p><a href=\"https://www.tpgi.com/\" rel=\"noopener noreferrer\" target=\"_blank\">TPGi</a></p></li></ul><h4 class=\"text-left\"><strong>Tools:</strong></h4><ul><li><p><a href=\"https://wave.webaim.org/extension/\" rel=\"noopener noreferrer\" target=\"_blank\">WAVE Web Accessibility Evaluation Tool</a></p></li><li><p><a href=\"https://www.deque.com/axe/\" rel=\"noopener noreferrer\" target=\"_blank\">axe accessibility toolkit</a></p></li><li><p><a href=\"https://pa11y.org/\" rel=\"noopener noreferrer\" target=\"_blank\">pa11y command line</a></p></li><li><p><a href=\"https://pauljadam.com/bookmarklets/tables.html\" rel=\"noopener noreferrer\" target=\"_blank\">Bookmarklets by Ian Loyyd and Paul J Adams</a></p></li><li><p><a href=\"https://github.com/microsoft/accessibility-insights-web\" rel=\"noopener noreferrer\" target=\"_blank\">Microsoft a11y insights</a></p></li><li><p><a href=\"https://developer.mozilla.org/en-US/docs/Tools/Accessibility_inspector\" rel=\"noopener noreferrer\" target=\"_blank\">Firefox a11y devtools</a></p></li><li><p><a href=\"https://developers.google.com/web/tools/lighthouse\" rel=\"noopener noreferrer\" target=\"_blank\">Lighthouse automated testing</a></p></li><li><p><a href=\"https://contrast-ratio.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Contrast Ratio tool by Lea Verou</a></p></li><li><p><a href=\"https://www.tpgi.com/color-contrast-checker/\" rel=\"noopener noreferrer\" target=\"_blank\">Colour Contrast Analyser</a></p></li></ul><h4 class=\"text-left\"><strong>Todd's steps for manual testing:</strong></h4><ol start=\"1\"><li><p>Mouse only</p></li><li><p>Keyboard only</p></li><li><p>Squint test</p></li><li><p><a href=\"https://www.afb.org/blindness-and-low-vision/using-technology/assistive-technology-products/screen-readers\" rel=\"noopener noreferrer\" target=\"_blank\">Screen readers</a></p></li><li><p><a href=\"https://webaim.org/articles/voiceover/\" rel=\"noopener noreferrer\" target=\"_blank\">Voice over in Safari</a></p></li><li><p><a href=\"https://www.nvaccess.org/\" rel=\"noopener noreferrer\" target=\"_blank\">NVDA</a> and <a href=\"https://www.freedomscientific.com/products/software/jaws/\" rel=\"noopener noreferrer\" target=\"_blank\">JAWS</a> on Windows</p></li><li><p><a href=\"https://help.gnome.org/users/orca/stable/introduction.html.en\" rel=\"noopener noreferrer\" target=\"_blank\">Orca</a> on Linux</p></li></ol>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0402-todd-episode.jpg",
+		"guests": [
+			{
+				"name": "Todd Libby",
+				"bio": "<p>Todd is a professional web developer, designer, and accessibility advocate for 22 years under many different technologies starting with HTML/CSS, Perl, and PHP, Todd has been an avid learner of web technologies for over 40 years starting with many flavors of BASIC all the way to React/Vue. Todd is also a member of the W3C working with groups on WCAG Silver (3.0). When not coding or advocating accessibility, you'll usually find Todd tweeting about (or eating) lobster rolls and accessibility.</p><ul><li><p><a href=\"https://toddl.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">toddl.dev</a></p></li><li><p><a href=\"https://twitter.com/toddlibby\" rel=\"noopener noreferrer\" target=\"_blank\">@toddlibby</a> on Twitter</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0402-todd.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Jennifer Konikowski - Hot Takes on Being a Woman in Tech",
+		"slug": "0403-jennifer-konikowski",
+		"id": "524",
+		"metaDescription": "Season Four, Episode Three of the Virtual Coffee Podcast",
+		"season": 4,
+		"episode": 3,
+		"buzzsproutId": "9396120",
+		"publishDate": "2021-10-19T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Jennifer Konikowski about building community for women in tech and her own experience as a woman in tech. She gives us some of her hot takes, and we are here for it 🔥</p>",
+		"showNotes": "<p>This week we welcome Jennifer Konikowski to the show to talk about being a woman in tech and building community for women in tech!</p><p class=\"text-left\">Jennifer brings her experience creating communities like <a href=\"http://www.meetup.com/pyladies-boston/\" rel=\"noopener noreferrer\" target=\"_blank\">Py Ladies Boston</a> and <a href=\"https://www.meetup.com/Boston-Ruby-Women/\" rel=\"noopener noreferrer\" target=\"_blank\">Boston Ruby Women</a> to the podcast, and talks about the value of learning to code even if you don't want to be a developer. She also talks about getting through toxic work environments, moving forward, and her hot takes on community and being a woman in tech.</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0403-jennifer-episode.jpg",
+		"guests": [
+			{
+				"name": "Jennifer Konikowski",
+				"bio": "<p>Jennifer has 10 years of experience as a software engineer, working in Ruby and Rails, Go, Swift, Scala, Rust, PHP, Javascript, Java, Perl, and Python. She was the founder and organizer of PyLadies Boston and a founding member of Boston Ruby Women. She currently resides in Pittsburgh and works remotely at Splice. She also really loves Negronis.</p><ul><li><p><a href=\"https://jenniferkonikowski.com/\" rel=\"noopener noreferrer\" target=\"_blank\">jenniferkonikowski.com</a></p></li><li><p><a href=\"https://twitter.com/jenkoni\" rel=\"noopener noreferrer\" target=\"_blank\">@jenkoni</a> on Twitter</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0403-jennifer.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Mark Noonan - Civic tech, accessibility, holding the door open for other career changers",
+		"slug": "0404-mark-noonan",
+		"id": "531",
+		"metaDescription": "Season Four, Episode Four of the Virtual Coffee Podcast",
+		"season": 4,
+		"episode": 4,
+		"buzzsproutId": "9442638",
+		"publishDate": "2021-10-27T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Mark Noonan about how we can make space for career changers through Civic Tech while we make an impact on our communities.</p>",
+		"showNotes": "<p>This week we welcome Mark Noonan to the show to talk about how becoming a part of Civic Tech initiatives can help career changers to grow and help existing developers create opportunities for mentorship, support, and connection for those coming into tech.</p><p class=\"text-left\">Mark talks about his experience with <a href=\"https://www.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">FreeCodeCamp</a> as well as <a href=\"https://www.codeforatlanta.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Code for Atlanta</a>, and the $40,000 Hackathon his group won and donated to charity! He brings his experience as a career transitioner to the conversation and we look at how participating in Civic Tech can help you develop skills to be a better communicator and programmer. And you might hear a little bit about how we prefer our breakfast foods too 🥞</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://www.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">FreeCodeCamp</a></p></li><li><p><a href=\"https://www.codeforatlanta.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Code for Atlanta</a></p></li><li><p><a href=\"https://www.codeforamerica.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Code for America</a></p></li><li><p><a href=\"https://medium.com/paratransit-pal/paratransit-pal-won-40-000-at-at-ts-atlanta-civic-coding-challenge-and-gave-it-all-to-charity-30bba157d92d\" rel=\"noopener noreferrer\" target=\"_blank\">Marta Hackathon</a></p></li><li><p><a href=\"https://brigade.codeforamerica.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Code for America Brigades</a></p></li><li><p><a href=\"http://peoplemakingprogress.org/\" rel=\"noopener noreferrer\" target=\"_blank\">People Making Progress</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0404-mark-episode.jpg",
+		"guests": [
+			{
+				"name": "Mark Noonan",
+				"bio": "<p>Mark is a senior engineer at Cypress.io and is a co-organizer at Code for Atlanta. He also works as a program developer for People Making Progress, an Atlanta-based nonprofit serving adults with developmental disabilities at home, work, and in the community.</p><ul><li><p><a href=\"https://twitter.com/marktnoonan\" rel=\"noopener noreferrer\" target=\"_blank\">@marktnoonan</a> on Twitter</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0404-mark.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Suze Shardlow - Creating welcoming spaces in dev communities",
+		"slug": "0405-suze-shardlow",
+		"id": "540",
+		"metaDescription": "Season Four, Episode Five of the Virtual Coffee Podcast",
+		"season": 4,
+		"episode": 5,
+		"buzzsproutId": "9487228",
+		"publishDate": "2021-11-03T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Suze Shardlow about how she approaches creating welcoming spaces in dev communities.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Suze Shardlow. Suze is an award winning community manager, coder, tech writer and tech event MC and she currently leads the developer community at <a href=\"https://redis.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Redis</a>. We had a really interesting conversation with Suze! She's done a million different things throughout her life and her career and she shared with us how her experiences have informed her time as a software developer and a community leader.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://www.goodreads.com/book/show/56638386-30-second-coding?from_search=true&amp;from_srp=true&amp;qid=kCeXU2k1Tx&amp;rank=1\" rel=\"noopener noreferrer\" target=\"_blank\">30-second-coding</a></p></li><li><p><a href=\"https://twitter.com/SuzeShardlow/status/1445413709891973121?s=20\" rel=\"noopener noreferrer\" target=\"_blank\">On being a published author</a></p></li><li><p><a href=\"https://www.twitch.tv/redislabs\" rel=\"noopener noreferrer\" target=\"_blank\">redislabs on Twitch</a></p></li><li><p><a href=\"https://suze.dev/blog/im-a-techwomen100-2020-winner/\" rel=\"noopener noreferrer\" target=\"_blank\">One of the top 100 women in tech in 2020</a></p></li><li><p><a href=\"https://university.redis.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Redis University</a></p></li><li><p><a href=\"https://hacktoberfest.digitalocean.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Hacktoberfest</a></p></li><li><p><a href=\"https://codelandconf.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Codeland</a></p></li><li><p><a href=\"https://t.co/G0RN3vx2Gd?amp=1\" rel=\"noopener noreferrer\" target=\"_blank\">global diversity CFP day</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0405-suze-episode.jpg",
+		"guests": [
+			{
+				"name": "Suze Shardlow",
+				"bio": "<p>Suze Shardlow is a published tech author, developer community manager and event MC. Before retraining as a software engineer, she worked in marketing and management for 20 years in the engineering, technology, law enforcement, education and economic development sectors. Currently the head of developer community at Redis, Suze has won numerous awards including Rising Star In Tech 2021, TechWomen100 2020, Women In Software Power List 2020 and is a finalist in the Women In Tech Excellence Awards 2021.</p><ul><li><p><a href=\"https://suze.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">suze.dev</a></p></li><li><p><a href=\"https://twitter.com/SuzeShardlow\" rel=\"noopener noreferrer\" target=\"_blank\">@SuzeShardlow</a> on Twitter</p></li><li><p><a href=\"https://github.com/SuzeShardlow\" rel=\"noopener noreferrer\" target=\"_blank\">@SuzeShardlow</a> on GitHub</p></li><li><p><a href=\"https://www.linkedin.com/in/SuzeShardlow\" rel=\"noopener noreferrer\" target=\"_blank\">SuzeShardlow</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0405-suze.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Bryan Healey - The Entrepreneurial Journey of a Startup Founder",
+		"slug": "0406-bryan-healey",
+		"id": "547",
+		"metaDescription": "Season Four, Episode Six of the Virtual Coffee Podcast",
+		"season": 4,
+		"episode": 6,
+		"buzzsproutId": "9522643",
+		"publishDate": "2021-11-10T05:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Bryan Healey about how to kickoff your career as a start-up founder and the lessons he's learned along the way.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Bryan Healey, an entrepreneur, tech leader, data scientist / ML engineer, and biz developer. Bryan talks about gaining experience as an entrepreneur, how to get started in the start-up life, and how the entrepreneurial spirit has always been in his blood.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a></p></li><li><p><a href=\"https://virtualcoffee.io/podcast/0401-jessi-shakarian/\" rel=\"noopener noreferrer\" target=\"_blank\">Jessi's VC Podcast episode</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0406-bryan-episode.jpg",
+		"guests": [
+			{
+				"name": "Bryan Healey",
+				"bio": "<p>Bryan Healey is an entrepreneur, tech leader, data scientist / ML engineer, and biz developer. He's helped create or grow several start-ups, raised money, and built/managed teams of varying sizes, small to large. Currently co-founder and CTO at <a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a>.</p><ul><li><p><a href=\"https://twitter.com/Bryan_Healey\" rel=\"noopener noreferrer\" target=\"_blank\">@Bryan_Healey</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/bryanhealey\" rel=\"noopener noreferrer\" target=\"_blank\">bryanhealey</a> on LinkedIn</p></li><li><p><a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0406-bryan.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Jessica Wilkins - Growing your tech career through writing",
+		"slug": "0407-jessica-wilkins",
+		"id": "554",
+		"metaDescription": "Season Four, Episode Seven of the Virtual Coffee Podcast",
+		"season": 4,
+		"episode": 7,
+		"buzzsproutId": "9566513",
+		"publishDate": "2021-11-17T05:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Jessica Wilkins about how writing can help you to grow your tech career. She gives us tips on getting started and on taking feedback.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Jessica Wilkins, a self-taught developer and a staff author for the freeCodeCamp News publication. Jessica talks about how to get started with tech writing, how to differentiate between constructive criticism and negative feedback, and how to avoid gatekeeping by eliminating assumptions from your writing, avoiding terms and phrases like \"it's so easy!\", and sometimes adding prerequisites to your posts.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://www.esm.rochester.edu/\" rel=\"noopener noreferrer\" target=\"_blank\">Eastman School of Music</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=hD6uRvCtA_0&amp;t=70s\" rel=\"noopener noreferrer\" target=\"_blank\">Jessica's Lunch & Learn: How to grow your tech career through writing</a></p></li><li><p><a href=\"https://www.freecodecamp.org/news/author/jessica-wilkins/\" rel=\"noopener noreferrer\" target=\"_blank\">Freecodecamp news</a></p></li><li><p><a href=\"https://forum.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Freecodecamp forum</a></p></li><li><p><a href=\"https://www.freecodecamp.org/news/author/quincylarson/\" rel=\"noopener noreferrer\" target=\"_blank\">Quincy Larson</a></p></li><li><p><a href=\"https://www.history.com/this-day-in-history/george-floyd-killed-by-police-officer\" rel=\"noopener noreferrer\" target=\"_blank\">George Floyd murder</a></p></li><li><p><a href=\"https://blackexcellencemusicproject.com/\" rel=\"noopener noreferrer\" target=\"_blank\">The Black Excellence Music Project</a></p></li><li><p><a href=\"https://github.com/jdwilkin4/Black_Excellence_Project\" rel=\"noopener noreferrer\" target=\"_blank\">Github for it</a></p></li><li><p><a href=\"https://virtualcoffee.io/monthlychallenges/nov-2021/\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee November Monthly Challenge</a></p></li><li><p><a href=\"https://www.gatsbyjs.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Gatsby</a></p></li><li><p><a href=\"https://www.gatsbyjs.com/blog/gatsby-voices-jessica-wilkins/\" rel=\"noopener noreferrer\" target=\"_blank\">Voices of Gatsby: Fighting Back Against Imposter Syndrome</a></p></li><li><p><a href=\"https://www.freecodecamp.org/news/how-to-use-replit/\" rel=\"noopener noreferrer\" target=\"_blank\">How to Use Repl.it: a beginner's guide</a></p></li><li><p><a href=\"https://www.freecodecamp.org/news/how-to-use-codepen/\" rel=\"noopener noreferrer\" target=\"_blank\">How to Use Codepen: a beginner's guide</a></p></li><li><p><a href=\"https://dev.to/codergirl1991/how-to-create-a-node-bot-that-sends-happy-emails-throughout-the-year-25nj\" rel=\"noopener noreferrer\" target=\"_blank\">NodeMailer</a></p></li></ul><p><br></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0407-jessica-episode.jpg",
+		"guests": [
+			{
+				"name": "Jessica Wilkins",
+				"bio": "<p>Jessica Wilkins is a self taught developer and technical writer from Los Angeles, California.</p><p class=\"text-left\">In her previous career, she was a professional oboist, educator and owner of JDW Sheet Music.</p><p class=\"text-left\">Jessica's interest in programming came during the pandemic when she wanted to build the Black Excellence Music Project which celebrates black artists from the jazz and classical fields.</p><p class=\"text-left\">She now works part-time as a junior developer for a small tech company and is a staff author for the freeCodeCamp News publication.</p><ul><li><p><a href=\"https://dev.to/codergirl1991\" rel=\"noopener noreferrer\" target=\"_blank\">Dev.to profile</a></p></li><li><p><a href=\"https://twitter.com/codergirl1991\" rel=\"noopener noreferrer\" target=\"_blank\">@codergirl1991 on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/jessica-wilkins-developer\" rel=\"noopener noreferrer\" target=\"_blank\">@jessica-wilkins-developer on LinkedIn</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0407-jessica.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Maeling Murphy - Transitioning to tech, and taking notes along the way",
+		"slug": "0408-maeling-murphy",
+		"id": "561",
+		"metaDescription": "Season Four, Episode Eight of the Virtual Coffee Podcast",
+		"season": 4,
+		"episode": 8,
+		"buzzsproutId": "9600325",
+		"publishDate": "2021-11-23T05:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Maeling Murphy about her journey from Material Science and Engineering to Software Engineering, including her personal documentation of her tech journey, work culture, and the big surprises when starting her job.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Dr. Maeling Murphy, a software engineer who recently transitioned into tech. Maeling shared the importance of connecting with potential employers to see if they would fit her values, how contributing to open source projects can help prepare you for your first job, and the value of developing the connection to community and being able to grow alongside others. Oh, and did we mention we talked a lot about Notion? She takes us through her notetaking journey and answers all our questions about finding the right approach.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://cs50.harvard.edu/\" rel=\"noopener noreferrer\" target=\"_blank\">Harvard's CS50</a></p></li><li><p><a href=\"https://www.100daysofcode.com/\" rel=\"noopener noreferrer\" target=\"_blank\">100 days of code</a></p></li><li><p><a href=\"https://virtualcoffee.io/monthlychallenges/july-2021/\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee Demo Monthly Challenge</a></p></li><li><p><a href=\"https://homeschool-journal.herokuapp.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Homeschool journal</a></p></li><li><p><a href=\"https://github.com/maelingmurphy\" rel=\"noopener noreferrer\" target=\"_blank\">Github</a></p></li><li><p><a href=\"https://github.com/maelingmurphy/My-Learning-Path/blob/main/log.md\" rel=\"noopener noreferrer\" target=\"_blank\">Learning Path log</a></p></li><li><p><a href=\"https://www.notion.so/templates/job-applications\" rel=\"noopener noreferrer\" target=\"_blank\">Karen's Notion for job searches</a></p></li><li><p><a href=\"https://docs.google.com/spreadsheets/d/1ZP0u5MjRiCOaYWuLoRTYr4BvB91M76ZCjkCYPuSePJc/edit?usp=sharing\" rel=\"noopener noreferrer\" target=\"_blank\">Karen's Job Application Details Spreadsheet</a></p></li><li><p><a href=\"https://www.notion.so/Thomas-Frank-s-Note-Taking-System-67924a5a25934f0fbe2f154cffcd8f97\" rel=\"noopener noreferrer\" target=\"_blank\">Frank's Notetaking System</a></p></li><li><p><a href=\"https://www.keyvalues.com/\" rel=\"noopener noreferrer\" target=\"_blank\">KeyValues: Find engineering teams that share your values</a></p></li><li><p><a href=\"https://pinboard.in/u:danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">Dan's Pinboard bookmarks</a></p></li><li><p><a href=\"https://github.com/forem/forem\" rel=\"noopener noreferrer\" target=\"_blank\">Forem</a> - Open source project that Nick Taylor helps maintain</p></li></ul><p><br></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0408-maeling-episode.jpg",
+		"guests": [
+			{
+				"name": "Maeling Murphy",
+				"bio": "<p>Dr. Maeling Murphy is a software engineer who recently transitioned into tech, coming from an 8+ year entrepreneurial journey as a digital content creator and as a Ph.D. research scientist in Materials Science & Engineering.</p><p class=\"text-left\">Maeling identifies as a multi-passionate creative soul, finding expression through gardening, programming, brush-lettering and other mediums that cross her path.</p><p class=\"text-left\">She lets her love for exploration, learning and sharing with others lead her in all aspects of life and is enjoying this journey with her husband and son.</p><ul><li><p><a href=\"https://github.com/maelingmurphy\" rel=\"noopener noreferrer\" target=\"_blank\">maelingmurphy</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/maelingcodes\" rel=\"noopener noreferrer\" target=\"_blank\">@maelingcodes on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/maeling-murphy\" rel=\"noopener noreferrer\" target=\"_blank\">@maeling-murphy on LinkedIn</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0408-maeling.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Season 4 Wrap Up - Reviewing the year and celebrating our community",
+		"slug": "0409-season-four-wrapup",
+		"id": "568",
+		"metaDescription": "Season 4 Wrap Up - Reviewing the year and celebrating our community",
+		"season": 4,
+		"episode": 9,
+		"buzzsproutId": "9650635",
+		"publishDate": "2021-12-02T05:00:00+00:00",
+		"shortDescription": "<p>In this final episode of season 4 of the podcast, Bekah and Dan bring back special guest and community maintainer, Kirk Shillingford to retro our Virtual Coffee Hacktoberfest Initiative, talk about our monthly challenges and our excitement of going into year 2 of the challenges, and we even throw in some amazing and/or awful jokes at the end.</p>",
+		"showNotes": "<p>Kirk, Dan, and Bekah are back again to wrap up Season 4 of the podcast. We talk about Hacktoberfest and how proud we are of what our community did over the month of Hacktoberfest:</p><ul><li><p>100 members signed up,</p></li><li><p>66 members merged at least 1 pr,</p></li><li><p>336 collectively we merged 336 PRs were merged by these members across 129 repos.</p></li></ul><p class=\"text-left\">On the <a href=\"https://virtualcoffee.io/\" rel=\"noopener noreferrer\" target=\"_blank\">virtualcoffee.io</a> site: 81 PRs merged, 50 were new member profiles, 31 others.</p><p class=\"text-left\">We talk about the monthly challenges, including already surpassing the monthly goal for blogging half way through <a href=\"https://virtualcoffee.io/monthlychallenges/nov-2021/\" rel=\"noopener noreferrer\" target=\"_blank\">November</a>, and what we're looking forward to doing in the next 12 months.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://hacktoberfest.digitalocean.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Digital Ocean Hacktoberfest</a></p></li><li><p><a href=\"https://virtualcoffee.io/podcast/0406-bryan-healey/\" rel=\"noopener noreferrer\" target=\"_blank\">Bryan's Episode</a></p></li><li><p><a href=\"https://github.com/colabottles/\" rel=\"noopener noreferrer\" target=\"_blank\">Todd Libby</a></p></li><li><p><a href=\"https://github.com/abbeyperini\" rel=\"noopener noreferrer\" target=\"_blank\">Abbey Perini</a></p></li><li><p><a href=\"https://github.com/MattyMc\" rel=\"noopener noreferrer\" target=\"_blank\">Matt McInnis</a></p></li><li><p><a href=\"https://prettier.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Prettier</a></p></li><li><p><a href=\"https://virtualcoffee.io/podcast/0407-jessica-wilkins/\" rel=\"noopener noreferrer\" target=\"_blank\">Jessica's Episode</a></p></li><li><p><a href=\"https://chrisbrogan.com/stories/community/audience-or-community/\" rel=\"noopener noreferrer\" target=\"_blank\">Audience or Community by Chris Brogan</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-episode.jpg",
+		"guests": [
+			{
+				"name": "Kirk Shillingford",
+				"bio": "<p>Software Developer, and Community Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://github.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-kirk.jpg"
+			},
+			{
+				"name": "Bekah Hawrot Weigel",
+				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dev.to/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/bekahhw</a></p></li><li><p><a href=\"https://twitter.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">@bekahhw</a> on Twitter</p></li><li><p><a href=\"https://www.instagram.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">bekahhw</a> on Instagram</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0209-bekah.jpg"
+			},
+			{
+				"name": "Dan Ott",
+				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dtott.com/\" rel=\"noopener noreferrer\" target=\"_blank\">dtott.com</a></p></li><li><p><a href=\"https://twitter.com/danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">@danieltott</a> on Twitter</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-dan.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Brian Rinaldi - Developer Advocacy and Fostering Community",
+		"slug": "0501-brian-rinaldi",
+		"id": "180",
+		"metaDescription": "Season Five, Episode One of the Virtual Coffee Podcast",
+		"season": 5,
+		"episode": 1,
+		"buzzsproutId": "10297519",
+		"publishDate": "2022-03-22T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Brian Rinaldi about doing DevRel (Developer Relations) right and playing to your team's strengths. We also talk about the importance of connection and why we as developers need to support each other.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Brian Rinaldi, a Developer Experience Engineer at LaunchDarkly with over 20 years of experience as a developer for the web, about how Developer Relationships has changed over the years and why need not just remote community experiences but also in-person opportunities. We talk about the value of different types of communities and how each is necessary to support developers.</p><h3>Links</h3><ul><li><p><a href=\"https://launchdarkly.com/\" rel=\"noopener noreferrer\" target=\"_blank\">LaunchDarkly</a></p></li><li><p><a href=\"https://CFE.dev\" rel=\"noopener noreferrer\" target=\"_blank\">CFE.dev</a></p></li><li><p><a href=\"https://thejam.dev\" rel=\"noopener noreferrer\" target=\"_blank\">TheJam.dev</a></p></li><li><p><a href=\"https://www.manning.com/books/the-jamstack-book\" rel=\"noopener noreferrer\" target=\"_blank\">The Jamstack Book</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0501-brian-episode.jpg",
+		"guests": [
+			{
+				"name": "Brian Rinaldi",
+				"bio": "<p>Brian Rinaldi is a Developer Experience Engineer at LaunchDarkly with over 20 years experience as a developer for the web. Brian is actively involved in the community running developer meetups via CFE.dev and Orlando Devs. He's the editor of the Jamstacked newsletter and co-author of The Jamstack Book from Manning.</p><ul><li><p><a href=\"http://remotesynthesis.com\" rel=\"noopener noreferrer\" target=\"_blank\">remotesynthesis.com</a></p></li><li><p><a href=\"https://github.com/remotesynth\" rel=\"noopener noreferrer\" target=\"_blank\">remotesynth</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/remotesynth\" rel=\"noopener noreferrer\" target=\"_blank\">@remotesynth on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/brianrinaldi\" rel=\"noopener noreferrer\" target=\"_blank\">@brianrinaldi on LinkedIn</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0501-brian.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Amy Shackles - Finding a job you love",
+		"slug": "amy-shackles-finding-a-job-you-love",
+		"id": "767",
+		"metaDescription": "Season Five, Episode Two of the Virtual Coffee Podcast",
+		"season": 5,
+		"episode": 2,
+		"buzzsproutId": "10353204",
+		"publishDate": "2022-03-31T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Amy Shackles about the importance of good communication in finding a job you love and defining your career path.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Amy Shackles, a Senior Software Engineer at MURAL, about how she made her way from being a Psychology and Anthropology double major to being a Senior Software Engineer. She shares what’s made her experience at MURAL a great one and the importance of openness in communication.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://amyshackles.com/\" rel=\"noopener noreferrer\" target=\"_blank\">amyshackles.com</a></p></li><li><p><a href=\"https://github.com/AmyShackles/regex_parser\" rel=\"noopener noreferrer\" target=\"_blank\">Amy's regular expression parser</a></p></li><li><p><a href=\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions\" rel=\"noopener noreferrer\" target=\"_blank\">MDN article on regular expressions</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0502-amy-episode.jpg",
+		"guests": [
+			{
+				"name": "Amy Shackles",
+				"bio": "<p>Amy is a Senior Software Engineer currently working at <a href=\"https://mural.co/\" rel=\"noopener noreferrer\" target=\"_blank\">MURAL</a>. She loves information, human interaction, solving problems, helping people, and cats - not in that order. She spends most of her free time lately learning Spanish, practicing calligraphy, singing, writing parody songs, and crocheting.</p><ul><li><p><a href=\"https://amyshackles.com/\" rel=\"noopener noreferrer\" target=\"_blank\">amyshackles.com</a></p></li><li><p><a href=\"https://github.com/AmyShackles\" rel=\"noopener noreferrer\" target=\"_blank\">AmyShackles</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/AmyShackles\" rel=\"noopener noreferrer\" target=\"_blank\">@AmyShackles on Twitter</a></p></li><li><p><a href=\"https://dev.to/amyshackles\" rel=\"noopener noreferrer\" target=\"_blank\">@AmyShackles on DEV.to</a></p></li><li><p><a href=\"https://www.linkedin.com/in/AmyShackles\" rel=\"noopener noreferrer\" target=\"_blank\">@AmyShackles on LinkedIn</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0502-amy.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Helen Griffin - Multi-passionate in tech",
+		"slug": "helen-griffin-multi-passionate-in-tech",
+		"id": "781",
+		"metaDescription": "Season Five, Episode Three of the Virtual Coffee Podcast",
+		"season": 5,
+		"episode": 3,
+		"buzzsproutId": "10397152",
+		"publishDate": "2022-04-07T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Helen Griffin about what she’s learned from her journey going from tech to founder and back to tech again.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Helen Griffin, a full-stack developer and founder, about how the tech industry changed during the time she was a founder, how what she’s learned as a founder has helped her to have a broader perspective about the tech industry, and what she’s doing with her companies Jovial and State of Developers to support developers in their career journeys.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://stateofdevs.com/\" rel=\"noopener noreferrer\" target=\"_blank\">The State of Developers</a></p></li><li><p><a href=\"https://jovial.work/\" rel=\"noopener noreferrer\" target=\"_blank\">Jovial</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0503-helen-episode.jpg",
+		"guests": [
+			{
+				"name": "Helen Griffin",
+				"bio": "<p>Helen started her career as a web developer. Now, as a full-stack dev & founder, she enjoys helping developers build products & a life they love. Today, she spends her time building developer tools, like State of Developers & Jovial. Helen is on a campaign to help her peers recover from burnout.</p><ul><li><p><a href=\"https://helenjr.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">HelenJr.dev</a></p></li><li><p><a href=\"https://github.com/helengriffinjr\" rel=\"noopener noreferrer\" target=\"_blank\">helengriffinjr</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/helengriffinjr\" rel=\"noopener noreferrer\" target=\"_blank\">@helengriffinjr</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/hgriffinjr\" rel=\"noopener noreferrer\" target=\"_blank\">@hgriffinjr</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0503-helen.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Yolanda Haynes - Breaking into Tech: It Takes Time",
+		"slug": "yolanda-haynes-breaking-into-tech-it-takes-time",
+		"id": "790",
+		"metaDescription": "Season Five, Episode Four of the Virtual Coffee Podcast",
+		"season": 5,
+		"episode": 4,
+		"buzzsproutId": "10431216",
+		"publishDate": "2022-04-13T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Yolanda Haynes about her journey into tech and how she created her own path and experiences, including joining Virtual Coffee, 100devs, and Collab Lab.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Yolanda Haynes, a career changer who went from working as a certified occupational therapy assistant to a Software Engineer, about the importance of finding community during your learning journey, and remembering that you shouldn’t judge your journey based on anyone else’s; focus on the learning journey, absorbing what you can, and preparing yourself for your future.</p><h3>Links:</h3><ul><li><p><a href=\"https://leonnoel.com/100devs/\" rel=\"noopener noreferrer\" target=\"_blank\">100devs</a></p></li><li><p><a href=\"https://the-collab-lab.codes/\" rel=\"noopener noreferrer\" target=\"_blank\">The Collab Lab</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0504-yolanda.jpg",
+		"guests": [
+			{
+				"name": "Yolanda Haynes",
+				"bio": "<p>A career changer from working in healthcare as a COTA (certified occupational therapy assistant) to a Software Engineer.</p><ul><li><p><a href=\"https://www.yhaynes.com/\" rel=\"noopener noreferrer\" target=\"_blank\">yhaynes.com</a></p></li><li><p><a href=\"https://github.com/YolandaHaynes\" rel=\"noopener noreferrer\" target=\"_blank\">@YolandaHaynes on GitHub</a></p></li><li><p><a href=\"https://twitter.com/_YolandaHaynes\" rel=\"noopener noreferrer\" target=\"_blank\">@_YolandaHaynes on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/yolanda-haynes/\" rel=\"noopener noreferrer\" target=\"_blank\">@yolanda-haynes on LinkedIn</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Profile.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Roger Gentry - Perseverance and  Problem Solving",
+		"slug": "roger-gentry-perseverance-and-problem-solving",
+		"id": "814",
+		"metaDescription": "Season 5, Episode 5 of the Virtual Coffee Podcast",
+		"season": 5,
+		"episode": 5,
+		"buzzsproutId": "10480828",
+		"publishDate": "2022-04-21T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Roger Gentry about his love of solving problems and how he's brought that with him into tech.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Roger Gentry, who has spent a lot of his career managing security and compliance for clients across the United States, about his passion for problem-solving and what to do when you get stuck. We're all going to run into frustrations during our tech journeys, but knowing how to navigate through them is one of the key skills you'll need.</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0505-roger-episode.jpg",
+		"guests": [
+			{
+				"name": "Roger Gentry",
+				"bio": "<p>Roger has managed the security and compliance for clients across the United States. Providing CTO/CSO level consulting to a variety of industries, Roger has worked with customers to achieve successful compliance certifications from PCI, ISO, SOC, and more.</p><p><a href=\"http://r-o-g-e-r.com/\" rel=\"noopener noreferrer\" target=\"_blank\">http://r-o-g-e-r.com/</a></p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0505-roger.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Special Kirk Day Bonus Episode (Live)",
+		"slug": "special-kirk-day-bonus-episode",
+		"id": "825",
+		"metaDescription": "Happy Kirk Day!",
+		"season": 5,
+		"episode": 999,
+		"buzzsproutId": "10509803",
+		"publishDate": "2022-04-26T04:00:00+00:00",
+		"shortDescription": "<p>A special live episode of the Virtual Coffee Podcast - Bekah and Dan meet for the first time in real life, and get to hang out with Kirk on Kirk Day!</p>",
+		"showNotes": "<p>A special live episode of the Virtual Coffee Podcast - Bekah and Dan meet for the first time in real life, and get to hang out with Kirk on Kirk Day! Also Dan fires Bekah (for the first time).</p><p><a href=\"https://youtu.be/uh-oA8czBVo\">Watch the stream on YouTube!</a></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/05-bonus-kirk-day.jpg",
+		"guests": [],
+		"sponsors": []
+	},
+	{
+		"title": "Andrew Bush - Mobile Development and Giving Back to Community",
+		"slug": "andrew-bush-mobile-development-and-giving-back-to-community",
+		"id": "828",
+		"metaDescription": "Season 5, Episode 6 of the Virtual Coffee Podcast",
+		"season": 5,
+		"episode": 6,
+		"buzzsproutId": "10565670",
+		"publishDate": "2022-05-05T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Andrew Bush about his experiences with mobile development, and his thoughts on community and what it means to give back.</p>",
+		"showNotes": "<p>In today's episode, Dan and Bekah talk to Andrew Bush, a Mobile Engineer Specializing in React Native. One of the updates we've made to our site is to have tags on our <a href=\"https://virtualcoffee.io/members\">members page</a> to indicate what volunteer roles they have. Andrew is one of our Monthly Challenge team leads, and he shared with us his experiences helping to facilitate the challenges, keeping our community motivated, and the processes we go through. We also go into what it's like to be a mobile developer, and the learning path he's been on throughout his career.</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0506-andrew-episode.jpg",
+		"guests": [
+			{
+				"name": "Andrew Bush",
+				"bio": "<p>Andrew is a mobile developer specializing in React Native based out of Wisconsin in the US. He has been developing professionally for 3 years and has really found his passion in mobile apps and accessibility. Being legally blind himself, he recognizes the need for inclusion in software development so that EVERYONE can use the applications we create.</p><p>Outside of his professional life, Andrew is a dedicated amateur runner with a love for the sport that rivals his love of Swedish Fish candy. You can also find him participating as a co-lead of the Virtual Coffee monthly challenges where he strives to create engagement and growth combined with the feeling of an intimate community.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0506-andrew.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Meg Gutshall - Building accountability into Community",
+		"slug": "meg-gutshall-building-accountability-into-community",
+		"id": "840",
+		"metaDescription": "Season 5, Episode 7 of the Virtual Coffee Podcast",
+		"season": 5,
+		"episode": 7,
+		"buzzsproutId": "10613498",
+		"publishDate": "2022-05-13T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk with Meg Gutshall about accountability and how to bring that to your community. She shares some of her memorable experiences with community and she does it all with Philly flair.</p>",
+		"showNotes": "<p>In today's episode, Bekah and Dan talk to Meg Gutshall, a Ruby on Rails Developer, and community volunteer at Virtual Coffee. She shared all things Philly and some memorable stories of how she's supported others--including Bekah--in their journeys into tech. Meg talks about her Accountabilibuddies group at Virtual Coffee and how she chose Ruby after graduating from a full stack bootcamp.</p><p></p><img src=\"http://storage.googleapis.com/virtualcoffeeio-assets/images/_podcastShowNotesImage/gritty.jpg\" alt=\"Gritty, the Fliers Mascot\" title=\"Gritty, the Fliers Mascot\"><p></p><h3>Links</h3><ul><li><p><a href=\"https://en.wikipedia.org/wiki/Gritty\" rel=\"noopener noreferrer\" target=\"_blank\">Gritty</a></p></li><li><p><a href=\"https://freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">freeCodeCamp</a></p></li><li><p><a href=\"https://www.pennmedicine.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Penn medicine</a></p></li><li><p><a href=\"https://www.urbandictionary.com/define.php?term=Jawn\" rel=\"noopener noreferrer\" target=\"_blank\">jawn</a></p></li><li><p>Meg's blog post on code and Spanish: <a href=\"https://meghangutshall.com/2018/07/21/the_little_things_matter/\" rel=\"noopener noreferrer\" target=\"_blank\">The Little Things Matter</a></p></li><li><p><a href=\"https://rubyforgood.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Ruby for Good</a></p></li><li><p><a href=\"https://humanessentials.app/\" rel=\"noopener noreferrer\" target=\"_blank\">HumanEssentials.app</a></p></li><li><p><a href=\"https://nationalcasagal.org/\" rel=\"noopener noreferrer\" target=\"_blank\">CASA</a></p></li><li><p><a href=\"https://2022.phillytechweek.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Philly Tech Week</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0507-meg-episode.jpg",
+		"guests": [
+			{
+				"name": "Meg Gutshall",
+				"bio": "<p>Meg is a Ruby on Rails developer with a passion for open source and tech for good. She's always smiling, continuously learning, and quick to strike up a conversation. She takes her advice with a grain of salt & a shot of tequila.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0507-meg.png"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Matt McInnis - Go Make Stuff!",
+		"slug": "matt-mcinnis-go-make-stuff",
+		"id": "860",
+		"metaDescription": "Season 5, Episode 8 of the Virtual Coffee Podcast",
+		"season": 5,
+		"episode": 8,
+		"buzzsproutId": "10680520",
+		"publishDate": "2022-05-25T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Matt McInnis about his incredible journey through tech from math professor, to self-taught data-scientist working with IBM and Microsoft, to founder.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Matt McInnis a former Math Professor, and current data scientist, full-stack engineer, and founder, about his journey through tech as a self-taught engineer. He shares his insight into building personal projects and creating value in the projects you work on, even if those projects are just for you.</p><h3>Links</h3><ul><li><p><a href=\"https://typistapp.ca/\">Typist</a></p></li><li><p><a href=\"https://www.littlebrown.com/titles/malcolm-gladwell/the-tipping-point/9780759574731/\">Malcolm Gladwell's Tipping Point</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Kidstreet\" rel=\"noopener noreferrer\" target=\"_blank\">Kidstreet</a></p></li><li><p><a href=\"https://www.hackerparadise.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Hacker Paradise</a></p></li><li><p><a href=\"https://ologicinc.com/portfolio/star-wars-science-force-trainer/\" rel=\"noopener noreferrer\" target=\"_blank\">Star Wars Force Trainer</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0508-matt-episode.jpg",
+		"guests": [
+			{
+				"name": "Matt McInnis",
+				"bio": "<p>Matt is a full-stack developer (Rails+React) at <a href=\"https://typistapp.ca/\">Typist</a> based in Toronto, Canada. Former artificial intelligence lead at IBM and Microsoft, mathematics professor at Centennial College and Saskatchewan Polytechnic. Matt really loves brunch.</p><ul><li><p><a href=\"https://github.com/MattyMc\">MattyMc on GitHub</a></p></li><li><p><a href=\"https://twitter.com/MattLovesMath\">MattLovesMath on Twitter</a></p></li><li><p><a href=\"http://linkedin.com/in/mattmcinnis\">mattmcinnis on LinkedIn</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0508-matt.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Season 5 Wrap-Up: Working to Empower the Virtual Coffee Community",
+		"slug": "season-5-wrap-up-working-to-empower-the-virtual-coffee-community",
+		"id": "876",
+		"metaDescription": "Season 5 Finale of the Virtual Coffee Podcast",
+		"season": 5,
+		"episode": 9,
+		"buzzsproutId": "10720878",
+		"publishDate": "2022-06-01T04:00:00+00:00",
+		"shortDescription": "<p>In this season finale of the podcast, Dan, Kirk, and Bekah come together to talk about making hard decisions to ensure community support and stability. They also share how they're navigating technical and community challenges as the community grows.</p>",
+		"showNotes": "<p>In this episode of the podcast, Bekah, Kirk, and Dan discuss the decision to pause new membership and what the maintainers are doing to progress towards opening the community up again. We share what we think makes our community special, how we're working to preserve that, and some of the challenges we're figuring out as we take steps towards reopening membership. What goes into the long-term strategy of making Virtual Coffee <em>an intimate group of devs, optimized for you</em>? You'll find out in this episode.</p><h3>Links:</h3><ul><li><p><a href=\"https://gamesnostalgia.com/game/dx-ball\" rel=\"noopener noreferrer\" target=\"_blank\">DX Ball</a></p></li><li><p><a href=\"https://boardgamegeek.com/boardgame/3086/omega-virus\" rel=\"noopener noreferrer\" target=\"_blank\">Omega Virus</a></p></li><li><p><a href=\"https://www.ultraboardgames.com/othello/game-rules.php\" rel=\"noopener noreferrer\" target=\"_blank\">Othello</a></p></li><li><p><a href=\"http://virtualcoffee.io/members\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee Members</a></p></li><li><p><a href=\"https://virtualcoffee.io/resources/virtual-coffee/get-involved/paths-to-leadership\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee Paths to Leadership</a></p></li><li><p><a href=\"https://twitter.com/SuzeShardlow\" rel=\"noopener noreferrer\" target=\"_blank\">Suze Shardlow</a></p></li><li><p><a href=\"https://www.bbc.com/future/article/20191001-dunbars-number-why-we-can-only-maintain-150-relationships\" rel=\"noopener noreferrer\" target=\"_blank\">Dunbar's Number</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0509-finale-episode.jpg",
+		"guests": [
+			{
+				"name": "Kirk Shillingford",
+				"bio": "<p>Software Developer, and Community Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://github.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-kirk.jpg"
+			},
+			{
+				"name": "Bekah Hawrot Weigel",
+				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dev.to/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/bekahhw</a></p></li><li><p><a href=\"https://twitter.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">@bekahhw</a> on Twitter</p></li><li><p><a href=\"https://www.instagram.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">bekahhw</a> on Instagram</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/T014AAKN3KP-U014HT3RNCU-f7cccf369940-512.png"
+			},
+			{
+				"name": "Dan Ott",
+				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dtott.com/\" rel=\"noopener noreferrer\" target=\"_blank\">dtott.com</a></p></li><li><p><a href=\"https://twitter.com/danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">@danieltott</a> on Twitter</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-dan.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "David Alpert - On pairing and providing support",
+		"slug": "david-alpert-on-pairing-and-providing-support",
+		"id": "913",
+		"metaDescription": "Season 6, Episode 1 of the Virtual Coffee Podcast",
+		"season": 6,
+		"episode": 1,
+		"buzzsproutId": "10964411",
+		"publishDate": "2022-07-15T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to David Alpert about supporting others in their tech journey, asking the right questions, and leading with empathy.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with David Alpert, Director of Engineering at Northfield IT, about taking a personalized approach to helping others as they ask coding questions and navigate career paths. David shares the importance of bringing empathy to every situation and gives tips on how to handle challenging situations.</p><h3>Links:</h3><ul><li><p><a href=\"https://en.wikipedia.org/wiki/Logo_(programming_language)\">Logo (the programming turtle)</a></p></li><li><p><a href=\"https://dev.to/virtualcoffee/how-the-virtual-coffee-coworking-room-works-2a89\">Virtual Coffee Co-Working Room</a></p></li><li><p><a href=\"https://agilemanifesto.org/\">The Agile Manifesto</a></p></li><li><p><a href=\"https://www.twitch.tv/virtualcoffeeio\">Typescript Tuesdays</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0601-david-episode.jpg",
+		"guests": [
+			{
+				"name": "David Alpert",
+				"bio": "<p>David Alpert is a collaborative leader and agile coach striving to reduce friction between people and software. Based in Winnipeg, Manitoba, David has over 20 years of professional IT experience in software development, system design, and project and people management spanning the finance, manufacturing, and sports entertainment industries. David is passionate about test-driven development, refactoring, pair programming, and helping people become better developers.</p><ul><li><p>Website: <a href=\"https://blog.spinthemoose.com\">Spin the Moose</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/davidalpert\">@davidalpert</a></p></li><li><p>GitHub: <a href=\"https://github.com/davidalpert\">davidalpert</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0601-david.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Bogdan Covrig - Navigating Tech Career Paths",
+		"slug": "bogdan-covrig-navigating-tech-career-paths",
+		"id": "933",
+		"metaDescription": "Season Six, Episode Two of the Virtual Coffee Podcast",
+		"season": 6,
+		"episode": 2,
+		"buzzsproutId": "11044164",
+		"publishDate": "2022-07-28T04:00:00+00:00",
+		"shortDescription": "<p>In this episode, Dan and Bekah talk to Bogdan Covrig about finding the right career path within tech and searching for what gets you excited.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Bogdan Covrig, a Software Engineer in the Netherlands who's into Typescript, React and Node, about navigating different learning and career paths in tech before landing a job that fulfills his interests to see the changes he's making and provides a dynamic work environment. He also drops his tips on the most important things you can do if you're starting your journey into tech.</p><h3>Links</h3><ul><li><p><a href=\"https://p5js.org/\">p5.js</a></p></li><li><p><a href=\"https://www.arduino.cc/\">Arduino</a></p></li><li><p><a href=\"https://www.twitch.tv/virtualcoffeeio/schedule\">Twitch TypeScript Tuesdays</a></p></li><li><p>Nick and Bekah's Lunch & Learn <a href=\"https://youtu.be/DVqtr3iwkwQ\">Coding questions: Problem-solving and working through challenges</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0602-bogdan-episode.png",
+		"guests": [
+			{
+				"name": "Bogdan Covrig",
+				"bio": "<p>Bogdan is a Software Engineer in the Netherlands. He’s passionate about privacy, automation and infrastructure. He’s into Typescript, React and Node, currently building and working with CMS. He’s usually busy with movies, concerts or sitting in the park for no reason.</p><ul><li><p><a href=\"https://github.com/BogDAAAMN\">@BogDAAAMN</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/BogdanCovrig\">@BogdanCovrig</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/BogdanCovrig\">@BogdanCovrig</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0602-bogdan.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Seth Hall - From Film Production to Technical Product Owner: A Career Changer's Story",
+		"slug": "seth-hall-from-film-production-to-technical-product-owner-a-career-changers-story",
+		"id": "954",
+		"metaDescription": "Season 6, Episode 3 of the Virtual Coffee Podcast",
+		"season": 6,
+		"episode": 3,
+		"buzzsproutId": "11103329",
+		"publishDate": "2022-08-09T04:00:00+00:00",
+		"shortDescription": "<p>Bekah and Dan talk to Seth Hall, a Technical Product Owner at Uniform. He talks about the importance of fostering authentic company culture, as well as how his search to find a challenging, fun, and flexible job led him from Film Production, to Frontend Developer, to his current role.</p>",
+		"showNotes": "<p>In today's episode, Dan and Bekah talk with Seth Hall about the importance of intimate collaboration, advocating for yourself, and transferable skills as part of his job as a Technical Product Owner at <a href=\"https://uniform.dev/\">Uniform</a>. He shares how his background as a creative producer informs how he guides demo initiatives, creates roadmaps, and collaborates with other departments.</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0603-seth-hall-episode.jpg",
+		"guests": [
+			{
+				"name": "Seth Hall",
+				"bio": "<p>Seth is a Technical Product Owner at <a href=\"https://uniform.dev/\">Uniform</a></p><ul><li><p>Website: <a href=\"https://sethhall.dev/\">sethhall.dev</a></p></li><li><p>Dev.to: <a href=\"https://dev.to/sethburtonhall\"><u>dev.to/sethburtonhall</u></a></p></li><li><p>Polywork: <a href=\"https://www.polywork.com/sethhall\"><u>polywork.com/sethhall</u></a></p></li><li><p>Twitter: <a href=\"https://twitter.com/sethburtonhall\">@sethburtonhall</a></p></li><li><p>GitHub: <a href=\"https://github.com/sethburtonhall\">@sethburtonhall</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0603-seth-hall.png"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "50th Episode Special - Live at KCDC 2022",
+		"slug": "50th-episode-special-live-at-kcdc-2022",
+		"id": "987",
+		"metaDescription": "Season Six Special Edition",
+		"season": 6,
+		"episode": 999,
+		"buzzsproutId": "11127313",
+		"publishDate": "2022-08-12T04:00:00+00:00",
+		"shortDescription": "<p>For the 50th episode of the podcast, Dan and Bekah are live at KCDC 2022 answering listener questions and practicing their accents.</p>",
+		"showNotes": "<p>For the 50th episode of the podcast, Dan and Bekah are live at the Kansas City Developer Conference 2022 answering listener questions and practicing their accents.</p><p><a href=\"https://www.youtube.com/watch?v=_fqFv1joZ3A\"><strong>Check out the video version on YouTube!</strong></a></p><h4>Listener questions:</h4><ul><li><p>What time do you go to sleep? (2:19)</p></li><li><p>How does a computer get drunk? (12:42)</p></li><li><p>What's the hardest part of community? (22:20)</p></li><li><p>Ayu would like to hear the history of how Virtual Coffee was founded. (31:57)</p></li><li><p>What does community mean to you? (38:01)</p></li><li><p>At in-person events, what are some techniques or tactics you used for starting a conversation with a stranger? (41:00)</p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/06-special.png",
+		"guests": [],
+		"sponsors": []
+	},
+	{
+		"title": "Sadie Jay - Technical Interviews for Bootcamp Grads",
+		"slug": "sadie-jay-technical-interview-for-bootcamp-grads",
+		"id": "990",
+		"metaDescription": "Season 6, Episode 4 of the Virtual Coffee Podcast",
+		"season": 6,
+		"episode": 4,
+		"buzzsproutId": "11204579",
+		"publishDate": "2022-08-30T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Sadie about technical interviewing after bootcamp. She shares her tips for landing interviews, prepping, and interviewing your interviewers.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Sadie a frontend developer for a federal agency, to chat about her experience navigating the interview process and how she found success after giving tech a second shot. She shares tips on how to avoid burnout both during the interview process and while you're working in tech.</p><h3>Links:</h3><ul><li><p><a href=\"https://18f.gsa.gov/\">18f</a></p></li><li><p><a href=\"https://skillcrush.com/\">Skill Crush</a></p></li><li><p><a href=\"https://leetcode.com/explore/challenge/\">Leet Code Challenge</a></p></li><li><p><a href=\"https://github.com/jmkoni/interview-questions\"><u>Jennifer's List of Interview Questions</u></a></p></li><li><p><a href=\"https://skillcrush.com/blog/technical-test-preparation-advice/\">Technical Test Preparation Advice</a> post by Sadie</p></li><li><p><a href=\"https://www.wordsofmouth.org/\">Words of Mouth job email</a></p></li><li><p><a href=\"https://designsystem.digital.gov/\">US Web Design Standards</a></p></li><li><p><a href=\"https://jekyllrb.com/\">Jekyll</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0604-sadie-episode.png",
+		"guests": [
+			{
+				"name": "Sadie Jay",
+				"bio": "<p>Sadie is a Front-end Developer and bootcamp alum. In 2016, Sadie started her journey into tech with web design courses. Along the way, she graduated with a Masters specializing in Web Design and Online Communication, taught yoga, searched for cheap flights at a travel startup, volunteered as a writer and proofreader for various non-profits, and contributed to a number of open source projects. Outside of coding and writing, Sadie can be found petting her cat Maxie, hanging out with her mom, or looking up the next vegan restaurant to check out.</p><ul><li><p><a href=\"https://sadiejay.github.io/portfolio/\">Sadie's Portfolio Site</a></p></li><li><p><a href=\"https://github.com/sadiejay\">@sadiejay on GitHub</a></p></li><li><p><a href=\"https://www.linkedin.com/in/sadiej/\">@sadiej on LinkedIn</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0604-sadie.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Chad Stewart - OSS and #TechisHiring",
+		"slug": "chad-stewart-oss-and-techishiring",
+		"id": "1026",
+		"metaDescription": "Season 6, Episode 5 of the Virtual Coffee Podcast",
+		"season": 6,
+		"episode": 5,
+		"buzzsproutId": "11269316",
+		"publishDate": "2022-09-06T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk with Chad Stewart about getting started in open source, finding a project with a supportive community, and his project #TechIsHiring.</p>",
+		"showNotes": "<p>In today's episode, Bekah and Dan talk to Chad Stewart, a Software Engineer from Kingston, Jamaica, about his journey into contributing to Open Source projects like Open Sauced and how to find your way to your first contribution. He shares the inspiration behind his <a href=\"https://www.getrevue.co/profile/techishiring\">#TechIsHiring project</a>, which helps to identify tech jobs and resources, but more importantly, to connect people in the wider tech community.</p><h3>Links</h3><ul><li><p><a href=\"https://www.amazon.com/Side-Mountain-Jean-Craighead-George/dp/0141312424\">My Side of the Mountain</a></p></li><li><p><a href=\"https://twitter.com/bdougieYO\">Brian Douglas, aka Bdougie</a></p></li><li><p><a href=\"https://opensauced.pizza/\">Open Sauced</a></p></li><li><p><a href=\"https://github.com/yangshun/tech-interview-handbook\">Tech Interview Handbook</a></p></li><li><p><a href=\"https://github.com/TheAlgorithms\">The Algorithms</a></p></li><li><p><a href=\"https://twitter.com/AdiatiAyu\">Ayu</a></p></li><li><p><a href=\"https://twitter.com/TechIsHiring\">Tech is Hiring</a></p></li><li><p><a href=\"https://github.com/Virtual-Coffee/virtualcoffee.io/blob/main/CONTRIBUTING.md\">Virtual Coffee Contributors Guide</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0605-chad-episode.jpg",
+		"guests": [
+			{
+				"name": "Chad Stewart",
+				"bio": "<p>Software Engineer from Kingston, Jamaica. Founder of <a href=\"https://www.getrevue.co/profile/techishiring\">TechIsHiring</a>.</p><ul><li><p><a href=\"https://twitter.com/Chad_R_Stewart\">@Chad_R_Stewart on Twitter</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0605-chad.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Julia Seidman - Embracing the Careen Over the Career",
+		"slug": "julia-seidman-embracing-the-careen-over-the-career",
+		"id": "1049",
+		"metaDescription": "Season Six, Episode Six, of the Virtual Coffee Podcast",
+		"season": 6,
+		"episode": 6,
+		"buzzsproutId": "11351419",
+		"publishDate": "2022-09-20T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Julia about learning how to learn as a Technical Writer, the importance of teaching as a tool for learning, and her approach to writing about new technologies.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Julia Seidman, a technical marketing consultant and developer in the Seattle area, and talked about her work writing about different technologies, learning by teaching, and embracing the careen over the career. She talks about her career journey from studying anthropology to financial analysis to teaching high school English, ESL and Debate, before landing her current role as a technical writer.</p><h3>Links</h3><ul><li><p><a href=\"https://en.wikipedia.org/wiki/Krugerrand\">Krugerrand</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Doubloon\">Gold Doubloons</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Rhodium\">Rhodium</a></p></li><li><p><a href=\"https://flutter.dev/\">Flutter</a></p></li><li><p><a href=\"https://www.amazon.com/Developer-Marketing-Does-Not-Exist-ebook/dp/B091NK954H\">Developer Marketing Does Not Exist</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0606-julia-episode.jpg",
+		"guests": [
+			{
+				"name": "Julia Seidman",
+				"bio": "<p>Julia Seidman is a technical marketing consultant and developer in the Seattle area. She has 2 terrific kids and a wonderful partner, and her family cos-plays as a “normal” family.</p><p class=\"text-left\">Julia is a believer in the careen, rather than the career.</p><p class=\"text-left\">After studying anthropology and writing a senior thesis on the ethics of museum collections of human skeletal remains, she took the job she could get, which was fundraising for a hospital.</p><p class=\"text-left\">From there, she became a financial analyst and employee educator for 401(k) and pension plans. After that, she got a Master’s in Teaching, and taught high school English, ESL and Debate for most of a decade.</p><p class=\"text-left\">Now, she works as a freelance technical writer and software developer, specializing in technical content marketing.</p><p class=\"text-left\">Along the way, she has learned a lot about a lot of things, including the Python ecosystem.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0606-juila.JPG"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Ryan Kahn - Building Better Teams",
+		"slug": "ryan-kahn-building-better-teams",
+		"id": "1091",
+		"metaDescription": "Season 6, Episode 7 of the Virtual Coffee Podcast",
+		"season": 6,
+		"episode": 7,
+		"buzzsproutId": "11407929",
+		"publishDate": "2022-09-29T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk with Ryan Kahn about building better teams to deliver quality software by practicing empathy and knowledge sharing.</p>",
+		"showNotes": "<p>In today's episode, Bekah and Dan talk to Ryan Kahn, a developer experience and productivity consultant from New York City, about his work as a consultant helping companies to build better software teams. He emphasizes the importance of recognizing that teams are made up of individuals who have different needs and approaches. He also breaks down the difference between quality, technical, knowledge, and innovation debt and the need to identify which most impacts teams as they seek better communication to build a stronger team.</p><h3>Links:</h3><ul><li><p><a href=\"http://adr.github.io\">ADR GitHub organization</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Oblique_Strategies\">Oblique Strategies</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0607-ryan-episode.jpg",
+		"guests": [
+			{
+				"name": "Ryan Kahn",
+				"bio": "<p>Ryan loves solving the human and technical problems of software development, and works on both as a developer experience and productivity consultant. He lives in New York City with his partner, daughter, and dog. Outside of his work he loves Astronomy and Amateur Radio.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0607-ryan.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Shelley McHardy: Junior Dev life",
+		"slug": "shelley-mchardy-junior-dev-life",
+		"id": "1101",
+		"metaDescription": "Season Six, Episode Eight of the Virtual Coffee Podcast",
+		"season": 6,
+		"episode": 8,
+		"buzzsproutId": "11445606",
+		"publishDate": "2022-10-05T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Shelley McHardy about navigating a career transition and the challenges of interviewing for your first developer role.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Shelley McHardy, a former chemistry teacher turned front end developer at <a href=\"https://www.rightpoint.com/\">Rightpoint</a>, and talked about the early career developer's journey. She gave insight into what her seven-month interview process looked like, forcing interviewers to interview you, the importance of finding \"your people\", and being picky in your job search.</p><h3>Links:</h3><ul><li><p><a href=\"https://www.edx.org/\">edX</a></p></li><li><p><a href=\"https://the-collab-lab.codes/\">Collab Lab</a></p></li><li><p><a href=\"https://www.studentachievementsolutions.com/what-are-professional-learning-communities-plcs/\">PLCs- Professional learning communities</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0608-shelley-episode.jpg",
+		"guests": [
+			{
+				"name": "Shelley McHardy",
+				"bio": "<p>Shelley is a former chemistry teacher turned front end developer at Rightpoint. A native San Franciscan, she is currently doing her best to stay cool in Atlanta, Georgia. When not crocheting, she and her wife love hiking the Georgia State Parks, geocaching, cooking, baking, and video games.</p><ul><li><p>GitHub: <a href=\"https://github.com/shelleymcq\">@shelleymcq</a></p></li><li><p>Twitter <a href=\"https://twitter.com/shelleymcqDev\">@shelleymcqDev</a></p></li><li><p>LinkedIn <a href=\"https://www.linkedin.com/in/shelleymchardy/\">shelleymchardy</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0608-shelley.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Season Six Finale - Talking Hacktoberfest with Bekah, Dan, and Kirk",
+		"slug": "season-six-finale-talking-hacktoberfest-with-bekah-dan-and-kirk",
+		"id": "1132",
+		"metaDescription": "Season Six, Episode Nine of the Virtual Coffee Podcast",
+		"season": 6,
+		"episode": 9,
+		"buzzsproutId": "11496083",
+		"publishDate": "2022-10-13T04:00:00+00:00",
+		"shortDescription": "<p>It’s the final episode of season six of the podcast and we’re bringing it to you live with Bekah, Dan, and Kirk!</p>",
+		"showNotes": "<p>It’s the final episode of season six of the podcast and we’re bringing it to you live with Bekah, Dan, and Kirk! We talked a lot about Hacktoberfest with many side-tracks and segues in between.</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0609-finale.jpg",
+		"guests": [],
+		"sponsors": []
+	},
+	{
+		"title": "Jörn Bernhardt - Becoming a Founder",
+		"slug": "jörn-bernhardt-becoming-a-founder",
+		"id": "1626",
+		"metaDescription": "Season Seven, Episode One of the Virtual Coffee Podcast",
+		"season": 7,
+		"episode": 1,
+		"buzzsproutId": "12164997",
+		"publishDate": "2023-02-02T05:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Jörn Bernhardt about his journey as a 2x founder and his lifelong interest in technology.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Jörn Bernhardt, a 2x founder in Germany, about his career path, the challenges of being a founder, and the key traits that have led to his success.</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Jörn.png",
+		"guests": [
+			{
+				"name": "Jörn Bernhardt",
+				"bio": "<p>Jörn started developing web-based software in the last century when he was still in school. In 2018, he founded his second company <a href=\"http://compose.us\">compose.us</a> where they implement digital solutions and share their knowledge with public administrations. In his spare time Jörn organizes local meetups in Germany and creates at least one open source commit per day to push his side projects.</p><ul><li><p><a href=\"https://compose.us/\">compose.us</a></p></li><li><p><a href=\"https://github.com/Narigo\">Jörn on GitHub</a></p></li><li><p><a href=\"NarigoDF\">Jörn on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/j%C3%B6rn-bernhardt-a04225104/\">Jörn on LinkedIn</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/joern.png"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Joe Karow - Career Transitions and the ADHD Experience",
+		"slug": "joe-karow-career-transitions-and-the-adhd-experience",
+		"id": "1655",
+		"metaDescription": "Season Seven, Episode Two of the Virtual Coffee Podcast",
+		"season": 7,
+		"episode": 2,
+		"buzzsproutId": "12213630",
+		"publishDate": "2023-02-09T05:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Joe Karow about his journey as into tech with 100devs and about his ADHD journey.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Joe Karow, the Lead Engineer at a nonprofit, about his career change from the hospitality industry, his experience with the online bootcamp, 100devs, and about the ADHD experience.</p><h3>Links</h3><ul><li><p><a href=\"https://jobs.all-hands.us/jobs\">All Hands Job Board</a></p></li><li><p><a href=\"https://leonnoel.com/100devs/\">100devs</a></p></li><li><p><a href=\"https://www.resilientcoders.org/\">Resilient Coders</a></p></li><li><p><a href=\"https://twitter.com/leonnoel\">Leon Noel</a></p></li><li><p><a href=\"https://www.cedarpoint.com/\">Cedar Point</a></p></li><li><p><a href=\"https://buschgardens.com/\">Busch Gardens</a></p></li><li><p><a href=\"https://www.kennywood.com/\">Kennywood</a></p></li><li><p><a href=\"https://cssbattle.dev/\">cssbattle.dev</a></p></li><li><p><a href=\"https://remo.co/\">remo</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0702-joe-episode.jpg",
+		"guests": [
+			{
+				"name": "Joe Karow",
+				"bio": "<p>Joe is the Lead Engineer at InReach, a 501(c)3 registered non-profit building world’s first tech platform matching LGBTQ+ people facing discrimination and persecution with safe, verified resources. Formerly a Director of Finance for a large hotel chain, he made the leap in to tech in 2022. Tech was always a part of Joe's life, it just took a global pandemic for him to decide to start getting paid for it.</p><ul><li><p><a href=\"https://joekarow.dev\"><u>joekarow.dev</u></a></p></li><li><p><a href=\"https://github.com/JoeKarow\">@JoeKarow</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/JoeKarow\">@JoeKarow</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/jkarow/\">@jkarow</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0702-joe.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Kai Katschthaler - Technical Writing &  Neurodiverse Learning",
+		"slug": "kai-katschthaler-technical-writing-neurodiverse-learning",
+		"id": "1680",
+		"metaDescription": "Season Seven, Episode Three of the Virtual Coffee Podcast",
+		"season": 7,
+		"episode": 3,
+		"buzzsproutId": "12263721",
+		"publishDate": "2023-02-16T05:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Kai Katschthaler about their experience growing their technical writing career and creating content.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Kai Katschthaler, a technical writer and content creator, about their creation process, finding learning approaches that work for them, and mentoring others.</p><h3>Links:</h3><ul><li><p><a href=\"https://www.spreaker.com/user/15541131/kai-ep-final\">Kai's appearance on the Coming Out Pod</a></p></li><li><p><a href=\"https://bau.edu/blog/kinesthetic-learner/\">Kinesthetic Learning</a></p></li><li><p><a href=\"https://www.freecodecamp.org/\">Freecodecamp</a></p></li><li><p><a href=\"https://www.codecademy.com/\">Codecademy</a></p></li><li><p><a href=\"https://learn.co/\">Flatironschool</a></p></li><li><p><a href=\"https://exercism.org/\">Exercism</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0703-kai-episode.jpg",
+		"guests": [
+			{
+				"name": "Kai Katschthaler",
+				"bio": "<p>Kai is a tech content specialist and mental health advocate. They run Taboola Rasa, a mental health awareness project that seeks to erase the stigma connected to mental health.</p><ul><li><p><a href=\"https://linktr.ee/thegrumpyenby\">linktr.ee/thegrumpyenby</a></p></li><li><p><a href=\"https://github.com/thegrumpyenby\">@thegrumpyenby</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/thegrumpyenby\">@thegrumpyenby</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/kaikatschthaler/\">@kaikatschthaler</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0703-kai.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Aishwarya Mali - A Journey into Open Source",
+		"slug": "aishwarya-mali-a-journey-into-open-source",
+		"id": "1695",
+		"metaDescription": "Season Seven, Episode Four of the Virtual Coffee Podcast",
+		"season": 7,
+		"episode": 4,
+		"buzzsproutId": "12315603",
+		"publishDate": "2023-02-23T05:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Aishwarya about her journey as a first time contributer during the 2022 Hacktoberfest.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Aishwarya, front-end developer from India, about her first open source contributions and how her perspective on open source changed after her fourth (of ten!) Pull Request during Hacktoberfest.</p><ul><li><p>One word to describe you - <strong>Dedicated</strong></p></li><li><p>One word to describe your developer journey - <strong>Evolving</strong></p></li><li><p><a href=\"https://www.amazon.com/Me-Before-You-Novel-Tie/dp/0143130153\"><em><u>Me Before You</u></em><u> by Jojo Moyes</u></a></p></li><li><p>Open-Source YouTube Videos:</p><ul><li><p><a href=\"https://www.youtube.com/watch?v=yfopPq4354o\">How to Find Beginner-Friendly Open Source Projects</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=_uetV0wZyXM\">4 Beginner Friendly Open Source Projects to Contribute before 2023</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=lnLiD0GfCRE\">5 Beginner friendly Open Source Organisations to start your Open source journey</a></p></li></ul></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0704-aishwara-episode.jpg",
+		"guests": [
+			{
+				"name": "Aishwarya Mali",
+				"bio": "<p>Aishwarya Mali is a front-end developer (React+XState+Redux) based in Pune, India. She loves to read!</p><ul><li><p><a href=\"https://github.com/aishwarya-mali\">@aishwarya-mali</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/aishwaryamali24\">@aishwaryamali24</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/aishwaryamali24/\">@aishwaryamali24</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0704-aishwara.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Rebecca Key - From PhD to Frontend",
+		"slug": "rebecca-key-from-phd-to-frontend",
+		"id": "1711",
+		"metaDescription": "Season Seven, Episode Five of the Virtual Coffee Podcast",
+		"season": 7,
+		"episode": 5,
+		"buzzsproutId": "12363084",
+		"publishDate": "2023-03-02T05:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Rebecca Key about her journey from a career in chemistry to Software Engineer and the hobbies that she finds exciting.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Rebecca Key, a PhD in Organic Chemistry and now Software Engineer, and chatted about her career journey, Ham radios, being left-handed, taking notes, and the importance of consistency.</p><h3>Links:</h3><ul><li><p><a href=\"https://en.wikipedia.org/wiki/Brassica_oleracea\">Brassica oleracea</a> (the plant Dan was talking about)</p></li><li><p><a href=\"https://www.sota-at.com/\">SOTA-AT</a>: An interactive map that displays and provides information for peaks along the GA section of the Appalachian Trail that count toward activations for “Summits on the Air”, a ham radio contest.</p></li><li><p><a href=\"https://github.com/rek990/crochet-counter\">Row Counter</a>: A tool to help fiber artists (crocheters, knitters, rug makers, basket weavers, etc.) keep track of the row they are on with a given project. <a href=\"https://dev.to/rek990/virtual-coffees-july-monthly-challenge-live-demo-of-the-progress-toward-my-row-counter-app-3jd7\">Live Demo of the Progress Toward my Row Counter App</a></p></li><li><p>Rebecca's RF Quests: <a href=\"https://www.rfquests.com/\">Blog</a> and <a href=\"https://www.youtube.com/channel/UC5Rtn09KIdwsySkf7B-DPsw\">YouTube Channel</a></p></li><li><p><a href=\"https://parksontheair.com/\">Parks on the Air (POTA)</a></p></li><li><p><a href=\"https://www.sota.org.uk/\">Summits on the Air (SOTA)</a></p></li><li><p><a href=\"https://www.sota.org.uk/Joining-In/Awards\">SOTA Mountain goat award</a></p></li><li><p><a href=\"https://orgmode.org/\">Emacs Org Mode</a></p></li></ul><h4>Left-handed Deep Dive</h4><ul><li><p><a href=\"https://kids.frontiersin.org/articles/10.3389/frym.2014.00013\">Your Left-Handed Brain</a></p></li><li><p><a href=\"https://www.bbc.com/news/health-49579810\">Left-handed DNA found - and it changes brain structure</a></p></li><li><p><a href=\"https://pubmed.ncbi.nlm.nih.gov/1839378/#:~:text=Left%2Dhandedness%20occurs%20in%20about,monozygotic%20twins%20show%20substantial%20discordance\">The inheritance of left-handedness</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0705-rebecca-episode.png",
+		"guests": [
+			{
+				"name": "Rebecca Key",
+				"bio": "<p>Rebecca Key is a Software Engineer based out of Atlanta, GA. She is a first-generation college graduate that went on to obtain a PhD in Organic Chemistry from Georgia Tech. After many years in research (roles ranging from Laboratory Technician to Research Director), she made a career change into the tech field, where she currently works as an Independent Front-End Engineer. When not coding, she enjoys mountain biking, running, weightlifting, crocheting, and knitting!</p><ul><li><p><a href=\"http://rebeccakeyphd.com/\">rebeccakeyphd.com</a></p></li><li><p><a href=\"https://github.com/rek990\">@rek990</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/rebeccakeyphd\">@rebeccakeyphd</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/rebecca-key/\">@rebecca-key</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0705-rebecca.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Arthur Doler - The Human Side of Tech",
+		"slug": "arthur-doler-the-human-side-of-tech",
+		"id": "1727",
+		"metaDescription": "Season Seven, Episode Six of the Virtual Coffee Podcast",
+		"season": 7,
+		"episode": 6,
+		"buzzsproutId": "12407750",
+		"publishDate": "2023-03-09T05:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Arthur Doler about team dynamics, motivation, and how to identify problematic situations.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Arthur Doler, a Software Engineer and Community and Culture Steward, and chatted about the human side of tech, the importance of recognizing our emotions, communication styles, and the dynamics of the environments we're working in.</p><h3>Links:</h3><ul><li><p><a href=\"https://www.danpink.com/books/drive/\">Daniel Pink's Drive</a></p></li><li><p><a href=\"https://youtu.be/-XYK8ulQId0\">Arthur's talk: You're Not Just Tired: The Psychology of Burnout</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Aikido\">Aikido</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/List_of_disc_golf_players\">Pro Disc Golfers</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0706-arthur-episode.jpg",
+		"guests": [
+			{
+				"name": "Arthur Doler",
+				"bio": "<p>Arthur (or Art, take your pick) has been a software engineer for 19 years and has worked on things as exciting as analysis software for casinos and things as boring as banking websites. He is an advocate for talking openly about mental health and psychology in the technical world, and he spends a lot of time thinking about <em>how</em> we program and <em>why</em> we program, and about the tools, structures, cultures, and mental processes that help and hinder us from our ultimate goal of writing amazing things. His hair is brown and his thorax is a shiny blue color.</p><ul><li><p><a href=\"https://arthurdoler.com\">arthurdoler.com</a></p></li><li><p><a href=\"https://github.com/doleraj\">@doleraj</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/arthurdoler\">@arthurdoler</a> on Twitter</p></li><li><p><a href=\"https://mastodon.sandwich.net/@arthurdoler\">@arthurdoler</a> on Mastodon</p></li><li><p><a href=\"https://www.linkedin.com/in/arthurdoler/\">@arthurdoler</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0706-arthur.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Dominic Duffin - Finding value in challenging ourselves",
+		"slug": "dominic-duffin-finding-value-in-challenging-ourselves",
+		"id": "1740",
+		"metaDescription": "Season Seven, Episode Seven of the Virtual Coffee Podcast",
+		"season": 7,
+		"episode": 7,
+		"buzzsproutId": "12453805",
+		"publishDate": "2023-03-16T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Dominic Duffin about the impact of non-traditional learning experiences and the importance of community collaboration.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Dominic Duffin, a Full-Stack Developer, Co-founder of ArtTechChat Twitter chat, Salon Host at The Interintellect, and Open Source contributor, and chatted about the the value gained in creating a learning environment wherever you go and the importance of participating in community experiences.</p><ul><li><p>Pass the Pen: <a href=\"https://codepen.io/collection/nZrZLy\">https://codepen.io/collection/nZrZLy</a></p></li><li><p><a href=\"@ArtTechChat on Twitter\"><u>https://twitter.com/arttechchat</u></a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0707-dominic-episode.jpg",
+		"guests": [
+			{
+				"name": "Dominic Duffin",
+				"bio": "<p>Full Stack Developer, community builder, remote worker and aspiring polymath. Passionate about open source everything, decentralization, peer-to-peer tech and cryptocurrency. Also to be found playing board games, studying paper maps and riding public transport.</p><ul><li><p><a href=\"https://dominicduffin.uk\">dominicduffin.uk</a></p></li><li><p><a href=\"https://github.com/dominicduffin1\">@dominicduffin1</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/DominicDuffin1\">@DominicDuffin1</a> on Twitter</p></li><li><p><a href=\"https://toot.cafe/@dominicduffin1\">@dominicduffin1</a> on Mastadon</p></li><li><p><a href=\"https://www.linkedin.com/in/dominic-duffin-a992b0225\">@dominic-duffin</a> on LinkedIn</p></li><li><p><a href=\"https://www.polywork.com/dominic\">@dominic</a> on Polywork</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0707-dominic.png"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Ramón Huidobro - Thoughtful Learning",
+		"slug": "ramón-huidobro-thoughtful-learning",
+		"id": "1756",
+		"metaDescription": "Season Seven, Episode Eight of the Virtual Coffee Podcast",
+		"season": 7,
+		"episode": 8,
+		"buzzsproutId": "12503114",
+		"publishDate": "2023-03-23T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Ramón Huidobro about asking good questions about your code and how to ask for help.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Ramón Huidobro, a developer advocate and DevEd enthusiast, and chatted about the process of learning and growing and how asking questions and knowing what questions to ask is an important part of the tech experience.</p><p>Check out Ramón's article <a href=\"https://ramonh.dev/2022/11/13/asking-for-help/\">about reaching out for help</a>!</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0708-ramon-episode.jpg",
+		"guests": [
+			{
+				"name": "Ramón Huidobro",
+				"bio": "<p>Ramón Huidobro is a developer advocate and DevEd enthusiast. He thrives on lifting others up in their tech careers and loves a good CSS challenge. Always excited to talk about teaching tech, especialmente en Español, oder auf Deutsch.</p><ul><li><p><a href=\"https://https://ramonh.dev\">ramonh.dev</a></p></li><li><p><a href=\"https://github.com/hola-soy-milk\">@hola-soy-milk</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/hola_soy_milk\">@hola_soy_milk</a> on Twitter</p></li><li><p><a href=\"https://hachyderm.io/@hola_soy_milk\">@hola_soy_milk</a> on Mastadon</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0708-ramon.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Season Seven Finale - Live with Nick Taylor",
+		"slug": "season-seven-finale-live-with-nick-taylor",
+		"id": "1772",
+		"metaDescription": "Season Seven, Episode Nine of the Virtual Coffee Podcast",
+		"season": 7,
+		"episode": 9,
+		"buzzsproutId": "12558497",
+		"publishDate": "2023-03-31T04:00:00+00:00",
+		"shortDescription": "<p>Join Bekah, Dan, and Special Guest Nick Taylor for a live-streamed episode of the Season Seven Finale!</p>",
+		"showNotes": "<p>Join Bekah, Dan, and Special Guest Nick Taylor for a live-streamed episode of the Season Seven Finale!</p><p>Watch the video replay here: <a href=\"https://www.youtube.com/watch?v=0Wj-zlORvm8\">https://www.youtube.com/watch?v=0Wj-zlORvm8</a></p><p>Watch our 2023 Spring Lightning Talks here: <a href=\"https://www.youtube.com/watch?v=O2CsTN-WEZ0\">https://www.youtube.com/watch?v=O2CsTN-WEZ0</a></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0709-finale.png",
+		"guests": [],
+		"sponsors": []
+	},
+	{
+		"title": "VC Maintainers - Importance of Culture Citizenship",
+		"slug": "vc-maintainers-importance-of-culture-citizenship",
+		"id": "1796",
+		"metaDescription": "Season Eight, Episode One of the Virtual Coffee Podcast",
+		"season": 8,
+		"episode": 1,
+		"buzzsproutId": "12988617",
+		"publishDate": "2023-06-07T04:00:00+00:00",
+		"shortDescription": "<p><span>We're starting the new season with a conversation with our maintainers, including our new maintainer, Julia Seidman! We share our thought process for adding a maintainer and walk through our culture citizenship statement to share how we intend to create a positive community.</span></p>",
+		"showNotes": "<p><span>Starting off this new season, we're bringing in all of our maintainers, Bekah Hawrot Weigel, Dan Ott, Kirk Shillingford, and Julia Seidman. We walk through the importance of understanding communities, members, and how to create a positive community experience.</span></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0801-Cover.jpeg",
+		"guests": [
+			{
+				"name": "Julia Seidman",
+				"bio": "<p><span>Julia Seidman is a developer education consultant based in the Seattle area. Julia is a believer in embracing the 'careen' over the career. </span></p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Julia-Headshot.jpeg"
+			},
+			{
+				"name": "Kirk Shillingford",
+				"bio": "<p><span>A full stack developer in the Caribbean interested in Functional Programming, Domain Driven Development, and Security.</span></p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Kirk-Headshot.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Alex Curtis-Slep - Enriching Your Life as a Developer",
+		"slug": "alex-curtis-slep-enriching-your-life-as-a-developer",
+		"id": "1827",
+		"metaDescription": "Season Eight, Episode Two of the Virtual Coffee Podcast",
+		"season": 8,
+		"episode": 2,
+		"buzzsproutId": "13038514",
+		"publishDate": "2023-06-15T04:00:00+00:00",
+		"shortDescription": "<p><span>In today's episode, Dan and Bekah talk to Alex about his gratifying journey as a self-taught developer and tools you can use to maintain a positive attitude, create balance, decrease stress, and form good habits to enrich your life.</span></p>",
+		"showNotes": "<p><span>This week Bekah and Dan sat down with Alex Curtis-Slep, long time member and volunteer and self-taught developer, about documenting the small wins, falling in love with the process, and aligning your goals to maintain a healthy life while job searching and during your tech career.</span></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe.png",
+		"guests": [
+			{
+				"name": "Alex Curtis-Slep",
+				"bio": "<p>Alex Curtis-Slep is a self taught software developer. After getting his initial tastes of HTML and CSS in the early 2000’s on his basketball blog, Alex jumped into coding in early 2019. He heard about a course Madison Kanna created on roadmapping to become a developer and took the plunge. Following a few years of learning, creating, contributing to open source, and much more, Alex landed his first job in tech at Paypixl. When he’s not coding and hyping up his developer friends, he loves everything basketball, tropical fruit, vegan, travel, family, friend, and foreign language related!</p><ul><li><p><a href=\"http://alexcurtisslep.com\">alexcurtisslep.com</a></p></li><li><p><a href=\"https://github.com/AlexVCS\" rel=\"noopener noreferrer\" target=\"_blank\">@AlexVCS</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/AlexCurtisSlep\" rel=\"noopener noreferrer\" target=\"_blank\">@AlexCurtisSlep</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/alexcurtisslep/\" rel=\"noopener noreferrer\" target=\"_blank\">@alexcurtisslep</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Alex-Curtis.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Carmen - Tech Industry Friendships: Leveraging Connections for Growth, Challenges, and Opportunities and DevOps!",
+		"slug": "carmen-tech-industry-friendships-leveraging-connections-for-growth-challenges-and-opportunities-and-devops",
+		"id": "1841",
+		"metaDescription": "Season Eight, Episode Three of the Virtual Coffee Podcast",
+		"season": 8,
+		"episode": 3,
+		"buzzsproutId": "13047459",
+		"publishDate": "2023-06-21T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Carmen about the impactful role of friendships in the tech industry. We talked about how these connections positively influenced her professional journeys, helped her overcome challenges, and contributed to career growth in DevOps.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Carmen Kohole, a DevOps Engineer based in Portland, Oregon, to chat about the benefits of collaboration and the valuable opportunities you can gain just by asking for help. We also discussed the benefits of fostering strong relationships in the tech industry, and what it means to be a DevOps engineer.</p><h3>Links:</h3><ul><li><p><a href=\"https://twitter.com/thejonanshow\">Jonan Scheffler</a></p></li><li><p><a href=\"https://twitter.com/nickytonline\">Nick Taylor</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0803-Carmen.png",
+		"guests": [
+			{
+				"name": "Carmen",
+				"bio": "<p>DevOps Engineer based in Portland, Oregon. Big fan of house plants, hiking, hats and cats. Here to help build stuff, break stuff, learn stuff and make friends.</p><ul><li><p><a href=\"https://github.com/carmenkolohe\" rel=\"noopener noreferrer\" target=\"_blank\">@carmenkolohe</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/carmenkolohe\" rel=\"noopener noreferrer\" target=\"_blank\">@carmenkolohe</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/carmenkolohe/\" rel=\"noopener noreferrer\" target=\"_blank\">@carmenkolohe</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Carmen.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Caitlin Floyd - Mentorship",
+		"slug": "caitlin-floyd",
+		"id": "1855",
+		"metaDescription": "Season Eight, Episode Four of the Virtual Coffee Podcast",
+		"season": 8,
+		"episode": 4,
+		"buzzsproutId": "13121425",
+		"publishDate": "2023-06-28T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Caitlin about expanding the definition of tech mentorship. We challenge the traditional one-on-one approach and delve into group and community mentorship, where learning, growth, and curiosity thrive collectively. We discuss how active and empathetic listening fosters understanding and knowledge exchange.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Caitlin Floyd, a front-end developer, to chat about the concept of collective learning and explore new possibilities in the evolving landscape of tech mentorship. Discover firsthand how Caitlin's experiences highlight the power of collaboration, breaking down silos, and leveraging collective knowledge to drive innovation and success.</p><h3>Links:</h3><ul><li><p><a href=\"https://the-collab-lab.codes/\">Collab Lab</a></p></li><li><p><a href=\"https://dev.to/the-collab-lab/tcl-22-recap-211m/\">Recap of a Collab Lab cohort that Caitlin participated in</a></p></li><li><p><a href=\"https://leaddev.com/mentoring-coaching-feedback/mentor-coach-sponsor-guide-developing-engineers\">Mentor, coach, sponsor: a guide to developing engineers</a> by Neha Batra</p></li><li><p><a href=\"https://kwugirl.blogspot.com/2020/10/secrets-of-stealth-mentee.html?m=1\">Secrets of a Stealth Mentee</a> by KWu</p></li><li><p><a href=\"https://larahogan.me/sponsors/\">Mentorship and Sponsorship</a> by Lara Hogan</p></li><li><p><a href=\"https://cate.blog/2017/03/21/sponsorship-can-start-small/\">Sponsorship Can Start Small</a> by Cate</p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe_2023-06-28-031129_uyfo.png",
+		"guests": [
+			{
+				"name": "Caitlin Floyd",
+				"bio": "<p>Caitlin is a front-end developer driven by the power of technology as a force for good. Before entering tech, she worked in linguistics, education, and nonprofit management. When not coding, she loves reading, studying languages, traveling, and most of all doting on her puppy.</p><ul><li><p><a href=\"https://caitlinfoyd.com\">caitlinfoyd.com</a></p></li><li><p><a href=\"https://github.com/cafloyd\" rel=\"noopener noreferrer\" target=\"_blank\">@cafloyd</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/caitlinfloyd\" rel=\"noopener noreferrer\" target=\"_blank\">@caitlinfloyd</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/caitlinfloyd/\" rel=\"noopener noreferrer\" target=\"_blank\">@caitlinfloyd</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Caitlin.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Reda - From Maritime Engineer to Self-Taught Front-End Developer",
+		"slug": "reda-from-maritime-engineer-to-self-taught-front-end-developer",
+		"id": "1880",
+		"metaDescription": "Season Eight, Episode Five of the Virtual Coffee Podcast",
+		"season": 8,
+		"episode": 5,
+		"buzzsproutId": "13204285",
+		"publishDate": "2023-07-12T04:00:00+00:00",
+		"shortDescription": "<p>Join hosts Bekah and Dan in this inspiring episode as they talk through the captivating journey of Reda, a self-taught developer. Discover the challenges and triumphs of the world of programming solo, and gain valuable insights on the optimal timing for job applications—because as Reda shares the advice he was given, \"When should you start applying for jobs? Yesterday.\"</p>",
+		"showNotes": "<p><span>Join Bekah and Dan in this week's episode, where they dive into the transformative journey of Reda, a self-taught developer. Hear about the unique challenges and victories Reda faced as he navigated the journey to becoming a front-end developer. Gain valuable advice on the ideal timing for job applications, as Reda shares advice he heard along his journey: \"When should you start applying for jobs? Yesterday.\" Tune in for an enriching conversation that will inspire aspiring self-taught developers and offer practical insights for your career paths.</span></p><h3>Links: </h3><ul><li><p><a href=\"https://www.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Free Code Camp</a></p></li><li><p><a href=\"https://the-collab-lab.codes/\" rel=\"noopener noreferrer\" target=\"_blank\">Collab Lab</a></p></li><li><p><a href=\"https://www.coursera.org/specializations/python\" rel=\"noopener noreferrer\" target=\"_blank\">Python Course</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe_2023-07-11-193524_yhob.png",
+		"guests": [
+			{
+				"name": "Reda",
+				"bio": "<p>I'm a self-taught front-end developer based in Morocco, with a background in Marine Mechanics.</p><ul><li><p><a href=\"https://github.com/redapy\" rel=\"noopener noreferrer\" target=\"_blank\">redapy</a> on GitHub</p></li><li><p><a href=\"https://www.google.com/url?sa=t&amp;rct=j&amp;q=&amp;esrc=s&amp;source=web&amp;cd=&amp;cad=rja&amp;uact=8&amp;ved=2ahUKEwjSsLzRsYeAAxVBmGoFHUEQDNUQFnoECBAQAQ&amp;url=https%3A%2F%2Ftwitter.com%2Fredabaha12&amp;usg=AOvVaw2LtVxW6oDxwQ_Aq1KKL3ik&amp;opi=89978449\" rel=\"noopener noreferrer\" target=\"_blank\">redabaha12</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/redabaha/\" rel=\"noopener noreferrer\" target=\"_blank\">redabaha</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Reda.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Josh - The Life of a Full Time Open Source Developer",
+		"slug": "josh-the-life-of-a-full-time-open-source-developer",
+		"id": "1895",
+		"metaDescription": "Season Eight, Episode Six of the Virtual Coffee Podcast",
+		"season": 8,
+		"episode": 6,
+		"buzzsproutId": "13247190",
+		"publishDate": "2023-07-19T04:00:00+00:00",
+		"shortDescription": "<p>In this episode, Dan and Bekah explore the fascinating journey of being a full-time open source contributor with Josh Goldberg. We discuss the challenges and rewards of dedicating yourself to the open source ecosystem, TypeScript's growing popularity, and how Josh supports the tech community.</p>",
+		"showNotes": "<p>Join Bekah and Dan in this week's episode, where they talk with Josh Goldberg, an independent full time open source developer working on projects in the TypeScript ecosystem, where he shares valuable tips and insights on how you can get started with contributing to open source, whether you're a seasoned developer or just dipping your toes into OSS. Josh also shares the story of his prolific speaking journey over the last couple of years and how staying involved in the tech community has been a rewarding experience.</p><p><strong>Links:</strong></p><ul><li><p><a href=\"https://typescript-eslint.io/\" rel=\"noopener noreferrer\" target=\"_blank\">typescript-eslint</a></p></li><li><p><a href=\"https://github.com/typescript-eslint/typescript-eslint\" rel=\"noopener noreferrer\" target=\"_blank\">typescript-eslint GitHub</a></p></li><li><p><a href=\"https://www.codecademy.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Code Academy</a></p></li><li><p><a href=\"https://sway.office.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Microsoft Sway</a> </p></li><li><p>Josh's Blog posts about applying to conferences:</p><ul><li><p><a href=\"https://blog.joshuakgoldberg.com/how-i-apply-to-conferences/\" rel=\"noopener noreferrer\" target=\"_blank\">How I Apply to Conferences</a></p></li><li><p><a href=\"https://blog.joshuakgoldberg.com/how-i-apply-to-conferences-faqs/\" rel=\"noopener noreferrer\" target=\"_blank\">How I Apply to Conferences: FAQs</a></p></li></ul></li><li><p>Josh's Book: <a href=\"https://www.learningtypescript.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Learning Typescript</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe_2023-07-19-033240_jrwt.png",
+		"guests": [
+			{
+				"name": "Josh Golberg",
+				"bio": "<p>Hi, I’m Josh! I’m an independent full time open source developer. I work on projects in the TypeScript ecosystem, most notably typescript-eslint: the tooling that enables ESLint and Prettier to run on TypeScript code. I’m also the author of the O’Reilly Learning TypeScript book, a Microsoft MVP for developer technologies, and an active conference speaker.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Josh.jpeg"
+			}
+		],
+		"sponsors": [
+			{
+				"title": "LevelUP Financial planning",
+				"url": "https://www.levelupfinancialplanning.com/?vc",
+				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+				"logoWidth": 679,
+				"logoHeight": 525,
+				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+			}
+		]
+	},
+	{
+		"title": "Taiwo Yusuf - The Importance of Having a Learning Mindset",
+		"slug": "taiwo-yusuf-the-importance-of-having-a-learning-mindset",
+		"id": "1910",
+		"metaDescription": "Season Eight, Episode Seven of the Virtual Coffee Podcast",
+		"season": 8,
+		"episode": 7,
+		"buzzsproutId": "13295814",
+		"publishDate": "2023-07-26T04:00:00+00:00",
+		"shortDescription": "<p>In this episode, Dan and Bekah chat with Taiwo, a backend developer from Nigeria. He shares his journey from Electrical Engineering Major to backend development, and the importance of staying motivated and always being hungry to learn and grow.</p>",
+		"showNotes": "<p>Join Bekah and Dan in this week's episode,  where they talk with Taiwo Yusuf, a back-end engineer with a passion for developing innovative solutions.  Despite being the top of his class in Electrical Engineering, he found his passion in backend development. He shares the importance of always learning, growing, and surrounding yourself with people who are more skilled than you are to find inspiration, support, and motivation.</p><p><strong>Links:</strong></p><ul><li><p><a href=\"https://www.grace.health/\" rel=\"noopener noreferrer\" target=\"_blank\">Grace Health</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe-1.png",
+		"guests": [
+			{
+				"name": "Taiwo Yusuf",
+				"bio": "<p>I'm Taiwo Yusuf, a back-end engineer with a passion for developing innovative solutions. I've been fortunate enough to work with amazing companies like Grace Health, LogicShift, and JufoPay. When I'm not busy coding, I'm an avid fan of generative art, and I adore cats. So, whether you want to talk about tech, art, or felines, let's connect and have a chat!</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/3bmcquEcQTRCESX5KIOTJO-AvdRCqPIKvQDtqprXWGY.png"
+			}
+		],
+		"sponsors": [
+			{
+				"title": "LevelUP Financial planning",
+				"url": "https://www.levelupfinancialplanning.com/?vc",
+				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+				"logoWidth": 679,
+				"logoHeight": 525,
+				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+			}
+		]
+	},
+	{
+		"title": "Rafi - Exploring Side Projects and AI",
+		"slug": "rafi-exploring-side-projects-and-ai",
+		"id": "1919",
+		"metaDescription": "Season Eight, Episode Eight of the Virtual Coffee Podcast",
+		"season": 8,
+		"episode": 8,
+		"buzzsproutId": "13331830",
+		"publishDate": "2023-08-02T04:00:00+00:00",
+		"shortDescription": "<p>Join Bekah and Dan in this week's episode,  where they talk with Rafi, a full-stack engineer who develops his passion and motivation with side projects.  Rafi highlights the importance of focusing on developing side projects using a time limit and completing tasks. Learn Rafi's approach to using AI as a tool in his toolbox to accelerate the development process.</p>",
+		"showNotes": "<p>Join hosts Bekah and Dan in this episode featuring Rafi, a talented full-stack developer from Bangalore. In this episode, you'll discover how building new things  and making progress helps him find calmness and focus. Learn Rafi's approach to side projects, including his exploration of Blender, mobile development, Chrome extensions, and Ionic framework. Rafi also shares valuable tips on leveraging AI to enhance learning during project work</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe.png",
+		"guests": [
+			{
+				"name": "Rafi",
+				"bio": "<p>I am a developer, hobbyist who loves JavaScript, Star trek and Cats. I build things, talk tech and write things.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Rafi.png"
+			}
+		],
+		"sponsors": [
+			{
+				"title": "LevelUP Financial planning",
+				"url": "https://www.levelupfinancialplanning.com/?vc",
+				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+				"logoWidth": 679,
+				"logoHeight": 525,
+				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+			}
+		]
+	},
+	{
+		"title": "Ayu & Dominic - Hacktoberfest is Coming, Preptember is Here!",
+		"slug": "ayu-dominic-hacktoberfest-is-coming-preptember-is-here",
+		"id": "1940",
+		"metaDescription": "Season 9, Episode 1 of the Virtual Coffee Podcast",
+		"season": 9,
+		"episode": 1,
+		"buzzsproutId": "13611744",
+		"publishDate": "2023-09-18T04:00:00+00:00",
+		"shortDescription": "<p><span>Join hosts Bekah and Dan in this episode featuring Dominic and Ayu as we explore Preptember—the month where we prepare for Hacktoberfest—and the importance of taking the month to prepare, learn more about open source projects, and evaluate open source repositories to recommend to contributors.</span></p>",
+		"showNotes": "<p>Join hosts Bekah and Dan in this episode with monthly challenge Preptember leads, Dominic and Ayu. We talk about the importance of preparing both as a contributor and a maintainer,  some of the challenges you might face as someone new to those roles during Hacktoberfest, and some of the benefits you'll receive by participating in open source.</p><h3>Links</h3><ul><li><p><a href=\"https://virtualcoffee.io/podcast/0303-ayu-adiati\">Ayu's Episode: Working through burnout as a self-taught developer</a></p></li><li><p><a class=\"postlist-title\" href=\"https://virtualcoffee.io/podcast/dominic-duffin-finding-value-in-challenging-ourselves\">Dominic's Episode: Finding value in challenging ourselves</a></p></li><li><p><a href=\"https://github.com/issues\">Your GitHub Issues</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0901-ayu-dominic.png",
+		"guests": [
+			{
+				"name": "Dominic Duffin",
+				"bio": "<p>Dominic is a Full Stack Developer, community builder, remote worker and aspiring polymath. He's passionate about open source everything, decentralization, peer-to-peer tech and cryptocurrency. He's also to be found playing board games, studying paper maps and riding public transport.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0707-dominic.png"
+			},
+			{
+				"name": "Ayu Adiati",
+				"bio": "<p>Ayu is a self-taught front-end developer and technical blogger based in The Netherlands.</p><p class=\"text-left\">She has a strong interest in building projects that are accessible to everyone.</p><p class=\"text-left\">Her passion for life-long learning is what motivates her open-source contributions, project collaboration, and community engagement.</p><p class=\"text-left\">Learning new things is something that fills her with excitement and she's eager to share her learning in public and pass on her knowledge through her blog and Twitter.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0303-ayu.jpg"
+			}
+		],
+		"sponsors": [
+			{
+				"title": "LevelUP Financial planning",
+				"url": "https://www.levelupfinancialplanning.com/?vc",
+				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+				"logoWidth": 679,
+				"logoHeight": 525,
+				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+			}
+		]
+	},
+	{
+		"title": "OSS Book Review: Nadia Eghbal's Working in Public - The Making and Maintenance of Open Source Software",
+		"slug": "working-in-public-the-making-and-maintenance-of-open-source-software-book-review",
+		"id": "1967",
+		"metaDescription": "Season Nine, Episode Two of the Virtual Coffee Podcast",
+		"season": 9,
+		"episode": 2,
+		"buzzsproutId": "13668999",
+		"publishDate": "2023-09-26T04:00:00+00:00",
+		"shortDescription": "<p><span>Join hosts Bekah and Dan in this episode featuring Jessica Wilkins and Brian Meeker as we delve into the insights from </span>Nadia Eghbal's book \"Working in Public.\" Discover the intricacies of open source collaboration, the evolving dynamics of digital communities, and the profound impact of individual contributions.</p>",
+		"showNotes": "<p>Join hosts Bekah and Dan in this episode with Nadia Eghbal's \"Working in Public\" enthusiasts Jessica Wilkins and Brian Meeker. We discuss the nuances of open source collaboration highlighted in the book, the challenges and rewards of being both a contributor and a maintainer, and the profound impact of individual contributions in the open source community. Dive into the transformative journey of participating in open source and redefining its true meaning with OpenSauced.</p><h3>Links</h3><ul><li><p><a href=\"https://press.stripe.com/working-in-public\">Working in Public: The Making and Maintenance of Open Source Software by Nadia Eghbal</a></p></li><li><p><a href=\"https://github.com/orgs/Virtual-Coffee/discussions/932\">Virtual Coffee Book Club Discussion</a></p></li><li><p><a href=\"https://qz.com/646467/how-one-programmer-broke-the-internet-by-deleting-a-tiny-piece-of-code\">The left-pad story</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0902.png",
+		"guests": [
+			{
+				"name": "Jessica Wilkins",
+				"bio": "<p>Jessica Wilkins is a self taught developer and technical writer from Los Angeles, California.</p><p class=\"text-left\">In her previous career, she was a professional oboist, educator and owner of JDW Sheet Music.</p><p class=\"text-left\">Jessica's interest in programming came during the pandemic when she wanted to build the Black Excellence Music Project which celebrates black artists from the jazz and classical fields.</p><p class=\"text-left\">She now works for freeCodeCamp on the curriculum team.</p><ul><li><p class=\"text-left\"><a href=\"https://github.com/jdwilkin4\"><u>@jdwilkin4 on GitHub</u></a></p></li><li><p class=\"text-left\"><a href=\"https://twitter.com/codergirl1991?lang=en\"><u>@codergirl1991 on Twitter</u></a></p></li><li><p class=\"text-left\"><a href=\"https://www.linkedin.com/in/jessica-wilkins-developer\"><u>@jessica-wilkins-developer on LinkedIn</u></a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0407-jessica.jpg"
+			},
+			{
+				"name": "Brian Meeker",
+				"bio": "<p>Brian Meeker is a full stack engineer who occasionally leaves his basement in Indiana. Currently, he works as a Senior Engineer at Online Rewards. He works mostly in Elixir these days, but has a past littered with a wide variety of technologies and platforms. Outside of work, Brian is a devoted father, avid nerd, and lover of metal.</p><ul><li><p><a href=\"https://brianmeeker.me/\"><u>brianmeeker.me</u></a></p></li><li><p><a href=\"https://github.com/CuriousCurmudgeon\"><span>@CuriousCurmudgeon on GitHub</span></a></p></li><li><p><a href=\"https://twitter.com/CuriousCurmudge\">@CuriousCurmudge on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/brianmeeker\">@brianmeeker on LinkedIn</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/headshot_cropped.png"
+			}
+		],
+		"sponsors": [
+			{
+				"title": "LevelUP Financial planning",
+				"url": "https://www.levelupfinancialplanning.com/?vc",
+				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+				"logoWidth": 679,
+				"logoHeight": 525,
+				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+			}
+		]
+	},
+	{
+		"title": "Open Source Licenses with Matt McInnis, Tom Cudd, and Ray Deck",
+		"slug": "open-source-licenses-with-matt-mcinnis-tom-cudd-and-ray-deck",
+		"id": "2044",
+		"metaDescription": "Season 9, Episode 3 of the Virtual Coffee Podcast",
+		"season": 9,
+		"episode": 3,
+		"buzzsproutId": "13757456",
+		"publishDate": "2023-10-11T04:00:00+00:00",
+		"shortDescription": "<p>Join hosts Bekah and Dan in this special episode where we sit down with Matt McInnis, Ray Deck, and Tom Cudd to explore the often overlooked but crucial topic of open source licenses. We'll discuss the nuances of choosing the right license for your project, the implications it has for contributors and maintainers, and the scenarios where leaving the license blank might actually be a strategic move.</p>",
+		"showNotes": "<p>Join hosts Bekah and Dan with guests Matt McInnis, Ray Deck, and Tom Cudd, as they chat about the complicated topic of open source software (OSS) licenses. They share insights into how to choose the appropriate license, how to understand licenses on other projects, and general guidelines for maintainers and contributors.</p><h3>Links:</h3><ul><li><p><a href=\"http://ChooseALicense.com\"><u>ChooseALicense.com</u></a> by GitHub</p></li><li><p>Example of clarifying subfolders in the LICENSE: <a href=\"https://github.com/tensorflow/models/blob/master/LICENSE\" rel=\"noopener noreferrer\" target=\"_blank\"><u>TensorFlow’s </u></a><code>models</code><a href=\"https://github.com/tensorflow/models/blob/master/LICENSE\" rel=\"noopener noreferrer\" target=\"_blank\"><u> repo</u></a>.</p></li><li><p>Example of a License section in the README indicating what parts of the repo the license applies to: <a href=\"https://github.com/openai/whisper/blob/e8622f9afc4eba139bf796c210f5c01081000472/README.md\" rel=\"noopener noreferrer\" target=\"_blank\"><u>OpenAI’s Whisper model</u></a>. “Whisper’s code and model weights are released under the MIT License.”</p></li><li><p>Example of a paid product with an open source license: <a href=\"https://github.com/craftcms/craft/blob/main/LICENSE.md\" rel=\"noopener noreferrer\" target=\"_blank\"><u>CraftCMS</u></a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0903.png",
+		"guests": [
+			{
+				"name": "Matt McInnis",
+				"bio": "<p>Full-stack developer (Rails+React) at Typist based in Toronto, Canada. Former artificial intelligence lead at IBM and Microsoft, mathematics professor at Centennial College and Saskatchewan Polytechnic. I really love brunch.</p><ul><li><p><a href=\"https://github.com/MattyMc\">@MattyMc on GitHub</a></p></li><li><p><a href=\"https://twitter.com/MattLovesMath\">@MattLovesMath on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/mattmcinnis\">mattmcinnis on LinkedIn</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/1581513771937-1.jpeg"
+			},
+			{
+				"name": "Tom Cudd",
+				"bio": "<p>As an advocate for DevOps within teams and communities, I strive to bring positive change in the way Development and Operations teams work together. I love to help people learn about teams, leadership, infrastructure, cloud, and automation.</p><ul><li><p><a href=\"https://tomcudd.com\">tomcudd.com</a></p></li><li><p><a href=\"https://github.com/tomcudd\">@tomcudd on GitHub</a></p></li><li><p><a href=\"https://twitter.com/tomcudd\">@tomcudd on Twitter</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/dZU1npoqScZd494fteFw.jpg"
+			},
+			{
+				"name": "Ray Deck",
+				"bio": "<p>Veteran leader of technology teams and startup companies over the last 20 years. Most recently founder of <a href=\"http://Statechange.ai\">Statechange.ai</a>, a learning community for solving the hardest 5% of no-code/low-code/AI-code challenges.</p><ul><li><p><a href=\"https://raydeck.com\">raydeck.com</a></p></li><li><p><a href=\"https://statechange.ai\">statechange.ai</a></p></li><li><p><a href=\"https://github.com/rhdeck\">@rhdeck on GitHub</a></p></li><li><p><a href=\"https://twitter.com/ray_deck\">@ray_deck on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/raydeck\">raydeck on LinkedIn</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/2016-11-27-11.25.20-1.jpg"
+			}
+		],
+		"sponsors": [
+			{
+				"title": "LevelUP Financial planning",
+				"url": "https://www.levelupfinancialplanning.com/?vc",
+				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+				"logoWidth": 679,
+				"logoHeight": 525,
+				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+			}
+		]
+	},
+	{
+		"title": "Jessica Wilkins - Using Open Source to Create Connections",
+		"slug": "jessica-wilkins-using-open-source-to-create-connections",
+		"id": "2105",
+		"metaDescription": "Season 9, Episode 4 of the Virtual Coffee Podcast",
+		"season": 9,
+		"episode": 4,
+		"buzzsproutId": "13897541",
+		"publishDate": "2023-11-02T04:00:00+00:00",
+		"shortDescription": "<p>Join hosts Bekah and Dan in this enlightening episode with Jessica Wilkins. Dive deep into the art of nurturing relationships in the open source community. Learn the intricacies of collaborating with maintainers, the value of non-traditional skillsets, and the journey of personal growth as a contributor. </p>",
+		"showNotes": "<p>Join hosts Bekah and Dan as they engage in a captivating conversation with Jessica Wilkins, a prominent figure from freeCodeCamp. In this episode, Jessica shares her invaluable insights on nurturing and developing relationships within the open source community. Delve into the nuances of effective collaboration with maintainers, understand the significance of embracing non-traditional skillsets, and discover the pathways to flourish as a contributor. Jessica's experiences with freeCodeCamp provide a unique perspective on the human dynamics and interpersonal relationships that form the backbone of successful open source projects.</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0904-jessica.png",
+		"guests": [
+			{
+				"name": "Jessica Wilkins",
+				"bio": "<p>Jessica Wilkins is a self taught developer and technical writer from Los Angeles, California.</p><p class=\"text-left\">In her previous career, she was a professional oboist, educator and owner of JDW Sheet Music.</p><p class=\"text-left\">Jessica's interest in programming came during the pandemic when she wanted to build the Black Excellence Music Project which celebrates black artists from the jazz and classical fields.</p><p class=\"text-left\">She now works for freeCodeCamp on the curriculum team.</p><ul><li><p class=\"text-left\"><a href=\"https://github.com/jdwilkin4\"><u>@jdwilkin4 on GitHub</u></a></p></li><li><p class=\"text-left\"><a href=\"https://twitter.com/codergirl1991?lang=en\"><u>@codergirl1991 on Twitter</u></a></p></li><li><p class=\"text-left\"><a href=\"https://www.linkedin.com/in/jessica-wilkins-developer\"><u>@jessica-wilkins-developer on LinkedIn</u></a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0904-jessica.png"
+			}
+		],
+		"sponsors": [
+			{
+				"title": "LevelUP Financial planning",
+				"url": "https://www.levelupfinancialplanning.com/?vc",
+				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+				"logoWidth": 679,
+				"logoHeight": 525,
+				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+			}
+		]
+	},
+	{
+		"title": "Remote Collaboration Tools and Techniques",
+		"slug": "remote-collaboration-tools-and-techniques",
+		"id": "2142",
+		"metaDescription": "Season 10, Episode 1 of the Virtual Coffee Podcast",
+		"season": 10,
+		"episode": 1,
+		"buzzsproutId": "15727596",
+		"publishDate": "2024-09-10T04:00:00+00:00",
+		"shortDescription": "<p><span>In the first episode of Season 10 of the Virtual Coffee Podcast, hosts Bekah and Dan introduce the new format focusing on </span>\"back pocket topics\" from Virtual Coffee <span>community discussions, beginning with a discussion on tools and techniques for remote collaboration.</span></p>",
+		"showNotes": "<p><span>In the first episode of Season 10 of the Virtual Coffee podcast, hosts Bekah and Dan introduce the new format focusing on \"back pocket topics\" from Virtual Coffee community discussions. They delve into common remote collaboration tools and techniques, sharing insights from their experiences in tech. Topics include effective communication, the importance of documentation, and how different company cultures influence remote work. The episode also touches on the role of community members in improving knowledge sharing, both in work settings and open-source projects.</span></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E01.png",
+		"guests": [],
+		"sponsors": [
+			{
+				"title": "LevelUP Financial planning",
+				"url": "https://www.levelupfinancialplanning.com/?vc",
+				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+				"logoWidth": 679,
+				"logoHeight": 525,
+				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+			}
+		]
+	},
+	{
+		"title": "How to Build Trust Capital",
+		"slug": "how-to-build-trust-capital",
+		"id": "2146",
+		"metaDescription": "Season 10, Episode 2 of the Virtual Coffee Podcast",
+		"season": 10,
+		"episode": 1,
+		"buzzsproutId": "15762421",
+		"publishDate": "2024-09-16T04:00:00+00:00",
+		"shortDescription": "<p>Bekah and Dan discuss the concept of 'trust capital' and its importance in tech communities.</p>",
+		"showNotes": "<p><span>In Episode 2 of Season 10 of the Virtual Coffee podcast, hosts Bekah and Dan discuss the concept of 'trust capital' and its importance in tech communities. They define trust capital as the value and trustworthiness one has with others. The hosts explore how to build trust through consistent actions, showing up, transparency, and effective communication. They highlight the difference between networking and building genuine relationships, emphasizing practical ways to accumulate trust capital, such as writing blog posts, mentoring, and being an active, dependable community member. The episode underscores the benefits of trust capital in fostering credibility, enhancing professional relationships, and reducing barriers to collaborative progress.</span></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E02.png",
+		"guests": [],
+		"sponsors": [
+			{
+				"title": "LevelUP Financial planning",
+				"url": "https://www.levelupfinancialplanning.com/?vc",
+				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+				"logoWidth": 679,
+				"logoHeight": 525,
+				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+			}
+		]
+	},
+	{
+		"title": "'Big M' versus 'Little m' Mentorship",
+		"slug": "big-m-versus-little-m-mentorship",
+		"id": "2154",
+		"metaDescription": "Season 10, Episode 3 of the Virtual Coffee Podcast",
+		"season": 10,
+		"episode": 3,
+		"buzzsproutId": "15809647",
+		"publishDate": "2024-09-24T04:00:00+00:00",
+		"shortDescription": "<p><span>Bekah and Dan discuss the differences between formal and informal mentorship, sharing insights on how community and personal connections play a role in effective mentorship.</span></p>",
+		"showNotes": "<p><span>In Season 10, Episode 3 of the Virtual Coffee Podcast, hosts Bekah and Dan explore the topic of 'Big M' versus 'Little m' Mentorship. They distinguish between formal, one-on-one mentorship ('Big M') and more informal, community-based mentorship ('Little M'). They discuss the advantages and potential pitfalls of each approach, emphasizing the importance of finding the right mentorship fit. They also touch on the role of coaches, the value of community support in events like Hacktoberfest, and the concept of a personal 'board of mentors.' </span></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E03.png",
+		"guests": [],
+		"sponsors": [
+			{
+				"title": "LevelUP Financial planning",
+				"url": "https://www.levelupfinancialplanning.com/?vc",
+				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+				"logoWidth": 679,
+				"logoHeight": 525,
+				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+			}
+		]
+	},
+	{
+		"title": "How to Make a Positive Impact during Hacktoberfest",
+		"slug": "how-to-make-a-positive-impact-during-hacktoberfest",
+		"id": "2161",
+		"metaDescription": "Season 10, Episode 4 of the Virtual Coffee Podcast",
+		"season": 10,
+		"episode": 4,
+		"buzzsproutId": "15841150",
+		"publishDate": "2024-09-30T04:00:00+00:00",
+		"shortDescription": "<p>Welcome to Hacktoberfest!</p>",
+		"showNotes": "<p>Bekah and Dan explore the community's engagement with Hacktoberfest, a month-long event encouraging open source contributions. They discuss what Hacktoberfest is and what it means to be a positive contributor in the open source community. They highlight the importance of meaningful contributions, respecting maintainers' time, and provides tips for navigating and contributing to open source projects, and touches on ways to be a good open source citizen and the benefits of contributing consistently to a single project or organization. The episode emphasizes understanding project documentation and being patient with maintainers, while exploring various ways to support open source initiatives beyond writing code.</p><ul><li><p><code>00:00</code> Welcome to the Virtual Coffee Podcast</p></li><li><p><code>00:25</code> Introduction to Hacktoberfest</p></li><li><p><code>00:45</code> Sponsorship Shoutout</p></li><li><p><code>01:08</code> Getting Started with Hacktoberfest</p></li><li><p><code>02:01</code> The Origins of Virtual Coffee and Hacktoberfest</p></li><li><p><code>05:01</code> How to Contribute Positively</p></li><li><p><code>13:02</code> The Importance of Documentation</p></li><li><p><code>18:04</code> Non-Code Contributions</p></li><li><p><code>24:02</code> Building Relationships in Open Source</p></li><li><p><code>26:25</code> Closing Remarks and Contact Information</p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E04.png",
+		"guests": [],
+		"sponsors": [
+			{
+				"title": "LevelUP Financial planning",
+				"url": "https://www.levelupfinancialplanning.com/?vc",
+				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+				"logoWidth": 679,
+				"logoHeight": 525,
+				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+			}
+		]
+	},
+	{
+		"title": "Open Source Maintainer Challenges and Benefits",
+		"slug": "open-source-maintainer-challenges-and-benefits",
+		"id": "2167",
+		"metaDescription": "Season 10, Episode 5 of the Virtual Coffee Podcast",
+		"season": 10,
+		"episode": 5,
+		"buzzsproutId": "15891752",
+		"publishDate": "2024-10-08T04:00:00+00:00",
+		"shortDescription": "<p><span>Bekah and Dan share personal experiences of maintaining open source projects, highlight the benefits of creating a community of contributors, and offer insights into tools and strategies for effective project management and collaboration.</span></p>",
+		"showNotes": "<p>In this episode of the Virtual Coffee Podcast, hosts Bekah and Dan delve into the benefits and challenges of being a maintainer in open source projects, particularly during Hacktoberfest. They discuss the excitement and responsibility of maintaining projects, the joy of welcoming new contributors, and the importance of community building. The hosts also highlight the preparation involved in enhancing project onboarding and documentation, and the growth opportunities for maintainers. The episode also emphasizes strategies to attract contributors and the impact of efficiently managing open source projects.</p><h3>Links:</h3><ul><li><p><a href=\"https://opensauced.pizza/learn\">https://opensauced.pizza/learn</a></p></li><li><p>Becoming an Open Source Maintainer</p></li></ul><p></p><p>00:00 Welcome to Virtual Coffee Podcast</p><p>00:26 Hacktoberfest Excitement and Open Source</p><p>00:43 Sponsorship Shoutout</p><p>01:06 Grab Your Drink and Settle In</p><p>01:34 Maintainer Experiences and Challenges</p><p>03:44 The Joy of Hacktoberfest</p><p>05:08 Maintaining Beyond Hacktoberfest</p><p>08:13 The Importance of Onboarding</p><p>09:29 PrepTember and Readiness</p><p>11:01 Building Trust and Community</p><p>12:18 The Benefits of Being a Maintainer</p><p>17:32 Growing as a Maintainer</p><p>18:40 Marketing Your Open Source Project</p><p>21:06 Community Support and Resources</p><p>23:44 Wrapping Up and Final Thoughts</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E05.png",
+		"guests": [],
+		"sponsors": [
+			{
+				"title": "LevelUP Financial planning",
+				"url": "https://www.levelupfinancialplanning.com/?vc",
+				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+				"logoWidth": 679,
+				"logoHeight": 525,
+				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+			}
+		]
+	},
+	{
+		"title": "Building Relationships in Open Source",
+		"slug": "building-relationships-in-open-source",
+		"id": "2172",
+		"metaDescription": "Season 10, Episode 6 of the Virtual Coffee Podcast",
+		"season": 10,
+		"episode": 6,
+		"buzzsproutId": "15931952",
+		"publishDate": "2024-10-15T04:00:00+00:00",
+		"shortDescription": "<p>The Virtual Coffee Podcast explores the significance of relationship-building and mentorship in open-source communities during Hacktoberfest, underlining practical advice, effective communication, and providing support to foster a welcoming environment for contributors.</p>",
+		"showNotes": "<p><span>In Season 10, Episode 6 of the Virtual Coffee Podcast, hosts Bekah and Dan explore the multifaceted aspects of building and nurturing relationships within the open source community, particularly during Hacktoberfest. The episode highlights the significance of effective networking, making meaningful connections, and becoming a valued repeat contributor. The hosts provide practical advice for newcomers, stressing the importance of understanding projects, submitting quality pull requests, and contributing beyond code through community management and content creation. Emphasizing mentorship, they discuss how maintainers can aid first-time contributors via comprehensive readme files, contributing guides, and constructive feedback. The importance of communication, relationship-building, and the impact of small gestures like a simple thank you are also covered to foster a supportive and efficient open source community.</span></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E06.png",
+		"guests": [],
+		"sponsors": [
+			{
+				"title": "LevelUP Financial planning",
+				"url": "https://www.levelupfinancialplanning.com/?vc",
+				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+				"logoWidth": 679,
+				"logoHeight": 525,
+				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+			}
+		]
+	},
+	{
+		"title": "Climbing the Contributor Ladder",
+		"slug": "climbing-the-contributor-ladder",
+		"id": "2175",
+		"metaDescription": "Season 10, Episode 7 of the Virtual Coffee Podcast",
+		"season": 10,
+		"episode": 7,
+		"buzzsproutId": "15975962",
+		"publishDate": "2024-10-23T04:00:00+00:00",
+		"shortDescription": "<p><span>Dan and Bekah discuss strategies for advancing from contributor to maintainer in open source projects by engaging with the community, understanding contribution guidelines, handling issues effectively, and collaborating respectfully.</span></p>",
+		"showNotes": "<p><span>In this episode of the Virtual Coffee Podcast, hosts Bekah Hawrot Weigel and Dan Ott delve into the journey of climbing the contributor ladder in open-source projects. They explore the progression from contributor to maintainer, focusing on the importance of trust-building, consistent contributions, and respectful interactions within the community. Key strategies discussed include engaging with project documentation, reproducing bugs, and effective communication. The episode also highlights how projects like Astro and Nuxt guide contributors and the role of events like Hacktoberfest in encouraging new participation. Real-life examples illustrate how proactive engagement can lead to managing more complex tasks and even job opportunities. Sponsored by Level Up Financial Planning, this insightful episode is a must-listen for anyone looking to make significant strides in the open-source community.</span><br><br><span>Visit <a href=\"https://virtualcoffee.io/resources/developer-resources/open-source\">https://virtualcoffee.io/resources/developer-resources/open-source</a> for additional resources.</span></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E07.png",
+		"guests": [],
+		"sponsors": [
+			{
+				"title": "LevelUP Financial planning",
+				"url": "https://www.levelupfinancialplanning.com/?vc",
+				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+				"logoWidth": 679,
+				"logoHeight": 525,
+				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+			}
+		]
+	},
+	{
+		"title": "Open Sourcing a Private Repo",
+		"slug": "open-sourcing-a-private-repo",
+		"id": "2178",
+		"metaDescription": "Season 10, Episode 8 of the Virtual Coffee Podcast",
+		"season": 10,
+		"episode": 8,
+		"buzzsproutId": "16019031",
+		"publishDate": "2024-10-30T04:00:00+00:00",
+		"shortDescription": "<p><span>Bekah and Dan discuss the considerations and steps involved in open sourcing a private repository, sharing insights from their own experience with the Virtual Coffee community docs.</span></p>",
+		"showNotes": "<p><span>In Episode 8 of Season 10 of the Virtual Coffee Podcast, hosts Bekah and Dan delve into the intricate process of open sourcing a private repository. Drawing from their experience with Virtual Coffee's community docs, they discuss considerations like verifying the safety of repository content, ensuring appropriate permissions, and maintaining the privacy of sensitive discussions. They also touch on the importance of updating READEMEs, licensing, and providing clear guidelines for new contributors.</span></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E08.png",
+		"guests": [],
+		"sponsors": []
+	}
 ]

--- a/src/data/podcast/episodes.json
+++ b/src/data/podcast/episodes.json
@@ -1,0 +1,1922 @@
+[
+  {
+    "title": "Virtual Coffee Podcast Trailer",
+    "slug": "0000-trailer",
+    "id": "271",
+    "metaDescription": "Welcome to the Virtual Coffee Podcast!",
+    "season": 1,
+    "episode": 0,
+    "buzzsproutId": "7119532",
+    "publishDate": "2021-01-04T05:00:00+00:00",
+    "shortDescription": "<p>Welcome to the Virtual Coffee Podcast!</p>",
+    "showNotes": "<p>This is the Virtual Coffee Podcast, hosted by Bekah Hawrot Weigel and Dan Ott. You'll find interviews with members of our community to learn more about their stories, who they are, how they found Virtual Coffee, and how it has influenced their lives as developers. We want to bring everything that's special about Virtual Coffee, the intimacy and the friendships we’ve built, and share that with everyone through the podcast. We’re always growing and learning together as a group, and there’s something really special about being able to do that knowing that you’ll have the full support of the community around you. And that’s what this podcast is about too.</p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/virtual-coffee-mug-square.png",
+    "guests": [
+      {
+        "name": "Virtual Coffee IO",
+        "bio": "<ul><li><p><a href=\"https://virtualcoffee.io/podcast\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee Podcast</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/virtual-coffee-mug-square.png"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Nick Taylor: Open Source, Live Streaming, and Structured YOLO",
+    "slug": "0101-nickyt",
+    "id": "284",
+    "metaDescription": "Season One, Episode One of the Virtual Coffee Podcast",
+    "season": 1,
+    "episode": 1,
+    "buzzsproutId": "7238548",
+    "publishDate": "2021-01-11T05:00:00+00:00",
+    "shortDescription": "<p>Dan and Bekah welcome Nick Taylor (Senior Software Engineer at Forem/DEV) to talk about his journey into tech, open source, and the importance of community</p>",
+    "showNotes": "<p>Dan and Bekah welcome Nick Taylor (Senior Software Engineer at Forem/DEV) to talk about his journey into tech, open source, and the importance of community. Nick talks about his journey through University and into tech, how the landscape of tech has changed with increased resources and community, and how his idea of \"structured YOLO\" has lead him to this point in his career. He talks about how his job at Forem and how the pandemic led to his livestreaming, where he tries to make coding as realistic as possible. His hour and a half livestreams focus on one issue, but realistically those issues won't be solved during that time. And that's ok, because coding takes time, and working through issues won't always be a simple solution. His approach to teaching includes learning as you go, which made him an amazing contributor, mentor, and maintainer for the Virtual Coffee Hacktoberfest Initiative. Every conversation with Nick is an interesting one, and this one isn't an exception.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Nick: <a href=\"https://dev.to/nickytonline\" rel=\"noopener noreferrer\" target=\"_blank\">https://dev.to/nickytonline</a></p></li><li><p>Forem: <a href=\"https://www.forem.com/\" rel=\"noopener noreferrer\" target=\"_blank\">https://www.forem.com/</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0101-nickyt-episode.jpg",
+    "guests": [
+      {
+        "name": "Nick Taylor",
+        "bio": "<p>Senior Software Engineer at <a href=\"https://www.forem.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Forem</a>, the software that powers <a href=\"https://dev.to/\" rel=\"noopener noreferrer\" target=\"_blank\">DEV</a>, working on all things Forem.</p><ul><li><p><a href=\"https://iamdeveloper.com/\" rel=\"noopener noreferrer\" target=\"_blank\">iamdeveloper.com</a></p></li><li><p><a href=\"https://livecoding.ca/\" rel=\"noopener noreferrer\" target=\"_blank\">livecoding.ca</a></p></li><li><p><a href=\"https://twitter.com/nickytonline\" rel=\"noopener noreferrer\" target=\"_blank\">twitter.com/nickytonline</a></p></li><li><p><a href=\"https://dev.to/nickytonline\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/nickytonline</a></p></li><li><p><a href=\"https://iamdeveloper.com/hacktoberfest2020\" rel=\"noopener noreferrer\" target=\"_blank\">Getting the Most Out of Open Source</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0101-nickyt.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Marie Antons: From Chef to Tech",
+    "slug": "0102-marieantons",
+    "id": "291",
+    "metaDescription": "Season One, Episode Two of the Virtual Coffee Podcast",
+    "season": 1,
+    "episode": 2,
+    "buzzsproutId": "7323430",
+    "publishDate": "2021-01-18T05:00:00+00:00",
+    "shortDescription": "<p>In this episode, Marie Antons talks with Dan, Bekah, and Kirk about how she went from being a chef to a junior developer.</p>",
+    "showNotes": "<p>In this episode, Marie Antons talks with Dan, Bekah, and Kirk about how she went from being a chef to a junior developer. With more and more developers coming into tech from non-traditional backgrounds, Marie shares her own unique story and how taking her past experience as a chef allowed her to understand coding in her own way. There are ingredients and steps to follow with recipes, and similarly, as you learn to code, you'll find what you need to get your code to work and the process you need to take to get there. She also talks about the challenges of coming into her first job from a bootcamp, and what she wishes she would've known before starting that job.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p><a href=\"https://www.deltavcodeschool.com/\" rel=\"noopener noreferrer\" target=\"_blank\">DeltaV Code School</a></p></li><li><p><a href=\"https://stratafolio.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Stratafolio</a></p></li><li><p><a href=\"https://d3js.org/\" rel=\"noopener noreferrer\" target=\"_blank\">D3 javascript library</a></p></li><li><p><a href=\"https://wattenberger.com/blog/css-percents\" rel=\"noopener noreferrer\" target=\"_blank\">Amy Wattenberger</a> (the blogger Dan couldn't remember!)</p></li><li><p><a href=\"https://twitter.com/MarieAntons\" rel=\"noopener noreferrer\" target=\"_blank\">@MarieAntons</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/marie\" rel=\"noopener noreferrer\" target=\"_blank\">Marie Antons</a> on LinkedIn</p></li><li><p>Kirk: <a href=\"https://twitter.com/tkshillinz\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshillinz</a> on Twitter</p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0102-marie-episode.jpg",
+    "guests": [
+      {
+        "name": "Marie Antons",
+        "bio": "<p>Marie is a C#/.NET developer working for a small start-up called Stratafolio.</p><ul><li><p><a href=\"https://twitter.com/MarieAntons\" rel=\"noopener noreferrer\" target=\"_blank\">@MarieAntons</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/marie\" rel=\"noopener noreferrer\" target=\"_blank\">Marie Antons</a> on LinkedIn</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0102-marie.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Tori Crawford: Interviewing — If it's broke, fix it",
+    "slug": "0103-tori-crawford",
+    "id": "298",
+    "metaDescription": "Season One, Episode Three of the Virtual Coffee Podcast",
+    "season": 1,
+    "episode": 3,
+    "buzzsproutId": "7474594",
+    "publishDate": "2021-01-25T05:00:00+00:00",
+    "shortDescription": "<p>In this episode, Dan and Bekah welcome Tori Crawford to talk about her journey through the interview process that included about 53 interviews, 430 applications, and a pandemic offer that ultimately led to her being ghosted by the company.</p>",
+    "showNotes": "<p>In this episode, Dan and Bekah welcome Tori to talk about her journey through the interview process that included about 53 interviews, 430 applications, and a pandemic offer that ultimately led to her being ghosted by the company. She gives her tips and tricks, including recognizing that interviews are a two-way street; you should also be interviewing the companies that are interviewing you. She talks about the problems of technical interviewing, how she's hopeful that the industry can make changes, and how the job she ultimately landed has been a great experience, starting with the interview.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Tori: <a href=\"https://dev.to/torianne02\" rel=\"noopener noreferrer\" target=\"_blank\">DEV</a>, <a href=\"https://twitter.com/_torrborr\" rel=\"noopener noreferrer\" target=\"_blank\">Twitter</a></p></li><li><p>Article Tori wrote detailing her interview journey: <a href=\"https://dev.to/torianne02/444-days-later-tori-hit-the-jackpot-3o4p\" rel=\"noopener noreferrer\" target=\"_blank\">444 Days Later, Tori Hit the Jackpot</a></p></li><li><p>Udemy course mentioned: <a href=\"https://www.udemy.com/course/master-the-coding-interview-data-structures-algorithms/\" rel=\"noopener noreferrer\" target=\"_blank\">Master the Coding Interview: Data Structures + Algorithms</a></p></li><li><p><a href=\"https://flatironschool.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Flatiron School</a></p></li><li><p><a href=\"https://firehydrant.io/\" rel=\"noopener noreferrer\" target=\"_blank\">FireHydrant</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0103-tori-episode.jpg",
+    "guests": [
+      {
+        "name": "Tori Crawford",
+        "bio": "<p>Software Engineer at <a href=\"https://firehydrant.io/\" rel=\"noopener noreferrer\" target=\"_blank\">FireHydrant</a>.</p><ul><li><p><a href=\"https://twitter.com/_torrborr\" rel=\"noopener noreferrer\" target=\"_blank\">@_torrborr</a> on Twitter</p></li><li><p><a href=\"https://dev.to/torianne02\" rel=\"noopener noreferrer\" target=\"_blank\">torianne02</a> on DEV</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0103-tori.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Vic Vijayakumar: Indie Hacking",
+    "slug": "0104-vic-vijayakumar",
+    "id": "305",
+    "metaDescription": "Season One, Episode Four of the Virtual Coffee Podcast",
+    "season": 1,
+    "episode": 4,
+    "buzzsproutId": "7564483",
+    "publishDate": "2021-02-01T05:00:00+00:00",
+    "shortDescription": "<p>In this episode, Vic talks about Indie Hacking and gives us his take on when to ship, what to focus on, and the value of diverse opinions in your community.</p>",
+    "showNotes": "<p>In this episode, Vic talks about Indie Hacking and gives us his take on when to ship, what to focus on, and the value of diverse opinions in your community. He also talks about treating life as a lot of drafts and about building things that you're passionate about as well as things that others find valuable. He cautions against the danger of survivorship bias, recognizing that it's difficult to find a path in indie hacking and that many of the popular voices have worked through challenges and no longer effectively represent how difficult it is to create a product that's successful.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><h5 class=\"text-left\"><strong>Vic:</strong></h5><ul><li><p><a href=\"https://vicvijayakumar.com/\" rel=\"noopener noreferrer\" target=\"_blank\">vicvijayakumar.com</a></p></li><li><p><a href=\"https://twitter.com/vicvijayakumar\" rel=\"noopener noreferrer\" target=\"_blank\">@vicvijayakumar</a> on Twitter</p></li></ul><h5 class=\"text-left\"><strong>Vic's Projects:</strong></h5><ul><li><p><a href=\"https://www.everyoak.com/\" rel=\"noopener noreferrer\" target=\"_blank\">EveryOak</a></p></li><li><p><a href=\"https://meetsweats.com/\" rel=\"noopener noreferrer\" target=\"_blank\">MeetSweats.com</a></p></li><li><p><a href=\"https://dogears.xyz/\" rel=\"noopener noreferrer\" target=\"_blank\">Dog Ears</a></p></li></ul><h5 class=\"text-left\"><strong>Low-Code Tools:</strong></h5><ul><li><p><a href=\"https://carrd.co/\" rel=\"noopener noreferrer\" target=\"_blank\">Carrd</a></p></li><li><p><a href=\"https://zapier.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Zapier</a></p></li><li><p><a href=\"https://airtable.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Airtable</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0104-vic-episode.jpg",
+    "guests": [
+      {
+        "name": "Vic Vijayakumar",
+        "bio": "<p>Principal software engineer at <a href=\"https://www.researchsquare.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Research Square</a>, a preprint platform</p><ul><li><p><a href=\"https://vicvijayakumar.com/\" rel=\"noopener noreferrer\" target=\"_blank\">vicvijayakumar.com</a></p></li><li><p><a href=\"https://twitter.com/vicvijayakumar\" rel=\"noopener noreferrer\" target=\"_blank\">@vicvijayakumar</a> on Twitter</p></li><li><p><a href=\"https://www.everyoak.com/\" rel=\"noopener noreferrer\" target=\"_blank\">EveryOak</a></p></li><li><p><a href=\"https://meetsweats.com/\" rel=\"noopener noreferrer\" target=\"_blank\">MeetSweats.com</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0104-vic.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Cameron Bardell and Rahat Chowdhury: Mental Health & Tech",
+    "slug": "0105-cameron-rahat",
+    "id": "312",
+    "metaDescription": "Season One, Episode Five of the Virtual Coffee Podcast",
+    "season": 1,
+    "episode": 5,
+    "buzzsproutId": "7741411",
+    "publishDate": "2021-02-08T05:00:00+00:00",
+    "shortDescription": "<p>In this episode, Bekah and Dan talk about mental health with Cameron Bardell, an iOS developer in the healthcare industry, and Rahat Chowdhury, a mental health start-up founder.</p>",
+    "showNotes": "<p>In this episode, Bekah and Dan talk about mental health with Cameron Bardell, an iOS developer in the healthcare industry, and Rahat Chowdhury, a mental health start-up founder. We talk about how sometimes building a product to meet our own needs is a great place to start and the importance of prioritizing mental health, especially in a fast-paced industry like tech. We walk through our own experiences, how mental health recovery isn't linear, and how different approaches to mental health technology create support for more people.</p><p class=\"text-left\">If you or someone else is suffering from mental health issues, you aren't alone. Below are some links to help you find resources or to seek help:</p><ul><li><p><a href=\"https://suicidepreventionlifeline.org/\" rel=\"noopener noreferrer\" target=\"_blank\">National Suicide Prevention Lifeline</a> - 1-800-273-8255</p></li><li><p><a href=\"https://www.samhsa.gov/find-help/national-helpline\" rel=\"noopener noreferrer\" target=\"_blank\">SAMHSA’s National Helpline</a> - 1-800-662-HELP (4357)</p></li><li><p><a href=\"https://cmha.ca/\" rel=\"noopener noreferrer\" target=\"_blank\">CMHA National</a></p></li></ul><h4 class=\"text-left\"><strong>Links:</strong></h4><h5 class=\"text-left\"><strong>Cameron:</strong></h5><ul><li><p><a href=\"https://cambardell.github.io/\" rel=\"noopener noreferrer\" target=\"_blank\">cambardell.github.io</a></p></li><li><p><a href=\"https://twitter.com/cameronbardell\" rel=\"noopener noreferrer\" target=\"_blank\">@cameronbardell</a> on Twitter</p></li></ul><h5 class=\"text-left\"><strong>Rahat:</strong></h5><ul><li><p><a href=\"https://www.rahatcodes.com/\" rel=\"noopener noreferrer\" target=\"_blank\">rahatcodes.com</a></p></li><li><p><a href=\"https://twitter.com/Rahatcodes\" rel=\"noopener noreferrer\" target=\"_blank\">@Rahatcodes</a> on Twitter</p></li><li><p><a href=\"https://whimser.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Whimser</a></p></li><li><p>Open source mental health resources database: <a href=\"https://www.sylarproject.com/\" rel=\"noopener noreferrer\" target=\"_blank\">The Sylar Project</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0105-camrahat-episode.jpg",
+    "guests": [
+      {
+        "name": "Cameron Bardell",
+        "bio": "<p>iOS developer in the healthcare industry</p><ul><li><p><a href=\"https://cambardell.github.io/\" rel=\"noopener noreferrer\" target=\"_blank\">cambardell.github.io</a></p></li><li><p><a href=\"https://twitter.com/cameronbardell\" rel=\"noopener noreferrer\" target=\"_blank\">@cameronbardell</a> on Twitter</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0105-cameron.jpg"
+      },
+      {
+        "name": "Rahat Chowdhury",
+        "bio": "<p>Mental health start-up founder</p><ul><li><p><a href=\"https://www.rahatcodes.com/\" rel=\"noopener noreferrer\" target=\"_blank\">rahatcodes.com</a></p></li><li><p><a href=\"https://twitter.com/Rahatcodes\" rel=\"noopener noreferrer\" target=\"_blank\">@Rahatcodes</a> on Twitter</p></li><li><p><a href=\"https://whimser.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Whimser</a></p></li><li><p><a href=\"https://www.sylarproject.com/\" rel=\"noopener noreferrer\" target=\"_blank\">The Sylar Project</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0105-rahat.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Drew Clements: Building a career and community",
+    "slug": "0106-drew",
+    "id": "329",
+    "metaDescription": "Season One, Episode Six of the Virtual Coffee Podcast",
+    "season": 1,
+    "episode": 6,
+    "buzzsproutId": "7867681",
+    "publishDate": "2021-02-15T05:00:00+00:00",
+    "shortDescription": "<p>In this episode, Bekah and Dan are joined by Drew Clements to talk about the struggles of junior-level job searching, the importance of supportive company culture, and learning in public while building <a href=\"https://protege.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Protege.dev</a>.</p>",
+    "showNotes": "<p>In this episode, we talk to Drew Clements about the challenges junior developers face, learning through building Protege.dev, and the importance of community support. Drew is a career transitioner, father of two, and full-time developer who spends his spare time building Protege.dev, the platform curated with remote jobs for junior developers. We also talk about approaches to problem-solving, when to ask questions, and using live-streaming as an accountability tool.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><h5 class=\"text-left\"><strong>Drew:</strong></h5><ul><li><p><a href=\"https://twitter.com/drewclemcr8\" rel=\"noopener noreferrer\" target=\"_blank\">@drewclemcr8</a> on Twitter</p></li><li><p><a href=\"https://protege.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Protege.dev</a></p></li><li><p><a href=\"https://github.com/drewclem/\" rel=\"noopener noreferrer\" target=\"_blank\">drewclem</a> on GitHub</p></li><li><p><a href=\"https://dev.to/drewclem/\" rel=\"noopener noreferrer\" target=\"_blank\">drewclem</a> on DEV</p></li></ul><h5 class=\"text-left\"><strong>Stu the Rubber Duck!</strong></h5><p class=\"text-left\"></p><img src=\"http://storage.googleapis.com/virtualcoffeeio-assets/images/_podcastShowNotesImage/0106-drew-duck.jpg\" alt=\"Drew holding Stu the Rubber Duck!\" title=\"\">",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0106-drew-episode.jpg",
+    "guests": [
+      {
+        "name": "Drew Clements",
+        "bio": "<p>Frontend Engineer at <a href=\"https://www.fostercommerce.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Foster Commerce</a>, co-founder of <a href=\"https://protege.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Protege.dev</a></p><ul><li><p><a href=\"https://twitter.com/drewclemcr8\" rel=\"noopener noreferrer\" target=\"_blank\">@drewclemcr8</a> on Twitter</p></li><li><p><a href=\"https://protege.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Protege.dev</a></p></li><li><p><a href=\"https://github.com/drewclem/\" rel=\"noopener noreferrer\" target=\"_blank\">drewclem</a> on GitHub</p></li><li><p><a href=\"https://dev.to/drewclem/\" rel=\"noopener noreferrer\" target=\"_blank\">drewclem</a> on DEV</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0106-drew.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Colleen Schnettler -- Tech: It's hard, but it's worth it",
+    "slug": "0107-colleen",
+    "id": "337",
+    "metaDescription": "Season One, Episode Seven of the Virtual Coffee Podcast",
+    "season": 1,
+    "episode": 7,
+    "buzzsproutId": "8007425",
+    "publishDate": "2021-02-22T05:00:00+00:00",
+    "shortDescription": "<p>In this episode, Bekah and Dan are joined by Colleen Schnettler to talk about the challenges women face in the workplace, the benefits of working for yourself, and growing her SaaS business.</p>",
+    "showNotes": "<p>In this episode, we talk to Colleen Schnettler about the challenges of being a woman in the workplace, the benefits of working for yourself, and building her own SaaS business. Colleen is a Ruby on Rails consultant, who recently launched her <a href=\"https://www.simplefileupload.com/\" rel=\"noopener noreferrer\" target=\"_blank\">first product</a>, a career changer, and a mom. Colleen talks about how difficult it is to learn to code; it will take time and commitment, but when you get there, it will all be worth it.</p><h5 class=\"text-left\"><strong>Colleen:</strong></h5><ul><li><p><a href=\"https://twitter.com/leenyburger\" rel=\"noopener noreferrer\" target=\"_blank\">@leenyburger</a> on Twitter</p></li><li><p><a href=\"http://www.bitmappeddesigns.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Bitmapped Designs</a></p></li><li><p><a href=\"https://www.simplefileupload.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Simple File Upload</a></p></li><li><p><a href=\"https://twitter.com/softwaresocpod\" rel=\"noopener noreferrer\" target=\"_blank\">@softwaresocpod</a> - Software Social Podcast</p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0107-colleen-episode.jpg",
+    "guests": [
+      {
+        "name": "Colleen Schnettler",
+        "bio": "<p>Ruby on Rails consultant at <a href=\"http://www.bitmappeddesigns.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Bitmapped Designs</a>.</p><ul><li><p><a href=\"https://twitter.com/leenyburger\" rel=\"noopener noreferrer\" target=\"_blank\">@leenyburger</a> on Twitter</p></li><li><p><a href=\"http://www.bitmappeddesigns.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Bitmapped Designs</a></p></li><li><p><a href=\"https://www.simplefileupload.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Simple File Upload</a></p></li><li><p><a href=\"https://twitter.com/softwaresocpod\" rel=\"noopener noreferrer\" target=\"_blank\">@softwaresocpod</a> - Software Social Podcast</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0107-colleen.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Kirk Shillingford: On Making Mistakes, Growth, and the Importance of Community",
+    "slug": "0108-kirk",
+    "id": "344",
+    "metaDescription": "Season One, Episode Eight of the Virtual Coffee Podcast",
+    "season": 1,
+    "episode": 8,
+    "buzzsproutId": "8052553",
+    "publishDate": "2021-03-01T05:00:00+00:00",
+    "shortDescription": "<p>In this episode, Dan and Bekah talk to Kirk Shillingford, a software developer (and Community Maintainer at Virtual Coffee), about the importance of making mistakes and the growth that comes with it.</p>",
+    "showNotes": "<p>In this episode, Dan and Bekah talk to Kirk Shillingford, a software developer (and Community Maintainer at Virtual Coffee), who has been \"haphazardly writing code for about seven years,\" about the importance of making mistakes and the growth that comes with it. We also talk about empathy being a key indicator of a senior developer and the importance of having a supportive community.</p><h5 class=\"text-left\"><strong>Links:</strong></h5><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://twitter.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Neverwinter_Nights\" rel=\"noopener noreferrer\" target=\"_blank\">Never Winter Nights</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0108-kirk-episode.jpg",
+    "guests": [
+      {
+        "name": "Kirk Shillingford",
+        "bio": "<p>Software Developer, and Community Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://twitter.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0108-kirk.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Dan and Bekah: Season One Wrap-Up",
+    "slug": "0109-bekah-dan",
+    "id": "353",
+    "metaDescription": "Season One, Episode Nine of the Virtual Coffee Podcast",
+    "season": 1,
+    "episode": 9,
+    "buzzsproutId": "8096247",
+    "publishDate": "2021-03-07T05:00:00+00:00",
+    "shortDescription": "<p>In this episode of the podcast, Dan and Bekah switch things up. Since it's last episode of season one, they share a bit about their origin stories, when their paths connected, and how that led to where Virtual Coffee is today.</p>",
+    "showNotes": "<p>In this episode of the podcast, Dan and Bekah switch things up. Since it's last episode of season one, they share a bit about their origin stories, when their paths connected, and how that led to where Virtual Coffee is today. They talk about the challenges of the last year, how Virtual Coffee has been a light during dark times, and how growing can be painful, but also the process that allows you to become more than you could've imagined. And they also drop some of their favorite Virtual Coffee moments of the last year.</p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0109-bekahdan-episode.jpg",
+    "guests": [
+      {
+        "name": "Bekah Hawrot Weigel",
+        "bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dev.to/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/bekahhw</a></p></li><li><p><a href=\"https://twitter.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">@bekahhw</a> on Twitter</p></li><li><p><a href=\"https://www.instagram.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">bekahhw</a> on Instagram</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0109-bekah.jpg"
+      },
+      {
+        "name": "Dan Ott",
+        "bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dtott.com/\" rel=\"noopener noreferrer\" target=\"_blank\">dtott.com</a></p></li><li><p><a href=\"https://twitter.com/danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">@danieltott</a> on Twitter</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0109-dan.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Gant Laborde: Finding your Voice",
+    "slug": "0201-gant",
+    "id": "370",
+    "metaDescription": "Season Two, Episode One of the Virtual Coffee Podcast",
+    "season": 2,
+    "episode": 1,
+    "buzzsproutId": "8281596",
+    "publishDate": "2021-04-06T04:00:00+00:00",
+    "shortDescription": "<p>We're back! In this episode of the Virtual Coffee podcast, Dan and Bekah talk to Gant Laborde, an owner of Infinite Red, mentor, adjunct professor, published author, and award-winning speaker, about overcoming challenges, being authentic, and finding your voice.</p>",
+    "showNotes": "<p>In this episode of the Virtual Coffee podcast, Dan and Bekah talk to Gant Laborde, an owner of Infinite Red, mentor, adjunct professor, published author, and award-winning speaker, about overcoming challenges, being authentic, and finding your voice. They share some of the struggles they've faced, talk about how practice can lead to growth, and the importance of recognizing your body's signals in the process.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Gant: <a href=\"https://gantlaborde.com/\" rel=\"noopener noreferrer\" target=\"_blank\">gantlaborde.com</a>, <a href=\"https://twitter.com/GantLaborde\" rel=\"noopener noreferrer\" target=\"_blank\">@GantLaborde</a></p></li><li><p>Some blog posts about public speaking by Gant:</p><ul><li><p><a href=\"https://gantlaborde.medium.com/open-your-speech-and-make-it-marvelous-e031cfa18858\" rel=\"noopener noreferrer\" target=\"_blank\">Open your speech, and make it marvelous</a></p></li><li><p><a href=\"https://medium.com/hackernoon/5-conference-speaking-tips-from-tech-gurus-2f7d1a250af3\" rel=\"noopener noreferrer\" target=\"_blank\">5 Conference Speaking Tips from Tech Gurus</a></p></li><li><p><a href=\"https://shift.infinite.red/the-road-to-distinguished-c9e458da091c\" rel=\"noopener noreferrer\" target=\"_blank\">The Road to Distinguished: From Afraid to Awarded — The path to public speaking success</a></p></li></ul></li><li><p><a href=\"https://cryptozombies.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Cryptozombies</a></p></li><li><p><a href=\"https://geddski.teachable.com/p/flexbox-zombies\" rel=\"noopener noreferrer\" target=\"_blank\">Flexbox zombies</a></p></li><li><p><a href=\"https://infinite.red/\" rel=\"noopener noreferrer\" target=\"_blank\">Infinite Red</a></p></li><li><p><a href=\"https://www.toastmasters.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Toastmasters</a></p></li><li><p><a href=\"https://www.amazon.com/gp/product/1492090794/ref=as_li_qf_asin_il_tl?ie=UTF8&amp;tag=gant0d-20&amp;creative=9325&amp;linkCode=as2&amp;creativeASIN=1492090794&amp;linkId=9b7b356b7b13efdaf9d34bfa47f7a6ee\" rel=\"noopener noreferrer\" target=\"_blank\">Learning TensorFlow.js: Powerful Machine Learning in JavaScript by Gant Laborde</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0201-gant-episode.jpg",
+    "guests": [
+      {
+        "name": "Gant Laborde",
+        "bio": "<p>Gant Laborde is an owner of Infinite Red, mentor, adjunct professor, published author, and award-winning speaker. For 20 years, he has been involved in software development and continues strong today. He is recognized as a Google Developer Expert in Web and Machine Learning, but informally he is an “open sourcerer” and aspires to one day become a mad scientist. He blogs, videos, and maintains popular repositories for the community. Follow Gant’s adventures at <a href=\"https://gantlaborde.com/\" rel=\"noopener noreferrer\" target=\"_blank\">gantlaborde.com</a>.</p>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0201-gant.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Lucia Cerchie: Mom life and finding your confidence",
+    "slug": "0202-lucia",
+    "id": "377",
+    "metaDescription": "Season Two, Episode Two of the Virtual Coffee Podcast",
+    "season": 2,
+    "episode": 2,
+    "buzzsproutId": "8315337",
+    "publishDate": "2021-04-11T04:00:00+00:00",
+    "shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk with Lucia Cercie, a Software Engineer, about the importance of having a growth-mindset, asking questions, and pair programming.</p>",
+    "showNotes": "<p>In this episode of the podcast, Dan and Bekah talk with Lucia Cercie, a Software Engineer at <a href=\"https://stepzen.com/\" rel=\"noopener noreferrer\" target=\"_blank\">StepZen</a>, mom, and Arizona transplant, about the importance of having a growth-mindset, asking questions, and pair programming. We also talk about the power of community and feeling comfortable asking questions and asking for help. When she's not coding, Lucia likes to make her baby laugh.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Lucia: <a href=\"https://luciacerchie.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">luciacerchie.dev</a>, <a href=\"https://twitter.com/CerchieLucia\" rel=\"noopener noreferrer\" target=\"_blank\">@CerchieLucia</a> on Twitter, <a href=\"https://dev.to/cerchie\" rel=\"noopener noreferrer\" target=\"_blank\">cerchi</a> on DEV</p></li><li><p><a href=\"https://stepzen.com/\" rel=\"noopener noreferrer\" target=\"_blank\">StepZen</a></p></li><li><p><a href=\"https://hbr.org/2016/01/what-having-a-growth-mindset-actually-means\" rel=\"noopener noreferrer\" target=\"_blank\"><em>What Having a “Growth Mindset” Actually Means</em></a><a href=\"https://hbr.org/2016/01/what-having-a-growth-mindset-actually-means\" rel=\"noopener noreferrer\" target=\"_blank\"> </a>by Carol Dweck</p></li><li><p><a href=\"https://martinfowler.com/articles/on-pair-programming.html\" rel=\"noopener noreferrer\" target=\"_blank\"><em>On Pair Programming</em></a> by Martin Fowler</p></li><li><p><a href=\"https://www.youtube.com/watch?v=u8qgehH3kEQ\" rel=\"noopener noreferrer\" target=\"_blank\">NCIS \"pair programming\"</a></p></li><li><p><a href=\"https://lindastone.net/2014/11/24/are-you-breathing-do-you-have-email-apnea/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Are You Breathing? Do You Have Email Apnea?</em></a> by Linda Stone</p></li><li><p><a href=\"https://oisinmoran.com/quinetweet\" rel=\"noopener noreferrer\" target=\"_blank\"><em>How I Made a Self-Quoting Tweet</em></a><a href=\"https://oisinmoran.com/quinetweet\" rel=\"noopener noreferrer\" target=\"_blank\"> </a>by Oisín Moran</p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0202-lucia-episode.jpg",
+    "guests": [
+      {
+        "name": "Lucia Cerchie",
+        "bio": "<p>Lucia Cerchie is a software engineer from Phoenix, AZ. She spends a lot of time orbiting outside her comfort zone and when she's not coding, she likes to make her baby laugh.</p>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0202-lucia.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Glen McCallum: From IC to Engineering Manager, and the lessons learned along the way",
+    "slug": "0203-glen",
+    "id": "384",
+    "metaDescription": "Season Two, Episode Three of the Virtual Coffee Podcast",
+    "season": 2,
+    "episode": 3,
+    "buzzsproutId": "8370318",
+    "publishDate": "2021-04-20T04:00:00+00:00",
+    "shortDescription": "<p>In this episode, Dan and Bekah talk to Glen McCallum, a Software engineer and manager from Victoria, Canada, about his unexpected career journey, the hard decisions he's had to make, and using open-source software with his artificial pancreas.</p>",
+    "showNotes": "<p>In this episode, Dan and Bekah talk to Glen McCallum, a Software engineer from Victoria, Canada who manages a team of 8 engineers for the 2nd largest independent book distributor in the US, about his unexpected career journey, the hard decisions he's had to make, and using open-source software with his artificial pancreas. Glen also talks about his near-death experience in his first IT job and the decision to move from Independent Contributor to Management.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Glen: <a href=\"https://glenmccallum.com/\" rel=\"noopener noreferrer\" target=\"_blank\">glenmccallum.com</a>, <a href=\"https://twitter.com/glenmccallumcan\" rel=\"noopener noreferrer\" target=\"_blank\">@glenmccallumcan</a> on Twitter,</p></li><li><p>Glen's Lightning Talk: <a href=\"https://youtu.be/2hIBz5Ogi3o\" rel=\"noopener noreferrer\" target=\"_blank\">From independent contributor to engineering manager</a></p></li><li><p><a href=\"https://www.healthline.com/health/diabetesmine/innovation/we-are-not-waiting#About-the-#WeAreNotWaiting-Movement\" rel=\"noopener noreferrer\" target=\"_blank\">We are not waiting movement</a></p></li><li><p><a href=\"https://openaps.org/\" rel=\"noopener noreferrer\" target=\"_blank\">OpenAPS</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0203-glen-episode.jpg",
+    "guests": [
+      {
+        "name": "Glen McCallum",
+        "bio": "<p>Glen McCallum is a Software engineer from Victoria, Canada. For the past 7 years he's been doing backend development in C# and SQL. Earlier, he did projects in Java and Rails. He's always learning, currently exploring big data with hadoop, python, and spark. Day-to-day he manages a team of 8 engineers for the 2nd largest independent book distributor in the United States.</p>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0203-glen.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Debra-Kaye Elliott: The Self-Taught Developer Journey",
+    "slug": "0204-debra-kaye",
+    "id": "391",
+    "metaDescription": "Season Two, Episode Four of the Virtual Coffee Podcast",
+    "season": 2,
+    "episode": 4,
+    "buzzsproutId": "8413543",
+    "publishDate": "2021-04-27T04:00:00+00:00",
+    "shortDescription": "<p>In this episode of the podcast, we talk to Debra-Kaye Elliott about what it's like to be on the self-taught developer journey, imposter syndrome, and some of the key things she's learned along the way.</p>",
+    "showNotes": "<p>In this episode of the podcast, we talk to Debra-Kaye Elliott, a self-taught frontend developer making her way through Frontend Masters Web Development Bootcamp, about what it's like to be on the self-taught developer journey, how she navigates imposter syndrome, and the lessons she's learned a long the way. She talks about the impact of being able to learn with support, choosing the resources that work best for you, and how blogging has been a part of her journey.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Debra-Kaye: <a href=\"https://twitter.com/debrakayelliott\" rel=\"noopener noreferrer\" target=\"_blank\">@debrakayelliott</a> on Twitter, <a href=\"https://www.linkedin.com/in/debrakayeelliott\" rel=\"noopener noreferrer\" target=\"_blank\">@debrakayeelliott</a> on LinkedIn, and <a href=\"https://dev.to/debrakayeelliott\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/debrakayeelliott</a>.</p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0204-debra-kaye-episode.jpg",
+    "guests": [
+      {
+        "name": "Debra-Kaye Elliott",
+        "bio": "<p>Debra-Kaye Elliott is a Front End Developer going through a bootcamp, who's adding community-learning to her learning process. She's a career changer from the administrative field and always wanted to be in tech.</p>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0204-debra-kaye.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Tom Cudd - Psychological Safety and DevOps",
+    "slug": "0205-tom-cudd",
+    "id": "399",
+    "metaDescription": "Season Two, Episode Five of the Virtual Coffee Podcast",
+    "season": 2,
+    "episode": 5,
+    "buzzsproutId": "8456725",
+    "publishDate": "2021-05-04T04:00:00+00:00",
+    "shortDescription": "<p>In this episode of the podcast, we talk to Tom Cudd about his experiences with DevOps, the importance of building psychological safety in to your team building and workflows.</p>",
+    "showNotes": "<p>In this episode of the podcast, we talk to Tom Cudd, a systems architect and 20-year veteran in technology. We talked about his experiences with DevOps and how it has changed over the years, about psychological safety: what it means to Tom, and how important it is to build in to your team and workflows, and about the dangers of \"hero culture\" in the workplace.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Tom Cudd: <a href=\"https://twitter.com/tomcudd\" rel=\"noopener noreferrer\" target=\"_blank\">@tomcudd</a> on Twitter, <a href=\"https://tomcudd.com/\" rel=\"noopener noreferrer\" target=\"_blank\">tomcudd.com</a></p></li></ul><h5 class=\"text-left\"><strong>Mentioned in the Episode:</strong></h5><ul><li><p><a href=\"https://www.goodreads.com/book/show/17255186-the-phoenix-project\" rel=\"noopener noreferrer\" target=\"_blank\">The Phoenix Project</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/44333183-the-unicorn-project\" rel=\"noopener noreferrer\" target=\"_blank\">the Unicorn Project</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/18167218-lean-enterprise\" rel=\"noopener noreferrer\" target=\"_blank\">Lean Enterprise</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/35747076-accelerate\" rel=\"noopener noreferrer\" target=\"_blank\">Accelerate</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/29939161-radical-candor\" rel=\"noopener noreferrer\" target=\"_blank\">Radical Candor</a></p></li><li><p><a href=\"https://softwaresocial.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Software Social Podcast</a></p></li><li><p><a href=\"https://www.manager-tools.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Manager Tools</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0205-tomcudd-episode.jpg",
+    "guests": [
+      {
+        "name": "Tom Cudd",
+        "bio": "<p>Tom Cudd is a Systems Architect and a reformed Systems Administrator for an ad agency in the Kansas City area. He has been employed in technology for nearly 20 years, but has been using computers and the internet for most of his life. Tom is a huge fan of DevOps, lean processes, learning mindsets, and empathy with action. He also rabidly follows Husker football and the Chiefs.</p>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0205-tomcudd.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Courtney Landau - On being quiet in a loud tech world",
+    "slug": "0206-courtney-landau",
+    "id": "406",
+    "metaDescription": "Season Two, Episode Six of the Virtual Coffee Podcast",
+    "season": 2,
+    "episode": 6,
+    "buzzsproutId": "8499055",
+    "publishDate": "2021-05-11T04:00:00+00:00",
+    "shortDescription": "<p>In this episode of the podcast, we talk to Courtney Landau about how the trend of constant self-marketing in tech has impacted her career, her experience as a developer, and what's it's been like to take on a variety of roles as a Virtual Coffee contributor.</p>",
+    "showNotes": "<p>In this episode of the podcast, we talk to Courtney Landau, a software engineer currently working at an early-stage startup in the Education Technology space. We talked about her experience with being quiet in tech with the constant push for self-marketing and how she learns new things. We also dive into her experience as a mentor, speaker, lightning talk team member, and the other roles she's played as part of Virtual Coffee.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Courtney Landau: <a href=\"https://twitter.com/sosuperc\" rel=\"noopener noreferrer\" target=\"_blank\">@sosuperc</a> on Twitter, <a href=\"http://www.celandau.com/\" rel=\"noopener noreferrer\" target=\"_blank\">celandau.com</a></p></li></ul><h5 class=\"text-left\"><strong>Mentioned in the Episode:</strong></h5><ul><li><p><a href=\"https://twitter.com/sosuperc/status/1372529647947288588?s=20\" rel=\"noopener noreferrer\" target=\"_blank\">Quiet & soft-spoken =/= inexperienced.</a></p></li><li><p>Courtney's Lightning Talk from 2021: <a href=\"https://www.youtube.com/watch?v=ghFNiCMy67M\" rel=\"noopener noreferrer\" target=\"_blank\">Breaking down coding problems in interviews</a></p></li><li><p><a href=\"https://chrome.google.com/webstore/detail/learnics-teacher-link/nhdacjmkhimeohpnahfmdmcknaneeffk\" rel=\"noopener noreferrer\" target=\"_blank\">Learnics Teacher Link Chrome Extension</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0206-courtney-episode.jpg",
+    "guests": [
+      {
+        "name": "Courtney Landau",
+        "bio": "<p>Courtney is a software engineer currently working at an early-stage startup in the Education Technology space. Previously in the medical imaging field, she’s been working in the industry since 2019 after obtaining her Master’s in Information Sciences. She works on full-stack web applications using primarily TypeScript and JavaScript, built on a cloud platform. For fun she likes to run, play board games with her family, and patronize local independent restaurants and breweries.</p>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0206-courtney.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Nerando Johnson - Keeping Momentum, Community, and Socialization as a Service",
+    "slug": "0207-nerando-johnson",
+    "id": "413",
+    "metaDescription": "Season Two, Episode Seven of the Virtual Coffee Podcast",
+    "season": 2,
+    "episode": 7,
+    "buzzsproutId": "8542053",
+    "publishDate": "2021-05-18T04:00:00+00:00",
+    "shortDescription": "<p>In this episode of the podcast we talk to Nerando Johnson, a full stack developer, about running freeCodeCamp meetups in Atlanta, learning through hackathons, and how his next endeavor should be socialization as a service for tech events.</p>",
+    "showNotes": "<p>In this episode of the podcast, Dan and Bekah talk with Nerando Johnson, a full stack developer looking for his next job, about running freeCodeCamp meetups in Atlanta, learning through hackathons (including that one time his team won the hackathon and donated the $40,000 in winnings to charity) and how his next endeavor should be socialization as a service for tech events. We also talk about the importance of having a solid support system and we laugh...a lot.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Nerando Johnson: <a href=\"https://twitter.com/nerajno\" rel=\"noopener noreferrer\" target=\"_blank\">@nerajno</a> on Twitter, <a href=\"https://dev.to/nerajno/\" rel=\"noopener noreferrer\" target=\"_blank\">nerajno</a> on DEV, <a href=\"https://github.com/Nerajno\" rel=\"noopener noreferrer\" target=\"_blank\">Nerajno</a> on GitHub</p></li></ul><h5 class=\"text-left\"><strong>Mentioned in the Episode:</strong></h5><ul><li><p><a href=\"https://www.itsmarta.com/marta-hackathon.aspx\" rel=\"noopener noreferrer\" target=\"_blank\">MARTA Hackathon</a></p></li><li><p>freeCodeCamp Atlanta - <a href=\"https://www.facebook.com/groups/free.code.camp.atlanta/\" rel=\"noopener noreferrer\" target=\"_blank\">Facebook</a> - <a href=\"https://study-group-directory.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Find your FCC Meetup</a>:</p></li><li><p>Reactadelphia - <a href=\"https://twitter.com/reactadelphia\" rel=\"noopener noreferrer\" target=\"_blank\">@reactadelphia</a></p></li><li><p><a href=\"https://connect.tech/\" rel=\"noopener noreferrer\" target=\"_blank\">Connect.Tech</a></p></li><li><p><a href=\"https://twitter.com/garyvee\" rel=\"noopener noreferrer\" target=\"_blank\">Gary Vee</a></p></li><li><p><a href=\"https://twitter.com/xirclebox\" rel=\"noopener noreferrer\" target=\"_blank\">Homer Gaines</a></p></li><li><p><a href=\"https://twitter.com/techieEliot\" rel=\"noopener noreferrer\" target=\"_blank\">Eliot Sanford</a></p></li><li><p><a href=\"https://twitter.com/DThompsonDev\" rel=\"noopener noreferrer\" target=\"_blank\">Danny Thompson</a></p></li><li><p><a href=\"https://twitter.com/Career_Karma\" rel=\"noopener noreferrer\" target=\"_blank\">Career Karma</a></p></li><li><p><a href=\"https://www.jim-butcher.com/books/Dresden\" rel=\"noopener noreferrer\" target=\"_blank\">Dresden Files</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/27213329-grit\" rel=\"noopener noreferrer\" target=\"_blank\">Grit: The Power of Passion and Perseverance</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0207-nerando-episode.jpg",
+    "guests": [
+      {
+        "name": "Nerando Johnson",
+        "bio": "<p>This is Nerando, he likes to use programming to solve problems, (Yup, he is a developer). Nerando has been a community organizer for <a href=\"https://www.facebook.com/groups/free.code.camp.atlanta/\" rel=\"noopener noreferrer\" target=\"_blank\">freeCodeCamp Atlanta</a> for over the last two years. He has been to a <a href=\"https://medium.com/paratransit-pal/paratransit-pal-won-40-000-at-at-ts-atlanta-civic-coding-challenge-and-gave-it-all-to-charity-30bba157d92d\" rel=\"noopener noreferrer\" target=\"_blank\">few hackathons</a> and is <a href=\"https://dev.to/nerajno\" rel=\"noopener noreferrer\" target=\"_blank\">an infrequent blogger</a>. When not coding, Nerando enjoys coding cooking, reading, the act of creating something from nothing and consuming the odd blog or podcast about the human mind (<a href=\"https://www.npr.org/programs/\" rel=\"noopener noreferrer\" target=\"_blank\">Hi, NPR</a>).</p>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0207-nerando.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Sara McCombs - Learning to leverage your past experience and embrace your whole self",
+    "slug": "0208-sara-mccombs",
+    "id": "420",
+    "metaDescription": "Season Two, Episode Eight of the Virtual Coffee Podcast",
+    "season": 2,
+    "episode": 8,
+    "buzzsproutId": "8584928",
+    "publishDate": "2021-05-25T04:00:00+00:00",
+    "shortDescription": "<p>In this episode of the podcast we talk to Sara McCombs, a software engineer, team lead, and Community Maintainer at Virtual Coffee, about how to leverage your past experience, talk about transferable skills, and owning your wins as an early career developer.</p>",
+    "showNotes": "<p>In this episode of the podcast, Dan and Bekah talk with Sara McCombs. Sara is a software engineer and team lead at <a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a>, and also one of the original organizers, and a current Community Maintainer, at Virtual Coffee. Sara shared her thoughts on how to think and talk about transferable skills, leveraging past experience to differentiate yourself, and the importance of embracing that past experience as part of your journey and strengths. She also talked about the impact of career changes, promotions, and overcoming self-doubt.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Sara McCombs: <a href=\"https://twitter.com/dino_momma\" rel=\"noopener noreferrer\" target=\"_blank\">@dino_momma</a> on Twitter, <a href=\"https://dev.to/saramccombs/\" rel=\"noopener noreferrer\" target=\"_blank\">saramccombs</a> on DEV, <a href=\"https://github.com/saramccombs\" rel=\"noopener noreferrer\" target=\"_blank\">saramccombs</a> on GitHub</p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0208-sara-episode.jpg",
+    "guests": [
+      {
+        "name": "Sara McCombs",
+        "bio": "<p>Sara is a published former research director turned software engineer and team lead at <a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a>, as well as a community engagement leader at <a href=\"https://www.projectalloy.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Project Alloy</a>. She is also one of the original organizers, and a current community maintainer, at <a href=\"https://virtualcoffee.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee</a>. Sara is passionate about diversity and inclusion, and has written frequently about her journey into tech. She has an M.Ag and a B.S.Ag from West Virginia University, and is a 2020 graduate of Flatiron School.</p>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0208-sara.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Season Two Wrap-Up: Code and Community",
+    "slug": "0209-season-two-wrapup",
+    "id": "427",
+    "metaDescription": "Season Two, Episode Nine of the Virtual Coffee Podcast",
+    "season": 2,
+    "episode": 9,
+    "buzzsproutId": "8625475",
+    "publishDate": "2021-06-01T04:00:00+00:00",
+    "shortDescription": "<p>In this episode of the podcast, Dan and Bekah wrap up season two by talking about what they've learned about community, supporting members, and trying to find the right tools to make it happen.</p>",
+    "showNotes": "<p>In this episode of the podcast, Dan and Bekah wrap up season two by talking about what they've learned about community building over the last year and some lessons they've learned along the way. They talk about Virtual Coffee's mission to support its members, and how Virtual Coffee's unique approach presents both challenges and opportunities when it comes to finding tools and guidance as the community grows.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p><a href=\"https://magnoliajs.com/\" rel=\"noopener noreferrer\" target=\"_blank\">MagnoliaJS</a></p></li><li><p><a href=\"https://www.radicalcandor.com/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Radical Candor</em></a> by Kim Scott</p></li><li><p><a href=\"https://twitter.com/kldickenson\" rel=\"noopener noreferrer\" target=\"_blank\">Karen Dickinson</a></p></li><li><p><a href=\"https://orbit.love/\" rel=\"noopener noreferrer\" target=\"_blank\">Orbit model</a></p></li><li><p><a href=\"https://twitter.com/MarieAntons\" rel=\"noopener noreferrer\" target=\"_blank\">Marie Antons</a></p></li><li><p><a href=\"https://twitter.com/ray_deck\" rel=\"noopener noreferrer\" target=\"_blank\">Ray Deck</a></p></li><li><p><a href=\"https://twitter.com/CerchieLucia\" rel=\"noopener noreferrer\" target=\"_blank\">Lucia Cerchie</a></p></li><li><p><a href=\"https://twitter.com/CerchieLucia/status/1397937325464723458\" rel=\"noopener noreferrer\" target=\"_blank\">Lucia's tweet about Hacktoberfest</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0209-season-2-wrapup.jpg",
+    "guests": [
+      {
+        "name": "Bekah Hawrot Weigel",
+        "bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dev.to/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/bekahhw</a></p></li><li><p><a href=\"https://twitter.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">@bekahhw</a> on Twitter</p></li><li><p><a href=\"https://www.instagram.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">bekahhw</a> on Instagram</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0209-bekah.jpg"
+      },
+      {
+        "name": "Dan Ott",
+        "bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dtott.com/\" rel=\"noopener noreferrer\" target=\"_blank\">dtott.com</a></p></li><li><p><a href=\"https://twitter.com/danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">@danieltott</a> on Twitter</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0209-dan.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Jono Yeong - Digital Gardening and Tim Tams",
+    "slug": "0301-jono-yeong",
+    "id": "444",
+    "metaDescription": "Season Three, Episode One of the Virtual Coffee Podcast",
+    "season": 3,
+    "episode": 1,
+    "buzzsproutId": "8821435",
+    "publishDate": "2021-07-06T04:00:00+00:00",
+    "shortDescription": "<p>In this episode of the podcast Bekah and Dan talk to Jono Yeong about digital gardening, learning Elixir, and how he brings learning new things to what he's doing with Rails. And for a bonus, he even walks us through how to do a proper Tim Tam slam.</p>",
+    "showNotes": "<p>In this episode of the podcast Bekah and Dan talk to Jono Yeong, a senior software engineer originally from Australia, but currently based in Seattle, USA, about how digital gardening leaves room for growth, allows you to develop what you enjoy, and is an investment in communication skills. We also talk about learning Elixir, the process he goes through as he's learning something new, and how he brings learning new things to what he's doing with Rails. Bonus: he even walks us through how to do a proper Tim Tam slam.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p><a href=\"https://www.jonathanyeong.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Jono's website</a></p></li><li><p><a href=\"https://www.descript.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Descript</a></p></li><li><p><a href=\"https://maggieappleton.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Maggie Appleton</a></p></li><li><p><a href=\"https://www.jonathanyeong.com/garden/using-github-and-notion-to-organise-side-projects\" rel=\"noopener noreferrer\" target=\"_blank\">Github and notion blogpost</a></p></li><li><p><a href=\"https://twitter.com/VicVijayakumar\" rel=\"noopener noreferrer\" target=\"_blank\">Vic Vijayakumar</a></p></li><li><p><a href=\"https://twitter.com/nickytonline\" rel=\"noopener noreferrer\" target=\"_blank\">NickyT</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=jhXJCqQBz04\" rel=\"noopener noreferrer\" target=\"_blank\">Building a social network for puppies</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=k8hEo4N8Nhs\" rel=\"noopener noreferrer\" target=\"_blank\">TimTams slams</a></p></li><li><p><a href=\"https://www.arnotts.com/products/tim-tam\" rel=\"noopener noreferrer\" target=\"_blank\">TimTams</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0301-jono-episode.jpg",
+    "guests": [
+      {
+        "name": "Jonathan Yeong",
+        "bio": "<p>Jonathan Yeong is a senior developer at Shopify. Being from Australia, he often goes by Jono. A Rubyist at heart, he blogs and produces videos about all things programming. He’s passionate about the human connections in technology. And believes that being part of a community, a mentor, and a teacher is one of the most rewarding things you can do.</p><ul><li><p><a href=\"https://twitter.com/JonoYeong\" rel=\"noopener noreferrer\" target=\"_blank\">Twitter</a></p></li><li><p><a href=\"https://www.jonathanyeong.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Website</a></p></li><li><p><a href=\"https://www.youtube.com/c/jonathanyeong\" rel=\"noopener noreferrer\" target=\"_blank\">YouTube</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0301-jono.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Abbey Perini - Finding Confidence and Opportunities",
+    "slug": "0302-abbey-perini",
+    "id": "451",
+    "metaDescription": "Season Three, Episode Two of the Virtual Coffee Podcast",
+    "season": 3,
+    "episode": 2,
+    "buzzsproutId": "8858957",
+    "publishDate": "2021-07-13T04:00:00+00:00",
+    "shortDescription": "<p>On this episode of the podcast, we talk to Abbey Perini, a full-stack web developer, about the importance of practice, building in public, and sending thank you notes when you're interviewing for your first tech job.</p>",
+    "showNotes": "<p>On this episode of the podcast, we talk to Abbey Perini, a full-stack web developer, about the impact building in public has had on her developer journey, what her experience as a recruiting admin taught her as she sent out 160 applications before landing her dev role, and how rehearsing before an interview can make a big impact.</p><h4 class=\"text-left\"><strong>Links mentioned in the episode:</strong></h4><ul><li><p>Github: <a href=\"https://github.com/abbeyperini\" rel=\"noopener noreferrer\" target=\"_blank\">https://github.com/abbeyperini</a></p></li><li><p><a href=\"https://www.indeed.com/career/salaries\" rel=\"noopener noreferrer\" target=\"_blank\">Indeed job rate checker</a></p></li><li><p>Abbey's posts mentioned:</p><ul><li><p><a href=\"https://dev.to/abbeyperini/css-animated-button-with-offset-border-1ibi\" rel=\"noopener noreferrer\" target=\"_blank\">CSS Animated Button with Offset Border</a></p></li><li><p><a href=\"https://javascript.plainenglish.io/react-redux-reload-a-page-when-a-user-makes-a-change-7661a3e1b8ed\" rel=\"noopener noreferrer\" target=\"_blank\">Sheba Counter: How To Reload a Page Whenever a User Makes a Change with React/Redux</a></p></li><li><p><a href=\"https://dev.to/abbeyperini/toggle-dark-mode-in-react-28c9\" rel=\"noopener noreferrer\" target=\"_blank\">Toggle Dark Mode in React</a></p></li><li><p><a href=\"https://dev.to/abbeyperini/knitting-as-programming-3e5\" rel=\"noopener noreferrer\" target=\"_blank\">Knitting as Programming</a></p></li><li><p><a href=\"https://dev.to/abbeyperini/practicing-confidence-for-the-job-search-38nj\" rel=\"noopener noreferrer\" target=\"_blank\">Practicing Confidence for the Job Search</a></p></li></ul></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0302-abbey-episode.jpg",
+    "guests": [
+      {
+        "name": "Abbey Perini",
+        "bio": "<p>Abbey Perini is many things - a metro Atlanta native, a person of many hobbies, and a full-stack web developer. Currently ramping up in her first development role, she loves blogging about stupid Discord bots, animated CSS buttons, and other fun and useful things about programming. You can find her work and ways to connect with her at <a href=\"https://abbeyperini.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">abbeyperini.dev</a>.</p><ul><li><p><a href=\"https://abbeyperini.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">abbeyperini.dev</a></p></li><li><p><a href=\"https://twitter.com/AbbeyPerini\" rel=\"noopener noreferrer\" target=\"_blank\">@AbbeyPerini</a> on Twitter</p></li><li><p><a href=\"https://github.com/abbeyperini\" rel=\"noopener noreferrer\" target=\"_blank\">@abbeyperini</a> on GitHub</p></li><li><p><a href=\"https://dev.to/abbeyperini\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/abbeyperini</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0302-abbey.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Ayu Adiati - Working through burnout as a self-taught developer",
+    "slug": "0303-ayu-adiati",
+    "id": "458",
+    "metaDescription": "Season Three, Episode Three of the Virtual Coffee Podcast",
+    "season": 3,
+    "episode": 3,
+    "buzzsproutId": "8893503",
+    "publishDate": "2021-07-20T04:00:00+00:00",
+    "shortDescription": "<p>In this episode, Dan and Bekah talk to Ayu about the impact of community, being a prolific blogger, and the very real challenge of burnout.</p>",
+    "showNotes": "<p>In this episode, Dan and Bekah talk to Ayu about the impact of community, being a prolific blogger, and the very real challenge of burnout. Ayu's openness about the challenges of being a mom on the self-taught track into tech, isolation, and fears of not being good enough are the stories that we don't share enough of. Because when we share, we can all work through them together. Thank you, Ayu, for reminding us that it's ok to not be ok.</p><h4 class=\"text-left\"><strong>Links mentioned in the episode:</strong></h4><ul><li><p><a href=\"https://community.codenewbie.org/adiatiayu/lesson-learned-massive-burnout-in-learning-web-development-3b5g?signin=true\" rel=\"noopener noreferrer\" target=\"_blank\">Lesson Learned: Massive Burnout In Learning Web Development</a></p></li><li><p><a href=\"https://twitter.com/AdiatiAyu/status/1400833965293019138?s=19\" rel=\"noopener noreferrer\" target=\"_blank\">Ayu's twitter thread about struggling with learning to code</a></p></li><li><p><a href=\"https://www.freecodecamp.org/learn/responsive-web-design/\" rel=\"noopener noreferrer\" target=\"_blank\">Free Code Camp - web responsive design certification</a></p></li><li><p><a href=\"https://community.codenewbie.org/codenewbie/ayu-polyglot-latte-lover-codenewbie-149m\" rel=\"noopener noreferrer\" target=\"_blank\">Ayu's CodeNewbie Community Spotlight</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0303-ayu-episode.jpg",
+    "guests": [
+      {
+        "name": "Ayu Adiati",
+        "bio": "<p>Originally from Indonesia and now based in The Netherlands, Ayu Adiati is a self-taught Frontend Developer & Technical Blogger. She’s on her way to break into tech from being a stay-at-home-mom of now a 4 years old daughter.</p><p class=\"text-left\">When Ayu is not coding, you can find her with the DLSR camera on her hands, cuddling with her daughter, or enjoying her iced macchiato latte.</p><ul><li><p><a href=\"https://virtualcoffee.io/podcast/0303-ayu-adiati/@AdiatiAyu%20(https://twitter.com/AdiatiAyu)\" rel=\"noopener noreferrer\" target=\"_blank\">Twitter</a></p></li><li><p><a href=\"https://adiati.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Blog</a></p></li><li><p><a href=\"https://dev.to/adiatiayu\" rel=\"noopener noreferrer\" target=\"_blank\">DEV</a></p></li><li><p><a href=\"https://community.codenewbie.org/adiatiayu\" rel=\"noopener noreferrer\" target=\"_blank\">CodeNewbie</a></p></li><li><p><a href=\"https://hashnode.com/@ayuadiati\" rel=\"noopener noreferrer\" target=\"_blank\">Hashnode</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0303-ayu.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Joan Marie Verba - Keeping hope through decades of challenges",
+    "slug": "0304-joan-marie-verba",
+    "id": "465",
+    "metaDescription": "Season Three, Episode Four of the Virtual Coffee Podcast",
+    "season": 3,
+    "episode": 4,
+    "buzzsproutId": "8929061",
+    "publishDate": "2021-07-27T04:00:00+00:00",
+    "shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk to Joan Marie Verba about her early days in tech using Fortran, and how refusal to accommodate her allergies has prevented her from having a lifelong career in tech. She talks about pushing forward and not taking no for an answer as she continues her decades-long journey into tech.</p>",
+    "showNotes": "<p>In this episode of the podcast, Dan and Bekah talk to Joan Marie Verba, a web developer, former astronomy teacher, and prolific science fiction writer, about her early days in tech using Fortran, and how refusal to accommodate her allergies has prevented her from having a lifelong career in tech. She shares the story of her recent job offer that actually turned out to be a scam that's being investigated by the FBI. But she's not done searching for her next place in tech. She's pushing past the challenges until she finds that next job.</p><h5 class=\"text-left\"><strong>Links:</strong></h5><ul><li><p><a href=\"https://www.ada.gov/\" rel=\"noopener noreferrer\" target=\"_blank\">Americans with Disabilities Act</a></p></li><li><p>Website: <a href=\"http://joanmarieverba.com/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.com</a></p></li><li><p>Blog: <a href=\"http://joanmarieverba.info/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.info</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/joanmarieverba\" rel=\"noopener noreferrer\" target=\"_blank\">@joanmarieverba</a></p></li><li><p>Web developer portfolio: <a href=\"http://joanmarieverba.co.technology/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.co.technology</a></p></li><li><p>Projects page: <a href=\"http://joanmarieverba.name/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.name</a></p></li><li><p>UX page: <a href=\"http://joanmarieverba.net/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.net</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0304-joan-episode.jpg",
+    "guests": [
+      {
+        "name": "Joan Marie Verba",
+        "bio": "<p>Joan Marie Verba earned a bachelor of physics degree from the University of Minnesota and attended the graduate school of astronomy at Indiana University, where she was an associate instructor of astronomy for one year. She has worked as a computer programmer and as an editor. She currently works as a writer, a publisher, and a web developer.</p><ul><li><p>Website: <a href=\"http://joanmarieverba.com/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.com</a></p></li><li><p>Blog: <a href=\"http://joanmarieverba.info/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.info</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/joanmarieverba\" rel=\"noopener noreferrer\" target=\"_blank\">@joanmarieverba</a></p></li><li><p>Web developer portfolio: <a href=\"http://joanmarieverba.co.technology/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.co.technology</a></p></li><li><p>Projects page: <a href=\"http://joanmarieverba.name/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.name</a></p></li><li><p>UX page: <a href=\"http://joanmarieverba.net/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.net</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0304-joan.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Kevin Truong - Tech Career Coaching",
+    "slug": "0305-kevin-truong",
+    "id": "472",
+    "metaDescription": "Season Three, Episode Five of the Virtual Coffee Podcast",
+    "season": 3,
+    "episode": 5,
+    "buzzsproutId": "8967149",
+    "publishDate": "2021-08-03T04:00:00+00:00",
+    "shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk to Kevin, a senior software consultant at Test Double and a coding career coach at his company Tap into Tech, about his approach to interviewing and how to navigate some of the biggest challenges early-career devs face when trying to break into the industry.</p>",
+    "showNotes": "<p>In this episode of the podcast, Dan and Bekah talk to Kevin, a senior software consultant at Test Double and a coding career coach at his company Tap into Tech, about some of the most common challenges early-career developers face getting into tech and offers practical advice for working through those problems. We dive into visualization, personal support, and ways to change the interview process in tech.</p><h5 class=\"text-left\"><strong>Links:</strong></h5><ul><li><p>Kevin's Twitter: <a href=\"https://twitter.com/TheKevinTruong\" rel=\"noopener noreferrer\" target=\"_blank\">@TheKevinTruong</a></p></li><li><p>Kevin's LinkedIn: <a href=\"https://www.linkedin.com/in/thekevintruong/\" rel=\"noopener noreferrer\" target=\"_blank\">thekevintruong</a></p></li><li><p><a href=\"https://tapintotech.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Tap into Tech</a></p></li><li><p><a href=\"https://testdouble.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Test Double</a></p></li><li><p><a href=\"http://thekevintruong.com/\" rel=\"noopener noreferrer\" target=\"_blank\">thekevintruong.com</a></p></li><li><p><a href=\"https://www.loom.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Loom</a></p></li><li><p><a href=\"https://twitter.com/terribledustin/status/1405903173684850695?s=19\" rel=\"noopener noreferrer\" target=\"_blank\">Dustin McCaffree Upwork/Loom Tweet</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0305-kevin-episode.jpg",
+    "guests": [
+      {
+        "name": "Kevin Truong",
+        "bio": "<p>Kevin Truong is a senior software consultant at Test Double and a coding career coach at his company Tap into Tech. Previously a coding boot camp instructor and mentor, Kevin realized that boot camps were missing a lot of information when it came to the final steps of getting hired. With his years of experience, he has developed a program where he has coached dozens of early career devs on how to improve their results on getting a tech job.</p><ul><li><p>Twitter: <a href=\"https://twitter.com/TheKevinTruong\" rel=\"noopener noreferrer\" target=\"_blank\">@TheKevinTruong</a></p></li><li><p>LinkedIn: <a href=\"https://www.linkedin.com/in/thekevintruong/\" rel=\"noopener noreferrer\" target=\"_blank\">thekevintruong</a></p></li><li><p><a href=\"https://tapintotech.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Tap into Tech</a></p></li><li><p><a href=\"http://thekevintruong.com/\" rel=\"noopener noreferrer\" target=\"_blank\">thekevintruong.com</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0305-kevin.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Ray Deck - Rubber-Ducking your Life",
+    "slug": "0306-ray-deck",
+    "id": "479",
+    "metaDescription": "Season Three, Episode Six of the Virtual Coffee Podcast",
+    "season": 3,
+    "episode": 6,
+    "buzzsproutId": "9007249",
+    "publishDate": "2021-08-10T04:00:00+00:00",
+    "shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk to Ray Deck about rubber ducking your career path, the importance of trust and relationships, and accepting that we're probably wrong more than we're right.</p>",
+    "showNotes": "<p>In this episode, Dan and Bekah talk to Ray Deck, a trained data scientist, occasional angel investor, and software entrepreneur, about finding the right career path through growth, learning, and motivation. We talk about the importance of trust and listening, and Ray drops a bunch of great resources to help everyone find their own path.</p><h5 class=\"text-left\"><strong>Favorite nonfiction books:</strong></h5><ul><li><p>Bekah's pick: <a href=\"https://allisonpataki.com/books/beauty-in-the-broken-places/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Beauty in the Broken Places</em></a><a href=\"https://allisonpataki.com/books/beauty-in-the-broken-places/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Allison Pataki</a></p></li><li><p>Bekah's second pick: <a href=\"https://drgabormate.com/book/scattered-minds/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Scattered Minds</em></a><a href=\"https://drgabormate.com/book/scattered-minds/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Dr. Gabor Maté</a></p></li><li><p>Dan's pick: <a href=\"https://www.hachettebooks.com/titles/lindy-west/shit-actually/9780316449847/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Shit, Actually</em></a><a href=\"https://www.hachettebooks.com/titles/lindy-west/shit-actually/9780316449847/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Lindy West</a></p></li><li><p>Ray's pick: <a href=\"https://www.edwardtufte.com/tufte/books_vdqi\" rel=\"noopener noreferrer\" target=\"_blank\"><em>The Visual Display of Quantitative Information</em></a><a href=\"https://www.edwardtufte.com/tufte/books_vdqi\" rel=\"noopener noreferrer\" target=\"_blank\"> by Edwarde Tufte</a></p></li></ul><h5 class=\"text-left\"><strong>Links to things mentioned in the episode:</strong></h5><ul><li><p><a href=\"https://simonsinek.com/product/start-with-why/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Start With Why</em></a><a href=\"https://simonsinek.com/product/start-with-why/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Simon Sinek</a></p></li><li><p><a href=\"https://www.franklincovey.com/the-7-habits/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>The 7 Habits of Highly Effective People</em></a><a href=\"https://www.franklincovey.com/the-7-habits/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Stephen R. Covey</a></p></li><li><p><a href=\"https://www.amazon.com/8th-Habit-Effectiveness-Greatness-Paperback/dp/B00GOHDKRI/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>The 8th Habit: From Effectiveness to Greatness</em></a><a href=\"https://www.amazon.com/8th-Habit-Effectiveness-Greatness-Paperback/dp/B00GOHDKRI/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Stephen R. Covey</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0306-ray-episode.jpg",
+    "guests": [
+      {
+        "name": "Ray Deck",
+        "bio": "<p>Ray is a trained data scientist, occasional angel investor, and software entrepreneur. His 25-year career spans industries from law to finance. Most recently, Ray is the founder of Sustained Ventures, a software product studio where he also publishes essays on technology and markets.</p><p class=\"text-left\">Ray's thoughts can be followed at <a href=\"https://sustainedventures.com/essays\" rel=\"noopener noreferrer\" target=\"_blank\">sustainedventures.com/essays</a>, and his less-thoughtful self is on Twitter <a href=\"https://twitter.com/ray_deck\" rel=\"noopener noreferrer\" target=\"_blank\">@ray_deck</a>.</p><ul><li><p><a href=\"https://sustainedventures.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Sustained Ventures</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/ray_deck\" rel=\"noopener noreferrer\" target=\"_blank\">@ray_deck</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0306-ray.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Mike Rogers - Tend Your Career like a Garden",
+    "slug": "0307-mike-rogers",
+    "id": "486",
+    "metaDescription": "Season Three, Episode Seven of the Virtual Coffee Podcast",
+    "season": 3,
+    "episode": 7,
+    "buzzsproutId": "9044559",
+    "publishDate": "2021-08-17T04:00:00+00:00",
+    "shortDescription": "<p>In this episode, Dan and Bekah are joined by Mike Rogers, to talk about changing course as a dev, and tending careers like gardens.</p>",
+    "showNotes": "<p>In this episode, Dan and Bekah are joined by Mike Rogers. Mike has had a long and successful career, but at one point he realized he no longer felt good or satisfied with where he was as a developer. He shared with us what he did to change course, and how he has learned to approach tending his career almost like a garden.</p><h5 class=\"text-left\"><strong>Links to things mentioned in the episode:</strong></h5><ul><li><p>Mike's YouTube: <a href=\"https://www.youtube.com/c/MikeRogers0\" rel=\"noopener noreferrer\" target=\"_blank\">MikeRogers0</a></p></li><li><p><a href=\"http://www.slate.com/articles/technology/technology/2012/03/ruby_ruby_on_rails_and__why_the_disappearance_of_one_of_the_world_s_most_beloved_computer_programmers_.html\" rel=\"noopener noreferrer\" target=\"_blank\">Where’s _why?</a> - What happened when one of the world’s most unusual, and beloved, computer programmers disappeared.</p></li><li><p>Meditation Minis podcast: <a href=\"https://www.meditationminis.com/\" rel=\"noopener noreferrer\" target=\"_blank\">meditationminis.com</a></p></li><li><p>Mike's Business Times cover:</p></li><li><p></p><img src=\"https://optimise2.assets-servd.host/virtual-coffee/production/images/0307-mike-bt-cover.jpg?w=378&amp;auto=compress%2Cformat&amp;fit=crop&amp;dm=1648577051&amp;s=3b73d41bc861dfe62cff7d45baac177b\" alt=\"Mike&#039;s cover on the Business Times\" title=\"\"></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0307-mike-episode.jpg",
+    "guests": [
+      {
+        "name": "Mike Rogers",
+        "bio": "<p>Mike Rogers is a Ruby developer from the UK. He made the chat bots for Virtual Coffee, has an awesome Ruby Event Calendar, and loves Docker.</p><ul><li><p><a href=\"https://mikerogers.io/\" rel=\"noopener noreferrer\" target=\"_blank\">mikerogers.io</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/mikerogers0\" rel=\"noopener noreferrer\" target=\"_blank\">mikerogers0</a></p></li><li><p>GitHub: <a href=\"https://github.com/MikeRogers0\" rel=\"noopener noreferrer\" target=\"_blank\">MikeRogers0</a></p></li><li><p>YouTube: <a href=\"https://www.youtube.com/c/MikeRogers0\" rel=\"noopener noreferrer\" target=\"_blank\">MikeRogers0</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0307-mike.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Aurelie Verrot - Learning and Working Remotely",
+    "slug": "0308-aurelie-verrot",
+    "id": "494",
+    "metaDescription": "Season Three, Episode Eight of the Virtual Coffee Podcast",
+    "season": 3,
+    "episode": 8,
+    "buzzsproutId": "9080882",
+    "publishDate": "2021-08-24T04:00:00+00:00",
+    "shortDescription": "<p>In this episode of the podcast, Dan and Bekah are joined by Aurelie Verrot to talk about working through bootcamp during the pandemic, remote work, and how to \"just be cool\" when you're dealing with challenges like the pandemic, virtual school, and remote work.</p>",
+    "showNotes": "<p>In this episode, Dan and Bekah talk to Aurelie Verrot, a Software Engineer from the San Francisco Bay Area, who's originally from France, about the importance of relationships in team-building--whether as part of the learning process or in a work environment--and the benefits of being able to work from home. She talks about the importance of clear communication, creating boundaries, and maintaining flexibility as key habits to build.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Twitter: <a href=\"https://twitter.com/LiliVerrot\" rel=\"noopener noreferrer\" target=\"_blank\">LiliVerrot</a></p></li><li><p>GitHub: <a href=\"https://github.com/aurelieverrot\" rel=\"noopener noreferrer\" target=\"_blank\">aurelieverrot</a></p></li><li><p>LinkedIn: <a href=\"https://www.linkedin.com/in/aurelieverrot/\" rel=\"noopener noreferrer\" target=\"_blank\">aurelieverrot</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0308-aurelie-episode.jpg",
+    "guests": [
+      {
+        "name": "Aurelie Verrot",
+        "bio": "<p>Aurelie Verrot is a software engineer from the San Francisco Bay Area, originally from France. After moving to the US and taking care of her children for 4 years, she decided to make a career change in 2019 to work in tech. She started her first dev job in May as a Software Engineer working mostly with Ruby on Rails.</p><ul><li><p>Twitter: <a href=\"https://twitter.com/LiliVerrot\" rel=\"noopener noreferrer\" target=\"_blank\">LiliVerrot</a></p></li><li><p>GitHub: <a href=\"https://github.com/aurelieverrot\" rel=\"noopener noreferrer\" target=\"_blank\">aurelieverrot</a></p></li><li><p>LinkedIn: <a href=\"https://www.linkedin.com/in/aurelieverrot/\" rel=\"noopener noreferrer\" target=\"_blank\">aurelieverrot</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0308-aurelie.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Season 3 Wrap Up: Hacktoberfest is Coming!",
+    "slug": "0309-season-three-wrap-up",
+    "id": "503",
+    "metaDescription": "Season Three, Episode Nine of the Virtual Coffee Podcast",
+    "season": 3,
+    "episode": 9,
+    "buzzsproutId": "9124000",
+    "publishDate": "2021-09-01T04:00:00+00:00",
+    "shortDescription": "<p>Community Maintainer Kirk joins us (again) for our Season 3 wrap up and Hacktoberfest preview!</p>",
+    "showNotes": "<p>Community Maintainer Kirk joins us (again) for our Season 3 wrap up! We review what Virtual Coffee did last year for Hacktoberfest, and talk about a lot of the exciting things we have coming up this year! We also shared some fun things from the last year at Virtual Coffee, like our Virtual Coffee Co-Working Room!</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p><a href=\"https://apps.apple.com/us/app/classic-sudoku/id1488838275\" rel=\"noopener noreferrer\" target=\"_blank\">Classic Sudoku</a></p></li><li><p><a href=\"https://www.youtube.com/channel/UCC-UOdK8-mIjxBQm_ot1T-Q\" rel=\"noopener noreferrer\" target=\"_blank\">Cracking the Cryptic</a></p></li><li><p><a href=\"https://twitter.com/MarieAntons\" rel=\"noopener noreferrer\" target=\"_blank\">@MarieAntons</a></p></li><li><p>Tatiana Mac - <a href=\"https://github.com/selfdefined\" rel=\"noopener noreferrer\" target=\"_blank\">selfdefined</a></p></li><li><p><a href=\"https://github.com/dominicduffin1/Quarto\" rel=\"noopener noreferrer\" target=\"_blank\">Quarto by Dominic Duffin</a></p></li><li><p><a href=\"https://github.com/BekahHW/postpartum-wellness-app\" rel=\"noopener noreferrer\" target=\"_blank\">Bekah's postpartum wellness app</a></p></li><li><p><a href=\"https://github.com/Virtual-Coffee/virtualcoffee.io\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee's GitHub Org</a></p></li><li><p><a href=\"https://hacktoberfest.digitalocean.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Hacktoberfest on Digital Ocean</a></p></li><li><p>shoutout to our Monthly Challenge team: Adam, Andrew, Aurelie, Chris, Courtney, Dominic, Kevin, Luis, Vanessa, and Yolanda!</p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0309-hacktoberfest.jpg",
+    "guests": [
+      {
+        "name": "Kirk Shillingford",
+        "bio": "<p>Software Developer, and Community Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://twitter.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0108-kirk.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Jessi Shakarian - You aren't your tech stack: sharing your passion",
+    "slug": "0401-jessi-shakarian",
+    "id": "510",
+    "metaDescription": "Season Four, Episode One of the Virtual Coffee Podcast",
+    "season": 4,
+    "episode": 1,
+    "buzzsproutId": "9322612",
+    "publishDate": "2021-10-06T04:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Jessi Shakarian about her journey into UX/UI and how that lead to the big energy she needed to find her place in tech.</p>",
+    "showNotes": "<p>We welcome Jessi Shakarian to the show today to talk about her journey into UX/UI!</p><p class=\"text-left\">Jessi talks about how passion can be your motivation, and how valuable it is to be able to share what you're excited about: you aren't your tech stack. Sometimes finding that passion can lead you to new and interesting places like Jessi's change in focus from web dev to design.</p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0401-jessi-episode.png",
+    "guests": [
+      {
+        "name": "Jessi Shakarian",
+        "bio": "<p>Jessi Shakarian got her start in tech as a developer, but also she loved everything that happened before it was time to build a website. She is currently a UX designer at DIA Design Guild in Los Angeles and a python developer interested in machine learning.</p><ul><li><p><a href=\"https://www.jessishakarian.com/\" rel=\"noopener noreferrer\" target=\"_blank\">jessishakarian.com</a></p></li><li><p><a href=\"https://twitter.com/jessishakarian\" rel=\"noopener noreferrer\" target=\"_blank\">@jessishakarian</a> on Twitter</p></li><li><p><a href=\"https://www.polywork.com/jessishakarian\" rel=\"noopener noreferrer\" target=\"_blank\">jessishakarian</a> on PolyWork</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0401-jessi.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Todd Libby - Making the web equal and accessible",
+    "slug": "0402-todd-libby",
+    "id": "517",
+    "metaDescription": "Season Four, Episode Two of the Virtual Coffee Podcast",
+    "season": 4,
+    "episode": 2,
+    "buzzsproutId": "9355176",
+    "publishDate": "2021-10-12T04:00:00+00:00",
+    "shortDescription": "<p>This week on the podcast, we have Todd Libby talking about his work making the web equal and accessible for everyone. He drops a ton of resources (check the show notes!) tips on how to get started, and talks about how he's continually learning on the job.</p>",
+    "showNotes": "<p>We're welcoming Todd Libby to give us an intro to accessibility and what it means to make the web equal. Todd, a professional web developer, designer, and accessibility advocate for 22 years, provides a plethora of resources that can help everyone to get started and talks about how to advocate for accessibility and equality on projects.</p><h3><strong>Show Notes:</strong></h3><h4 class=\"text-left\"><strong>Things/People mentioned in the episode:</strong></h4><ul><li><p><a href=\"https://www.smashingmagazine.com/2021/07/strong-case-for-accessibility/\" rel=\"noopener noreferrer\" target=\"_blank\">Making A Strong Case for Accessibility</a> by Todd Libby</p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Microsoft_FrontPage\" rel=\"noopener noreferrer\" target=\"_blank\">Front Page Express</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Designing_with_Web_Standards\" rel=\"noopener noreferrer\" target=\"_blank\">Designing with Web Standards</a></p></li><li><p><a href=\"https://www.w3.org/WAI/standards-guidelines/wcag/\" rel=\"noopener noreferrer\" target=\"_blank\">Web Content Accessibility Guidelines (WCAG)</a></p></li><li><p><a href=\"https://twitter.com/cassandrafaris\" rel=\"noopener noreferrer\" target=\"_blank\">Cass Faris</a></p></li><li><p><a href=\"https://twitter.com/saltnburnem\" rel=\"noopener noreferrer\" target=\"_blank\">Chris DeMars</a></p></li></ul><h4 class=\"text-left\"><strong>A11y Learning Resources:</strong></h4><ul><li><p><a href=\"https://www.edx.org/course/web-accessibility-introduction\" rel=\"noopener noreferrer\" target=\"_blank\">Introduction to Web Accessibility</a> on edX</p></li><li><p><a href=\"https://webaim.org/\" rel=\"noopener noreferrer\" target=\"_blank\">WebAIM</a></p></li><li><p><a href=\"https://www.tpgi.com/\" rel=\"noopener noreferrer\" target=\"_blank\">TPGi</a></p></li></ul><h4 class=\"text-left\"><strong>Tools:</strong></h4><ul><li><p><a href=\"https://wave.webaim.org/extension/\" rel=\"noopener noreferrer\" target=\"_blank\">WAVE Web Accessibility Evaluation Tool</a></p></li><li><p><a href=\"https://www.deque.com/axe/\" rel=\"noopener noreferrer\" target=\"_blank\">axe accessibility toolkit</a></p></li><li><p><a href=\"https://pa11y.org/\" rel=\"noopener noreferrer\" target=\"_blank\">pa11y command line</a></p></li><li><p><a href=\"https://pauljadam.com/bookmarklets/tables.html\" rel=\"noopener noreferrer\" target=\"_blank\">Bookmarklets by Ian Loyyd and Paul J Adams</a></p></li><li><p><a href=\"https://github.com/microsoft/accessibility-insights-web\" rel=\"noopener noreferrer\" target=\"_blank\">Microsoft a11y insights</a></p></li><li><p><a href=\"https://developer.mozilla.org/en-US/docs/Tools/Accessibility_inspector\" rel=\"noopener noreferrer\" target=\"_blank\">Firefox a11y devtools</a></p></li><li><p><a href=\"https://developers.google.com/web/tools/lighthouse\" rel=\"noopener noreferrer\" target=\"_blank\">Lighthouse automated testing</a></p></li><li><p><a href=\"https://contrast-ratio.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Contrast Ratio tool by Lea Verou</a></p></li><li><p><a href=\"https://www.tpgi.com/color-contrast-checker/\" rel=\"noopener noreferrer\" target=\"_blank\">Colour Contrast Analyser</a></p></li></ul><h4 class=\"text-left\"><strong>Todd's steps for manual testing:</strong></h4><ol start=\"1\"><li><p>Mouse only</p></li><li><p>Keyboard only</p></li><li><p>Squint test</p></li><li><p><a href=\"https://www.afb.org/blindness-and-low-vision/using-technology/assistive-technology-products/screen-readers\" rel=\"noopener noreferrer\" target=\"_blank\">Screen readers</a></p></li><li><p><a href=\"https://webaim.org/articles/voiceover/\" rel=\"noopener noreferrer\" target=\"_blank\">Voice over in Safari</a></p></li><li><p><a href=\"https://www.nvaccess.org/\" rel=\"noopener noreferrer\" target=\"_blank\">NVDA</a> and <a href=\"https://www.freedomscientific.com/products/software/jaws/\" rel=\"noopener noreferrer\" target=\"_blank\">JAWS</a> on Windows</p></li><li><p><a href=\"https://help.gnome.org/users/orca/stable/introduction.html.en\" rel=\"noopener noreferrer\" target=\"_blank\">Orca</a> on Linux</p></li></ol>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0402-todd-episode.jpg",
+    "guests": [
+      {
+        "name": "Todd Libby",
+        "bio": "<p>Todd is a professional web developer, designer, and accessibility advocate for 22 years under many different technologies starting with HTML/CSS, Perl, and PHP, Todd has been an avid learner of web technologies for over 40 years starting with many flavors of BASIC all the way to React/Vue. Todd is also a member of the W3C working with groups on WCAG Silver (3.0). When not coding or advocating accessibility, you'll usually find Todd tweeting about (or eating) lobster rolls and accessibility.</p><ul><li><p><a href=\"https://toddl.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">toddl.dev</a></p></li><li><p><a href=\"https://twitter.com/toddlibby\" rel=\"noopener noreferrer\" target=\"_blank\">@toddlibby</a> on Twitter</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0402-todd.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Jennifer Konikowski - Hot Takes on Being a Woman in Tech",
+    "slug": "0403-jennifer-konikowski",
+    "id": "524",
+    "metaDescription": "Season Four, Episode Three of the Virtual Coffee Podcast",
+    "season": 4,
+    "episode": 3,
+    "buzzsproutId": "9396120",
+    "publishDate": "2021-10-19T04:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Jennifer Konikowski about building community for women in tech and her own experience as a woman in tech. She gives us some of her hot takes, and we are here for it 🔥</p>",
+    "showNotes": "<p>This week we welcome Jennifer Konikowski to the show to talk about being a woman in tech and building community for women in tech!</p><p class=\"text-left\">Jennifer brings her experience creating communities like <a href=\"http://www.meetup.com/pyladies-boston/\" rel=\"noopener noreferrer\" target=\"_blank\">Py Ladies Boston</a> and <a href=\"https://www.meetup.com/Boston-Ruby-Women/\" rel=\"noopener noreferrer\" target=\"_blank\">Boston Ruby Women</a> to the podcast, and talks about the value of learning to code even if you don't want to be a developer. She also talks about getting through toxic work environments, moving forward, and her hot takes on community and being a woman in tech.</p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0403-jennifer-episode.jpg",
+    "guests": [
+      {
+        "name": "Jennifer Konikowski",
+        "bio": "<p>Jennifer has 10 years of experience as a software engineer, working in Ruby and Rails, Go, Swift, Scala, Rust, PHP, Javascript, Java, Perl, and Python. She was the founder and organizer of PyLadies Boston and a founding member of Boston Ruby Women. She currently resides in Pittsburgh and works remotely at Splice. She also really loves Negronis.</p><ul><li><p><a href=\"https://jenniferkonikowski.com/\" rel=\"noopener noreferrer\" target=\"_blank\">jenniferkonikowski.com</a></p></li><li><p><a href=\"https://twitter.com/jenkoni\" rel=\"noopener noreferrer\" target=\"_blank\">@jenkoni</a> on Twitter</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0403-jennifer.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Mark Noonan - Civic tech, accessibility, holding the door open for other career changers",
+    "slug": "0404-mark-noonan",
+    "id": "531",
+    "metaDescription": "Season Four, Episode Four of the Virtual Coffee Podcast",
+    "season": 4,
+    "episode": 4,
+    "buzzsproutId": "9442638",
+    "publishDate": "2021-10-27T04:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Mark Noonan about how we can make space for career changers through Civic Tech while we make an impact on our communities.</p>",
+    "showNotes": "<p>This week we welcome Mark Noonan to the show to talk about how becoming a part of Civic Tech initiatives can help career changers to grow and help existing developers create opportunities for mentorship, support, and connection for those coming into tech.</p><p class=\"text-left\">Mark talks about his experience with <a href=\"https://www.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">FreeCodeCamp</a> as well as <a href=\"https://www.codeforatlanta.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Code for Atlanta</a>, and the $40,000 Hackathon his group won and donated to charity! He brings his experience as a career transitioner to the conversation and we look at how participating in Civic Tech can help you develop skills to be a better communicator and programmer. And you might hear a little bit about how we prefer our breakfast foods too 🥞</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://www.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">FreeCodeCamp</a></p></li><li><p><a href=\"https://www.codeforatlanta.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Code for Atlanta</a></p></li><li><p><a href=\"https://www.codeforamerica.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Code for America</a></p></li><li><p><a href=\"https://medium.com/paratransit-pal/paratransit-pal-won-40-000-at-at-ts-atlanta-civic-coding-challenge-and-gave-it-all-to-charity-30bba157d92d\" rel=\"noopener noreferrer\" target=\"_blank\">Marta Hackathon</a></p></li><li><p><a href=\"https://brigade.codeforamerica.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Code for America Brigades</a></p></li><li><p><a href=\"http://peoplemakingprogress.org/\" rel=\"noopener noreferrer\" target=\"_blank\">People Making Progress</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0404-mark-episode.jpg",
+    "guests": [
+      {
+        "name": "Mark Noonan",
+        "bio": "<p>Mark is a senior engineer at Cypress.io and is a co-organizer at Code for Atlanta. He also works as a program developer for People Making Progress, an Atlanta-based nonprofit serving adults with developmental disabilities at home, work, and in the community.</p><ul><li><p><a href=\"https://twitter.com/marktnoonan\" rel=\"noopener noreferrer\" target=\"_blank\">@marktnoonan</a> on Twitter</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0404-mark.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Suze Shardlow - Creating welcoming spaces in dev communities",
+    "slug": "0405-suze-shardlow",
+    "id": "540",
+    "metaDescription": "Season Four, Episode Five of the Virtual Coffee Podcast",
+    "season": 4,
+    "episode": 5,
+    "buzzsproutId": "9487228",
+    "publishDate": "2021-11-03T04:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Suze Shardlow about how she approaches creating welcoming spaces in dev communities.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Suze Shardlow. Suze is an award winning community manager, coder, tech writer and tech event MC and she currently leads the developer community at <a href=\"https://redis.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Redis</a>. We had a really interesting conversation with Suze! She's done a million different things throughout her life and her career and she shared with us how her experiences have informed her time as a software developer and a community leader.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://www.goodreads.com/book/show/56638386-30-second-coding?from_search=true&amp;from_srp=true&amp;qid=kCeXU2k1Tx&amp;rank=1\" rel=\"noopener noreferrer\" target=\"_blank\">30-second-coding</a></p></li><li><p><a href=\"https://twitter.com/SuzeShardlow/status/1445413709891973121?s=20\" rel=\"noopener noreferrer\" target=\"_blank\">On being a published author</a></p></li><li><p><a href=\"https://www.twitch.tv/redislabs\" rel=\"noopener noreferrer\" target=\"_blank\">redislabs on Twitch</a></p></li><li><p><a href=\"https://suze.dev/blog/im-a-techwomen100-2020-winner/\" rel=\"noopener noreferrer\" target=\"_blank\">One of the top 100 women in tech in 2020</a></p></li><li><p><a href=\"https://university.redis.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Redis University</a></p></li><li><p><a href=\"https://hacktoberfest.digitalocean.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Hacktoberfest</a></p></li><li><p><a href=\"https://codelandconf.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Codeland</a></p></li><li><p><a href=\"https://t.co/G0RN3vx2Gd?amp=1\" rel=\"noopener noreferrer\" target=\"_blank\">global diversity CFP day</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0405-suze-episode.jpg",
+    "guests": [
+      {
+        "name": "Suze Shardlow",
+        "bio": "<p>Suze Shardlow is a published tech author, developer community manager and event MC. Before retraining as a software engineer, she worked in marketing and management for 20 years in the engineering, technology, law enforcement, education and economic development sectors. Currently the head of developer community at Redis, Suze has won numerous awards including Rising Star In Tech 2021, TechWomen100 2020, Women In Software Power List 2020 and is a finalist in the Women In Tech Excellence Awards 2021.</p><ul><li><p><a href=\"https://suze.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">suze.dev</a></p></li><li><p><a href=\"https://twitter.com/SuzeShardlow\" rel=\"noopener noreferrer\" target=\"_blank\">@SuzeShardlow</a> on Twitter</p></li><li><p><a href=\"https://github.com/SuzeShardlow\" rel=\"noopener noreferrer\" target=\"_blank\">@SuzeShardlow</a> on GitHub</p></li><li><p><a href=\"https://www.linkedin.com/in/SuzeShardlow\" rel=\"noopener noreferrer\" target=\"_blank\">SuzeShardlow</a> on LinkedIn</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0405-suze.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Bryan Healey - The Entrepreneurial Journey of a Startup Founder",
+    "slug": "0406-bryan-healey",
+    "id": "547",
+    "metaDescription": "Season Four, Episode Six of the Virtual Coffee Podcast",
+    "season": 4,
+    "episode": 6,
+    "buzzsproutId": "9522643",
+    "publishDate": "2021-11-10T05:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Bryan Healey about how to kickoff your career as a start-up founder and the lessons he's learned along the way.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Bryan Healey, an entrepreneur, tech leader, data scientist / ML engineer, and biz developer. Bryan talks about gaining experience as an entrepreneur, how to get started in the start-up life, and how the entrepreneurial spirit has always been in his blood.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a></p></li><li><p><a href=\"https://virtualcoffee.io/podcast/0401-jessi-shakarian/\" rel=\"noopener noreferrer\" target=\"_blank\">Jessi's VC Podcast episode</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0406-bryan-episode.jpg",
+    "guests": [
+      {
+        "name": "Bryan Healey",
+        "bio": "<p>Bryan Healey is an entrepreneur, tech leader, data scientist / ML engineer, and biz developer. He's helped create or grow several start-ups, raised money, and built/managed teams of varying sizes, small to large. Currently co-founder and CTO at <a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a>.</p><ul><li><p><a href=\"https://twitter.com/Bryan_Healey\" rel=\"noopener noreferrer\" target=\"_blank\">@Bryan_Healey</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/bryanhealey\" rel=\"noopener noreferrer\" target=\"_blank\">bryanhealey</a> on LinkedIn</p></li><li><p><a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0406-bryan.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Jessica Wilkins - Growing your tech career through writing",
+    "slug": "0407-jessica-wilkins",
+    "id": "554",
+    "metaDescription": "Season Four, Episode Seven of the Virtual Coffee Podcast",
+    "season": 4,
+    "episode": 7,
+    "buzzsproutId": "9566513",
+    "publishDate": "2021-11-17T05:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Jessica Wilkins about how writing can help you to grow your tech career. She gives us tips on getting started and on taking feedback.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Jessica Wilkins, a self-taught developer and a staff author for the freeCodeCamp News publication. Jessica talks about how to get started with tech writing, how to differentiate between constructive criticism and negative feedback, and how to avoid gatekeeping by eliminating assumptions from your writing, avoiding terms and phrases like \"it's so easy!\", and sometimes adding prerequisites to your posts.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://www.esm.rochester.edu/\" rel=\"noopener noreferrer\" target=\"_blank\">Eastman School of Music</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=hD6uRvCtA_0&amp;t=70s\" rel=\"noopener noreferrer\" target=\"_blank\">Jessica's Lunch & Learn: How to grow your tech career through writing</a></p></li><li><p><a href=\"https://www.freecodecamp.org/news/author/jessica-wilkins/\" rel=\"noopener noreferrer\" target=\"_blank\">Freecodecamp news</a></p></li><li><p><a href=\"https://forum.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Freecodecamp forum</a></p></li><li><p><a href=\"https://www.freecodecamp.org/news/author/quincylarson/\" rel=\"noopener noreferrer\" target=\"_blank\">Quincy Larson</a></p></li><li><p><a href=\"https://www.history.com/this-day-in-history/george-floyd-killed-by-police-officer\" rel=\"noopener noreferrer\" target=\"_blank\">George Floyd murder</a></p></li><li><p><a href=\"https://blackexcellencemusicproject.com/\" rel=\"noopener noreferrer\" target=\"_blank\">The Black Excellence Music Project</a></p></li><li><p><a href=\"https://github.com/jdwilkin4/Black_Excellence_Project\" rel=\"noopener noreferrer\" target=\"_blank\">Github for it</a></p></li><li><p><a href=\"https://virtualcoffee.io/monthlychallenges/nov-2021/\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee November Monthly Challenge</a></p></li><li><p><a href=\"https://www.gatsbyjs.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Gatsby</a></p></li><li><p><a href=\"https://www.gatsbyjs.com/blog/gatsby-voices-jessica-wilkins/\" rel=\"noopener noreferrer\" target=\"_blank\">Voices of Gatsby: Fighting Back Against Imposter Syndrome</a></p></li><li><p><a href=\"https://www.freecodecamp.org/news/how-to-use-replit/\" rel=\"noopener noreferrer\" target=\"_blank\">How to Use Repl.it: a beginner's guide</a></p></li><li><p><a href=\"https://www.freecodecamp.org/news/how-to-use-codepen/\" rel=\"noopener noreferrer\" target=\"_blank\">How to Use Codepen: a beginner's guide</a></p></li><li><p><a href=\"https://dev.to/codergirl1991/how-to-create-a-node-bot-that-sends-happy-emails-throughout-the-year-25nj\" rel=\"noopener noreferrer\" target=\"_blank\">NodeMailer</a></p></li></ul><p><br></p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0407-jessica-episode.jpg",
+    "guests": [
+      {
+        "name": "Jessica Wilkins",
+        "bio": "<p>Jessica Wilkins is a self taught developer and technical writer from Los Angeles, California.</p><p class=\"text-left\">In her previous career, she was a professional oboist, educator and owner of JDW Sheet Music.</p><p class=\"text-left\">Jessica's interest in programming came during the pandemic when she wanted to build the Black Excellence Music Project which celebrates black artists from the jazz and classical fields.</p><p class=\"text-left\">She now works part-time as a junior developer for a small tech company and is a staff author for the freeCodeCamp News publication.</p><ul><li><p><a href=\"https://dev.to/codergirl1991\" rel=\"noopener noreferrer\" target=\"_blank\">Dev.to profile</a></p></li><li><p><a href=\"https://twitter.com/codergirl1991\" rel=\"noopener noreferrer\" target=\"_blank\">@codergirl1991 on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/jessica-wilkins-developer\" rel=\"noopener noreferrer\" target=\"_blank\">@jessica-wilkins-developer on LinkedIn</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0407-jessica.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Maeling Murphy - Transitioning to tech, and taking notes along the way",
+    "slug": "0408-maeling-murphy",
+    "id": "561",
+    "metaDescription": "Season Four, Episode Eight of the Virtual Coffee Podcast",
+    "season": 4,
+    "episode": 8,
+    "buzzsproutId": "9600325",
+    "publishDate": "2021-11-23T05:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Maeling Murphy about her journey from Material Science and Engineering to Software Engineering, including her personal documentation of her tech journey, work culture, and the big surprises when starting her job.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Dr. Maeling Murphy, a software engineer who recently transitioned into tech. Maeling shared the importance of connecting with potential employers to see if they would fit her values, how contributing to open source projects can help prepare you for your first job, and the value of developing the connection to community and being able to grow alongside others. Oh, and did we mention we talked a lot about Notion? She takes us through her notetaking journey and answers all our questions about finding the right approach.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://cs50.harvard.edu/\" rel=\"noopener noreferrer\" target=\"_blank\">Harvard's CS50</a></p></li><li><p><a href=\"https://www.100daysofcode.com/\" rel=\"noopener noreferrer\" target=\"_blank\">100 days of code</a></p></li><li><p><a href=\"https://virtualcoffee.io/monthlychallenges/july-2021/\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee Demo Monthly Challenge</a></p></li><li><p><a href=\"https://homeschool-journal.herokuapp.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Homeschool journal</a></p></li><li><p><a href=\"https://github.com/maelingmurphy\" rel=\"noopener noreferrer\" target=\"_blank\">Github</a></p></li><li><p><a href=\"https://github.com/maelingmurphy/My-Learning-Path/blob/main/log.md\" rel=\"noopener noreferrer\" target=\"_blank\">Learning Path log</a></p></li><li><p><a href=\"https://www.notion.so/templates/job-applications\" rel=\"noopener noreferrer\" target=\"_blank\">Karen's Notion for job searches</a></p></li><li><p><a href=\"https://docs.google.com/spreadsheets/d/1ZP0u5MjRiCOaYWuLoRTYr4BvB91M76ZCjkCYPuSePJc/edit?usp=sharing\" rel=\"noopener noreferrer\" target=\"_blank\">Karen's Job Application Details Spreadsheet</a></p></li><li><p><a href=\"https://www.notion.so/Thomas-Frank-s-Note-Taking-System-67924a5a25934f0fbe2f154cffcd8f97\" rel=\"noopener noreferrer\" target=\"_blank\">Frank's Notetaking System</a></p></li><li><p><a href=\"https://www.keyvalues.com/\" rel=\"noopener noreferrer\" target=\"_blank\">KeyValues: Find engineering teams that share your values</a></p></li><li><p><a href=\"https://pinboard.in/u:danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">Dan's Pinboard bookmarks</a></p></li><li><p><a href=\"https://github.com/forem/forem\" rel=\"noopener noreferrer\" target=\"_blank\">Forem</a> - Open source project that Nick Taylor helps maintain</p></li></ul><p><br></p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0408-maeling-episode.jpg",
+    "guests": [
+      {
+        "name": "Maeling Murphy",
+        "bio": "<p>Dr. Maeling Murphy is a software engineer who recently transitioned into tech, coming from an 8+ year entrepreneurial journey as a digital content creator and as a Ph.D. research scientist in Materials Science & Engineering.</p><p class=\"text-left\">Maeling identifies as a multi-passionate creative soul, finding expression through gardening, programming, brush-lettering and other mediums that cross her path.</p><p class=\"text-left\">She lets her love for exploration, learning and sharing with others lead her in all aspects of life and is enjoying this journey with her husband and son.</p><ul><li><p><a href=\"https://github.com/maelingmurphy\" rel=\"noopener noreferrer\" target=\"_blank\">maelingmurphy</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/maelingcodes\" rel=\"noopener noreferrer\" target=\"_blank\">@maelingcodes on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/maeling-murphy\" rel=\"noopener noreferrer\" target=\"_blank\">@maeling-murphy on LinkedIn</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0408-maeling.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Season 4 Wrap Up - Reviewing the year and celebrating our community",
+    "slug": "0409-season-four-wrapup",
+    "id": "568",
+    "metaDescription": "Season 4 Wrap Up - Reviewing the year and celebrating our community",
+    "season": 4,
+    "episode": 9,
+    "buzzsproutId": "9650635",
+    "publishDate": "2021-12-02T05:00:00+00:00",
+    "shortDescription": "<p>In this final episode of season 4 of the podcast, Bekah and Dan bring back special guest and community maintainer, Kirk Shillingford to retro our Virtual Coffee Hacktoberfest Initiative, talk about our monthly challenges and our excitement of going into year 2 of the challenges, and we even throw in some amazing and/or awful jokes at the end.</p>",
+    "showNotes": "<p>Kirk, Dan, and Bekah are back again to wrap up Season 4 of the podcast. We talk about Hacktoberfest and how proud we are of what our community did over the month of Hacktoberfest:</p><ul><li><p>100 members signed up,</p></li><li><p>66 members merged at least 1 pr,</p></li><li><p>336 collectively we merged 336 PRs were merged by these members across 129 repos.</p></li></ul><p class=\"text-left\">On the <a href=\"https://virtualcoffee.io/\" rel=\"noopener noreferrer\" target=\"_blank\">virtualcoffee.io</a> site: 81 PRs merged, 50 were new member profiles, 31 others.</p><p class=\"text-left\">We talk about the monthly challenges, including already surpassing the monthly goal for blogging half way through <a href=\"https://virtualcoffee.io/monthlychallenges/nov-2021/\" rel=\"noopener noreferrer\" target=\"_blank\">November</a>, and what we're looking forward to doing in the next 12 months.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://hacktoberfest.digitalocean.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Digital Ocean Hacktoberfest</a></p></li><li><p><a href=\"https://virtualcoffee.io/podcast/0406-bryan-healey/\" rel=\"noopener noreferrer\" target=\"_blank\">Bryan's Episode</a></p></li><li><p><a href=\"https://github.com/colabottles/\" rel=\"noopener noreferrer\" target=\"_blank\">Todd Libby</a></p></li><li><p><a href=\"https://github.com/abbeyperini\" rel=\"noopener noreferrer\" target=\"_blank\">Abbey Perini</a></p></li><li><p><a href=\"https://github.com/MattyMc\" rel=\"noopener noreferrer\" target=\"_blank\">Matt McInnis</a></p></li><li><p><a href=\"https://prettier.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Prettier</a></p></li><li><p><a href=\"https://virtualcoffee.io/podcast/0407-jessica-wilkins/\" rel=\"noopener noreferrer\" target=\"_blank\">Jessica's Episode</a></p></li><li><p><a href=\"https://chrisbrogan.com/stories/community/audience-or-community/\" rel=\"noopener noreferrer\" target=\"_blank\">Audience or Community by Chris Brogan</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-episode.jpg",
+    "guests": [
+      {
+        "name": "Kirk Shillingford",
+        "bio": "<p>Software Developer, and Community Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://github.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-kirk.jpg"
+      },
+      {
+        "name": "Bekah Hawrot Weigel",
+        "bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dev.to/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/bekahhw</a></p></li><li><p><a href=\"https://twitter.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">@bekahhw</a> on Twitter</p></li><li><p><a href=\"https://www.instagram.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">bekahhw</a> on Instagram</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0209-bekah.jpg"
+      },
+      {
+        "name": "Dan Ott",
+        "bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dtott.com/\" rel=\"noopener noreferrer\" target=\"_blank\">dtott.com</a></p></li><li><p><a href=\"https://twitter.com/danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">@danieltott</a> on Twitter</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-dan.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Brian Rinaldi - Developer Advocacy and Fostering Community",
+    "slug": "0501-brian-rinaldi",
+    "id": "180",
+    "metaDescription": "Season Five, Episode One of the Virtual Coffee Podcast",
+    "season": 5,
+    "episode": 1,
+    "buzzsproutId": "10297519",
+    "publishDate": "2022-03-22T04:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Brian Rinaldi about doing DevRel (Developer Relations) right and playing to your team's strengths. We also talk about the importance of connection and why we as developers need to support each other.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Brian Rinaldi, a Developer Experience Engineer at LaunchDarkly with over 20 years of experience as a developer for the web, about how Developer Relationships has changed over the years and why need not just remote community experiences but also in-person opportunities. We talk about the value of different types of communities and how each is necessary to support developers.</p><h3>Links</h3><ul><li><p><a href=\"https://launchdarkly.com/\" rel=\"noopener noreferrer\" target=\"_blank\">LaunchDarkly</a></p></li><li><p><a href=\"https://CFE.dev\" rel=\"noopener noreferrer\" target=\"_blank\">CFE.dev</a></p></li><li><p><a href=\"https://thejam.dev\" rel=\"noopener noreferrer\" target=\"_blank\">TheJam.dev</a></p></li><li><p><a href=\"https://www.manning.com/books/the-jamstack-book\" rel=\"noopener noreferrer\" target=\"_blank\">The Jamstack Book</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0501-brian-episode.jpg",
+    "guests": [
+      {
+        "name": "Brian Rinaldi",
+        "bio": "<p>Brian Rinaldi is a Developer Experience Engineer at LaunchDarkly with over 20 years experience as a developer for the web. Brian is actively involved in the community running developer meetups via CFE.dev and Orlando Devs. He's the editor of the Jamstacked newsletter and co-author of The Jamstack Book from Manning.</p><ul><li><p><a href=\"http://remotesynthesis.com\" rel=\"noopener noreferrer\" target=\"_blank\">remotesynthesis.com</a></p></li><li><p><a href=\"https://github.com/remotesynth\" rel=\"noopener noreferrer\" target=\"_blank\">remotesynth</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/remotesynth\" rel=\"noopener noreferrer\" target=\"_blank\">@remotesynth on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/brianrinaldi\" rel=\"noopener noreferrer\" target=\"_blank\">@brianrinaldi on LinkedIn</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0501-brian.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Amy Shackles - Finding a job you love",
+    "slug": "amy-shackles-finding-a-job-you-love",
+    "id": "767",
+    "metaDescription": "Season Five, Episode Two of the Virtual Coffee Podcast",
+    "season": 5,
+    "episode": 2,
+    "buzzsproutId": "10353204",
+    "publishDate": "2022-03-31T04:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Amy Shackles about the importance of good communication in finding a job you love and defining your career path.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Amy Shackles, a Senior Software Engineer at MURAL, about how she made her way from being a Psychology and Anthropology double major to being a Senior Software Engineer. She shares what’s made her experience at MURAL a great one and the importance of openness in communication.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://amyshackles.com/\" rel=\"noopener noreferrer\" target=\"_blank\">amyshackles.com</a></p></li><li><p><a href=\"https://github.com/AmyShackles/regex_parser\" rel=\"noopener noreferrer\" target=\"_blank\">Amy's regular expression parser</a></p></li><li><p><a href=\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions\" rel=\"noopener noreferrer\" target=\"_blank\">MDN article on regular expressions</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0502-amy-episode.jpg",
+    "guests": [
+      {
+        "name": "Amy Shackles",
+        "bio": "<p>Amy is a Senior Software Engineer currently working at <a href=\"https://mural.co/\" rel=\"noopener noreferrer\" target=\"_blank\">MURAL</a>. She loves information, human interaction, solving problems, helping people, and cats - not in that order. She spends most of her free time lately learning Spanish, practicing calligraphy, singing, writing parody songs, and crocheting.</p><ul><li><p><a href=\"https://amyshackles.com/\" rel=\"noopener noreferrer\" target=\"_blank\">amyshackles.com</a></p></li><li><p><a href=\"https://github.com/AmyShackles\" rel=\"noopener noreferrer\" target=\"_blank\">AmyShackles</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/AmyShackles\" rel=\"noopener noreferrer\" target=\"_blank\">@AmyShackles on Twitter</a></p></li><li><p><a href=\"https://dev.to/amyshackles\" rel=\"noopener noreferrer\" target=\"_blank\">@AmyShackles on DEV.to</a></p></li><li><p><a href=\"https://www.linkedin.com/in/AmyShackles\" rel=\"noopener noreferrer\" target=\"_blank\">@AmyShackles on LinkedIn</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0502-amy.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Helen Griffin - Multi-passionate in tech",
+    "slug": "helen-griffin-multi-passionate-in-tech",
+    "id": "781",
+    "metaDescription": "Season Five, Episode Three of the Virtual Coffee Podcast",
+    "season": 5,
+    "episode": 3,
+    "buzzsproutId": "10397152",
+    "publishDate": "2022-04-07T04:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Helen Griffin about what she’s learned from her journey going from tech to founder and back to tech again.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Helen Griffin, a full-stack developer and founder, about how the tech industry changed during the time she was a founder, how what she’s learned as a founder has helped her to have a broader perspective about the tech industry, and what she’s doing with her companies Jovial and State of Developers to support developers in their career journeys.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://stateofdevs.com/\" rel=\"noopener noreferrer\" target=\"_blank\">The State of Developers</a></p></li><li><p><a href=\"https://jovial.work/\" rel=\"noopener noreferrer\" target=\"_blank\">Jovial</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0503-helen-episode.jpg",
+    "guests": [
+      {
+        "name": "Helen Griffin",
+        "bio": "<p>Helen started her career as a web developer. Now, as a full-stack dev & founder, she enjoys helping developers build products & a life they love. Today, she spends her time building developer tools, like State of Developers & Jovial. Helen is on a campaign to help her peers recover from burnout.</p><ul><li><p><a href=\"https://helenjr.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">HelenJr.dev</a></p></li><li><p><a href=\"https://github.com/helengriffinjr\" rel=\"noopener noreferrer\" target=\"_blank\">helengriffinjr</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/helengriffinjr\" rel=\"noopener noreferrer\" target=\"_blank\">@helengriffinjr</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/hgriffinjr\" rel=\"noopener noreferrer\" target=\"_blank\">@hgriffinjr</a> on LinkedIn</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0503-helen.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Yolanda Haynes - Breaking into Tech: It Takes Time",
+    "slug": "yolanda-haynes-breaking-into-tech-it-takes-time",
+    "id": "790",
+    "metaDescription": "Season Five, Episode Four of the Virtual Coffee Podcast",
+    "season": 5,
+    "episode": 4,
+    "buzzsproutId": "10431216",
+    "publishDate": "2022-04-13T04:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Yolanda Haynes about her journey into tech and how she created her own path and experiences, including joining Virtual Coffee, 100devs, and Collab Lab.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Yolanda Haynes, a career changer who went from working as a certified occupational therapy assistant to a Software Engineer, about the importance of finding community during your learning journey, and remembering that you shouldn’t judge your journey based on anyone else’s; focus on the learning journey, absorbing what you can, and preparing yourself for your future.</p><h3>Links:</h3><ul><li><p><a href=\"https://leonnoel.com/100devs/\" rel=\"noopener noreferrer\" target=\"_blank\">100devs</a></p></li><li><p><a href=\"https://the-collab-lab.codes/\" rel=\"noopener noreferrer\" target=\"_blank\">The Collab Lab</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0504-yolanda.jpg",
+    "guests": [
+      {
+        "name": "Yolanda Haynes",
+        "bio": "<p>A career changer from working in healthcare as a COTA (certified occupational therapy assistant) to a Software Engineer.</p><ul><li><p><a href=\"https://www.yhaynes.com/\" rel=\"noopener noreferrer\" target=\"_blank\">yhaynes.com</a></p></li><li><p><a href=\"https://github.com/YolandaHaynes\" rel=\"noopener noreferrer\" target=\"_blank\">@YolandaHaynes on GitHub</a></p></li><li><p><a href=\"https://twitter.com/_YolandaHaynes\" rel=\"noopener noreferrer\" target=\"_blank\">@_YolandaHaynes on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/yolanda-haynes/\" rel=\"noopener noreferrer\" target=\"_blank\">@yolanda-haynes on LinkedIn</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Profile.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Roger Gentry - Perseverance and  Problem Solving",
+    "slug": "roger-gentry-perseverance-and-problem-solving",
+    "id": "814",
+    "metaDescription": "Season 5, Episode 5 of the Virtual Coffee Podcast",
+    "season": 5,
+    "episode": 5,
+    "buzzsproutId": "10480828",
+    "publishDate": "2022-04-21T04:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Roger Gentry about his love of solving problems and how he's brought that with him into tech.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Roger Gentry, who has spent a lot of his career managing security and compliance for clients across the United States, about his passion for problem-solving and what to do when you get stuck. We're all going to run into frustrations during our tech journeys, but knowing how to navigate through them is one of the key skills you'll need.</p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0505-roger-episode.jpg",
+    "guests": [
+      {
+        "name": "Roger Gentry",
+        "bio": "<p>Roger has managed the security and compliance for clients across the United States. Providing CTO/CSO level consulting to a variety of industries, Roger has worked with customers to achieve successful compliance certifications from PCI, ISO, SOC, and more.</p><p><a href=\"http://r-o-g-e-r.com/\" rel=\"noopener noreferrer\" target=\"_blank\">http://r-o-g-e-r.com/</a></p>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0505-roger.jpeg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Special Kirk Day Bonus Episode (Live)",
+    "slug": "special-kirk-day-bonus-episode",
+    "id": "825",
+    "metaDescription": "Happy Kirk Day!",
+    "season": 5,
+    "episode": 999,
+    "buzzsproutId": "10509803",
+    "publishDate": "2022-04-26T04:00:00+00:00",
+    "shortDescription": "<p>A special live episode of the Virtual Coffee Podcast - Bekah and Dan meet for the first time in real life, and get to hang out with Kirk on Kirk Day!</p>",
+    "showNotes": "<p>A special live episode of the Virtual Coffee Podcast - Bekah and Dan meet for the first time in real life, and get to hang out with Kirk on Kirk Day! Also Dan fires Bekah (for the first time).</p><p><a href=\"https://youtu.be/uh-oA8czBVo\">Watch the stream on YouTube!</a></p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/05-bonus-kirk-day.jpg",
+    "guests": [],
+    "sponsors": []
+  },
+  {
+    "title": "Andrew Bush - Mobile Development and Giving Back to Community",
+    "slug": "andrew-bush-mobile-development-and-giving-back-to-community",
+    "id": "828",
+    "metaDescription": "Season 5, Episode 6 of the Virtual Coffee Podcast",
+    "season": 5,
+    "episode": 6,
+    "buzzsproutId": "10565670",
+    "publishDate": "2022-05-05T04:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Andrew Bush about his experiences with mobile development, and his thoughts on community and what it means to give back.</p>",
+    "showNotes": "<p>In today's episode, Dan and Bekah talk to Andrew Bush, a Mobile Engineer Specializing in React Native. One of the updates we've made to our site is to have tags on our <a href=\"https://virtualcoffee.io/members\">members page</a> to indicate what volunteer roles they have. Andrew is one of our Monthly Challenge team leads, and he shared with us his experiences helping to facilitate the challenges, keeping our community motivated, and the processes we go through. We also go into what it's like to be a mobile developer, and the learning path he's been on throughout his career.</p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0506-andrew-episode.jpg",
+    "guests": [
+      {
+        "name": "Andrew Bush",
+        "bio": "<p>Andrew is a mobile developer specializing in React Native based out of Wisconsin in the US. He has been developing professionally for 3 years and has really found his passion in mobile apps and accessibility. Being legally blind himself, he recognizes the need for inclusion in software development so that EVERYONE can use the applications we create.</p><p>Outside of his professional life, Andrew is a dedicated amateur runner with a love for the sport that rivals his love of Swedish Fish candy. You can also find him participating as a co-lead of the Virtual Coffee monthly challenges where he strives to create engagement and growth combined with the feeling of an intimate community.</p>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0506-andrew.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Meg Gutshall - Building accountability into Community",
+    "slug": "meg-gutshall-building-accountability-into-community",
+    "id": "840",
+    "metaDescription": "Season 5, Episode 7 of the Virtual Coffee Podcast",
+    "season": 5,
+    "episode": 7,
+    "buzzsproutId": "10613498",
+    "publishDate": "2022-05-13T04:00:00+00:00",
+    "shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk with Meg Gutshall about accountability and how to bring that to your community. She shares some of her memorable experiences with community and she does it all with Philly flair.</p>",
+    "showNotes": "<p>In today's episode, Bekah and Dan talk to Meg Gutshall, a Ruby on Rails Developer, and community volunteer at Virtual Coffee. She shared all things Philly and some memorable stories of how she's supported others--including Bekah--in their journeys into tech. Meg talks about her Accountabilibuddies group at Virtual Coffee and how she chose Ruby after graduating from a full stack bootcamp.</p><p></p><img src=\"http://storage.googleapis.com/virtualcoffeeio-assets/images/_podcastShowNotesImage/gritty.jpg\" alt=\"Gritty, the Fliers Mascot\" title=\"Gritty, the Fliers Mascot\"><p></p><h3>Links</h3><ul><li><p><a href=\"https://en.wikipedia.org/wiki/Gritty\" rel=\"noopener noreferrer\" target=\"_blank\">Gritty</a></p></li><li><p><a href=\"https://freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">freeCodeCamp</a></p></li><li><p><a href=\"https://www.pennmedicine.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Penn medicine</a></p></li><li><p><a href=\"https://www.urbandictionary.com/define.php?term=Jawn\" rel=\"noopener noreferrer\" target=\"_blank\">jawn</a></p></li><li><p>Meg's blog post on code and Spanish: <a href=\"https://meghangutshall.com/2018/07/21/the_little_things_matter/\" rel=\"noopener noreferrer\" target=\"_blank\">The Little Things Matter</a></p></li><li><p><a href=\"https://rubyforgood.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Ruby for Good</a></p></li><li><p><a href=\"https://humanessentials.app/\" rel=\"noopener noreferrer\" target=\"_blank\">HumanEssentials.app</a></p></li><li><p><a href=\"https://nationalcasagal.org/\" rel=\"noopener noreferrer\" target=\"_blank\">CASA</a></p></li><li><p><a href=\"https://2022.phillytechweek.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Philly Tech Week</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0507-meg-episode.jpg",
+    "guests": [
+      {
+        "name": "Meg Gutshall",
+        "bio": "<p>Meg is a Ruby on Rails developer with a passion for open source and tech for good. She's always smiling, continuously learning, and quick to strike up a conversation. She takes her advice with a grain of salt & a shot of tequila.</p>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0507-meg.png"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Matt McInnis - Go Make Stuff!",
+    "slug": "matt-mcinnis-go-make-stuff",
+    "id": "860",
+    "metaDescription": "Season 5, Episode 8 of the Virtual Coffee Podcast",
+    "season": 5,
+    "episode": 8,
+    "buzzsproutId": "10680520",
+    "publishDate": "2022-05-25T04:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Matt McInnis about his incredible journey through tech from math professor, to self-taught data-scientist working with IBM and Microsoft, to founder.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Matt McInnis a former Math Professor, and current data scientist, full-stack engineer, and founder, about his journey through tech as a self-taught engineer. He shares his insight into building personal projects and creating value in the projects you work on, even if those projects are just for you.</p><h3>Links</h3><ul><li><p><a href=\"https://typistapp.ca/\">Typist</a></p></li><li><p><a href=\"https://www.littlebrown.com/titles/malcolm-gladwell/the-tipping-point/9780759574731/\">Malcolm Gladwell's Tipping Point</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Kidstreet\" rel=\"noopener noreferrer\" target=\"_blank\">Kidstreet</a></p></li><li><p><a href=\"https://www.hackerparadise.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Hacker Paradise</a></p></li><li><p><a href=\"https://ologicinc.com/portfolio/star-wars-science-force-trainer/\" rel=\"noopener noreferrer\" target=\"_blank\">Star Wars Force Trainer</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0508-matt-episode.jpg",
+    "guests": [
+      {
+        "name": "Matt McInnis",
+        "bio": "<p>Matt is a full-stack developer (Rails+React) at <a href=\"https://typistapp.ca/\">Typist</a> based in Toronto, Canada. Former artificial intelligence lead at IBM and Microsoft, mathematics professor at Centennial College and Saskatchewan Polytechnic. Matt really loves brunch.</p><ul><li><p><a href=\"https://github.com/MattyMc\">MattyMc on GitHub</a></p></li><li><p><a href=\"https://twitter.com/MattLovesMath\">MattLovesMath on Twitter</a></p></li><li><p><a href=\"http://linkedin.com/in/mattmcinnis\">mattmcinnis on LinkedIn</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0508-matt.jpeg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Season 5 Wrap-Up: Working to Empower the Virtual Coffee Community",
+    "slug": "season-5-wrap-up-working-to-empower-the-virtual-coffee-community",
+    "id": "876",
+    "metaDescription": "Season 5 Finale of the Virtual Coffee Podcast",
+    "season": 5,
+    "episode": 9,
+    "buzzsproutId": "10720878",
+    "publishDate": "2022-06-01T04:00:00+00:00",
+    "shortDescription": "<p>In this season finale of the podcast, Dan, Kirk, and Bekah come together to talk about making hard decisions to ensure community support and stability. They also share how they're navigating technical and community challenges as the community grows.</p>",
+    "showNotes": "<p>In this episode of the podcast, Bekah, Kirk, and Dan discuss the decision to pause new membership and what the maintainers are doing to progress towards opening the community up again. We share what we think makes our community special, how we're working to preserve that, and some of the challenges we're figuring out as we take steps towards reopening membership. What goes into the long-term strategy of making Virtual Coffee <em>an intimate group of devs, optimized for you</em>? You'll find out in this episode.</p><h3>Links:</h3><ul><li><p><a href=\"https://gamesnostalgia.com/game/dx-ball\" rel=\"noopener noreferrer\" target=\"_blank\">DX Ball</a></p></li><li><p><a href=\"https://boardgamegeek.com/boardgame/3086/omega-virus\" rel=\"noopener noreferrer\" target=\"_blank\">Omega Virus</a></p></li><li><p><a href=\"https://www.ultraboardgames.com/othello/game-rules.php\" rel=\"noopener noreferrer\" target=\"_blank\">Othello</a></p></li><li><p><a href=\"http://virtualcoffee.io/members\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee Members</a></p></li><li><p><a href=\"https://virtualcoffee.io/resources/virtual-coffee/get-involved/paths-to-leadership\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee Paths to Leadership</a></p></li><li><p><a href=\"https://twitter.com/SuzeShardlow\" rel=\"noopener noreferrer\" target=\"_blank\">Suze Shardlow</a></p></li><li><p><a href=\"https://www.bbc.com/future/article/20191001-dunbars-number-why-we-can-only-maintain-150-relationships\" rel=\"noopener noreferrer\" target=\"_blank\">Dunbar's Number</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0509-finale-episode.jpg",
+    "guests": [
+      {
+        "name": "Kirk Shillingford",
+        "bio": "<p>Software Developer, and Community Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://github.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-kirk.jpg"
+      },
+      {
+        "name": "Bekah Hawrot Weigel",
+        "bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dev.to/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/bekahhw</a></p></li><li><p><a href=\"https://twitter.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">@bekahhw</a> on Twitter</p></li><li><p><a href=\"https://www.instagram.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">bekahhw</a> on Instagram</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/T014AAKN3KP-U014HT3RNCU-f7cccf369940-512.png"
+      },
+      {
+        "name": "Dan Ott",
+        "bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dtott.com/\" rel=\"noopener noreferrer\" target=\"_blank\">dtott.com</a></p></li><li><p><a href=\"https://twitter.com/danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">@danieltott</a> on Twitter</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-dan.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "David Alpert - On pairing and providing support",
+    "slug": "david-alpert-on-pairing-and-providing-support",
+    "id": "913",
+    "metaDescription": "Season 6, Episode 1 of the Virtual Coffee Podcast",
+    "season": 6,
+    "episode": 1,
+    "buzzsproutId": "10964411",
+    "publishDate": "2022-07-15T04:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to David Alpert about supporting others in their tech journey, asking the right questions, and leading with empathy.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with David Alpert, Director of Engineering at Northfield IT, about taking a personalized approach to helping others as they ask coding questions and navigate career paths. David shares the importance of bringing empathy to every situation and gives tips on how to handle challenging situations.</p><h3>Links:</h3><ul><li><p><a href=\"https://en.wikipedia.org/wiki/Logo_(programming_language)\">Logo (the programming turtle)</a></p></li><li><p><a href=\"https://dev.to/virtualcoffee/how-the-virtual-coffee-coworking-room-works-2a89\">Virtual Coffee Co-Working Room</a></p></li><li><p><a href=\"https://agilemanifesto.org/\">The Agile Manifesto</a></p></li><li><p><a href=\"https://www.twitch.tv/virtualcoffeeio\">Typescript Tuesdays</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0601-david-episode.jpg",
+    "guests": [
+      {
+        "name": "David Alpert",
+        "bio": "<p>David Alpert is a collaborative leader and agile coach striving to reduce friction between people and software. Based in Winnipeg, Manitoba, David has over 20 years of professional IT experience in software development, system design, and project and people management spanning the finance, manufacturing, and sports entertainment industries. David is passionate about test-driven development, refactoring, pair programming, and helping people become better developers.</p><ul><li><p>Website: <a href=\"https://blog.spinthemoose.com\">Spin the Moose</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/davidalpert\">@davidalpert</a></p></li><li><p>GitHub: <a href=\"https://github.com/davidalpert\">davidalpert</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0601-david.jpeg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Bogdan Covrig - Navigating Tech Career Paths",
+    "slug": "bogdan-covrig-navigating-tech-career-paths",
+    "id": "933",
+    "metaDescription": "Season Six, Episode Two of the Virtual Coffee Podcast",
+    "season": 6,
+    "episode": 2,
+    "buzzsproutId": "11044164",
+    "publishDate": "2022-07-28T04:00:00+00:00",
+    "shortDescription": "<p>In this episode, Dan and Bekah talk to Bogdan Covrig about finding the right career path within tech and searching for what gets you excited.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Bogdan Covrig, a Software Engineer in the Netherlands who's into Typescript, React and Node, about navigating different learning and career paths in tech before landing a job that fulfills his interests to see the changes he's making and provides a dynamic work environment. He also drops his tips on the most important things you can do if you're starting your journey into tech.</p><h3>Links</h3><ul><li><p><a href=\"https://p5js.org/\">p5.js</a></p></li><li><p><a href=\"https://www.arduino.cc/\">Arduino</a></p></li><li><p><a href=\"https://www.twitch.tv/virtualcoffeeio/schedule\">Twitch TypeScript Tuesdays</a></p></li><li><p>Nick and Bekah's Lunch & Learn <a href=\"https://youtu.be/DVqtr3iwkwQ\">Coding questions: Problem-solving and working through challenges</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0602-bogdan-episode.png",
+    "guests": [
+      {
+        "name": "Bogdan Covrig",
+        "bio": "<p>Bogdan is a Software Engineer in the Netherlands. He’s passionate about privacy, automation and infrastructure. He’s into Typescript, React and Node, currently building and working with CMS. He’s usually busy with movies, concerts or sitting in the park for no reason.</p><ul><li><p><a href=\"https://github.com/BogDAAAMN\">@BogDAAAMN</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/BogdanCovrig\">@BogdanCovrig</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/BogdanCovrig\">@BogdanCovrig</a> on LinkedIn</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0602-bogdan.jpeg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Seth Hall - From Film Production to Technical Product Owner: A Career Changer's Story",
+    "slug": "seth-hall-from-film-production-to-technical-product-owner-a-career-changers-story",
+    "id": "954",
+    "metaDescription": "Season 6, Episode 3 of the Virtual Coffee Podcast",
+    "season": 6,
+    "episode": 3,
+    "buzzsproutId": "11103329",
+    "publishDate": "2022-08-09T04:00:00+00:00",
+    "shortDescription": "<p>Bekah and Dan talk to Seth Hall, a Technical Product Owner at Uniform. He talks about the importance of fostering authentic company culture, as well as how his search to find a challenging, fun, and flexible job led him from Film Production, to Frontend Developer, to his current role.</p>",
+    "showNotes": "<p>In today's episode, Dan and Bekah talk with Seth Hall about the importance of intimate collaboration, advocating for yourself, and transferable skills as part of his job as a Technical Product Owner at <a href=\"https://uniform.dev/\">Uniform</a>. He shares how his background as a creative producer informs how he guides demo initiatives, creates roadmaps, and collaborates with other departments.</p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0603-seth-hall-episode.jpg",
+    "guests": [
+      {
+        "name": "Seth Hall",
+        "bio": "<p>Seth is a Technical Product Owner at <a href=\"https://uniform.dev/\">Uniform</a></p><ul><li><p>Website: <a href=\"https://sethhall.dev/\">sethhall.dev</a></p></li><li><p>Dev.to: <a href=\"https://dev.to/sethburtonhall\"><u>dev.to/sethburtonhall</u></a></p></li><li><p>Polywork: <a href=\"https://www.polywork.com/sethhall\"><u>polywork.com/sethhall</u></a></p></li><li><p>Twitter: <a href=\"https://twitter.com/sethburtonhall\">@sethburtonhall</a></p></li><li><p>GitHub: <a href=\"https://github.com/sethburtonhall\">@sethburtonhall</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0603-seth-hall.png"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "50th Episode Special - Live at KCDC 2022",
+    "slug": "50th-episode-special-live-at-kcdc-2022",
+    "id": "987",
+    "metaDescription": "Season Six Special Edition",
+    "season": 6,
+    "episode": 999,
+    "buzzsproutId": "11127313",
+    "publishDate": "2022-08-12T04:00:00+00:00",
+    "shortDescription": "<p>For the 50th episode of the podcast, Dan and Bekah are live at KCDC 2022 answering listener questions and practicing their accents.</p>",
+    "showNotes": "<p>For the 50th episode of the podcast, Dan and Bekah are live at the Kansas City Developer Conference 2022 answering listener questions and practicing their accents.</p><p><a href=\"https://www.youtube.com/watch?v=_fqFv1joZ3A\"><strong>Check out the video version on YouTube!</strong></a></p><h4>Listener questions:</h4><ul><li><p>What time do you go to sleep? (2:19)</p></li><li><p>How does a computer get drunk? (12:42)</p></li><li><p>What's the hardest part of community? (22:20)</p></li><li><p>Ayu would like to hear the history of how Virtual Coffee was founded. (31:57)</p></li><li><p>What does community mean to you? (38:01)</p></li><li><p>At in-person events, what are some techniques or tactics you used for starting a conversation with a stranger? (41:00)</p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/06-special.png",
+    "guests": [],
+    "sponsors": []
+  },
+  {
+    "title": "Sadie Jay - Technical Interviews for Bootcamp Grads",
+    "slug": "sadie-jay-technical-interview-for-bootcamp-grads",
+    "id": "990",
+    "metaDescription": "Season 6, Episode 4 of the Virtual Coffee Podcast",
+    "season": 6,
+    "episode": 4,
+    "buzzsproutId": "11204579",
+    "publishDate": "2022-08-30T04:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Sadie about technical interviewing after bootcamp. She shares her tips for landing interviews, prepping, and interviewing your interviewers.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Sadie a frontend developer for a federal agency, to chat about her experience navigating the interview process and how she found success after giving tech a second shot. She shares tips on how to avoid burnout both during the interview process and while you're working in tech.</p><h3>Links:</h3><ul><li><p><a href=\"https://18f.gsa.gov/\">18f</a></p></li><li><p><a href=\"https://skillcrush.com/\">Skill Crush</a></p></li><li><p><a href=\"https://leetcode.com/explore/challenge/\">Leet Code Challenge</a></p></li><li><p><a href=\"https://github.com/jmkoni/interview-questions\"><u>Jennifer's List of Interview Questions</u></a></p></li><li><p><a href=\"https://skillcrush.com/blog/technical-test-preparation-advice/\">Technical Test Preparation Advice</a> post by Sadie</p></li><li><p><a href=\"https://www.wordsofmouth.org/\">Words of Mouth job email</a></p></li><li><p><a href=\"https://designsystem.digital.gov/\">US Web Design Standards</a></p></li><li><p><a href=\"https://jekyllrb.com/\">Jekyll</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0604-sadie-episode.png",
+    "guests": [
+      {
+        "name": "Sadie Jay",
+        "bio": "<p>Sadie is a Front-end Developer and bootcamp alum. In 2016, Sadie started her journey into tech with web design courses. Along the way, she graduated with a Masters specializing in Web Design and Online Communication, taught yoga, searched for cheap flights at a travel startup, volunteered as a writer and proofreader for various non-profits, and contributed to a number of open source projects. Outside of coding and writing, Sadie can be found petting her cat Maxie, hanging out with her mom, or looking up the next vegan restaurant to check out.</p><ul><li><p><a href=\"https://sadiejay.github.io/portfolio/\">Sadie's Portfolio Site</a></p></li><li><p><a href=\"https://github.com/sadiejay\">@sadiejay on GitHub</a></p></li><li><p><a href=\"https://www.linkedin.com/in/sadiej/\">@sadiej on LinkedIn</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0604-sadie.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Chad Stewart - OSS and #TechisHiring",
+    "slug": "chad-stewart-oss-and-techishiring",
+    "id": "1026",
+    "metaDescription": "Season 6, Episode 5 of the Virtual Coffee Podcast",
+    "season": 6,
+    "episode": 5,
+    "buzzsproutId": "11269316",
+    "publishDate": "2022-09-06T04:00:00+00:00",
+    "shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk with Chad Stewart about getting started in open source, finding a project with a supportive community, and his project #TechIsHiring.</p>",
+    "showNotes": "<p>In today's episode, Bekah and Dan talk to Chad Stewart, a Software Engineer from Kingston, Jamaica, about his journey into contributing to Open Source projects like Open Sauced and how to find your way to your first contribution. He shares the inspiration behind his <a href=\"https://www.getrevue.co/profile/techishiring\">#TechIsHiring project</a>, which helps to identify tech jobs and resources, but more importantly, to connect people in the wider tech community.</p><h3>Links</h3><ul><li><p><a href=\"https://www.amazon.com/Side-Mountain-Jean-Craighead-George/dp/0141312424\">My Side of the Mountain</a></p></li><li><p><a href=\"https://twitter.com/bdougieYO\">Brian Douglas, aka Bdougie</a></p></li><li><p><a href=\"https://opensauced.pizza/\">Open Sauced</a></p></li><li><p><a href=\"https://github.com/yangshun/tech-interview-handbook\">Tech Interview Handbook</a></p></li><li><p><a href=\"https://github.com/TheAlgorithms\">The Algorithms</a></p></li><li><p><a href=\"https://twitter.com/AdiatiAyu\">Ayu</a></p></li><li><p><a href=\"https://twitter.com/TechIsHiring\">Tech is Hiring</a></p></li><li><p><a href=\"https://github.com/Virtual-Coffee/virtualcoffee.io/blob/main/CONTRIBUTING.md\">Virtual Coffee Contributors Guide</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0605-chad-episode.jpg",
+    "guests": [
+      {
+        "name": "Chad Stewart",
+        "bio": "<p>Software Engineer from Kingston, Jamaica. Founder of <a href=\"https://www.getrevue.co/profile/techishiring\">TechIsHiring</a>.</p><ul><li><p><a href=\"https://twitter.com/Chad_R_Stewart\">@Chad_R_Stewart on Twitter</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0605-chad.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Julia Seidman - Embracing the Careen Over the Career",
+    "slug": "julia-seidman-embracing-the-careen-over-the-career",
+    "id": "1049",
+    "metaDescription": "Season Six, Episode Six, of the Virtual Coffee Podcast",
+    "season": 6,
+    "episode": 6,
+    "buzzsproutId": "11351419",
+    "publishDate": "2022-09-20T04:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Julia about learning how to learn as a Technical Writer, the importance of teaching as a tool for learning, and her approach to writing about new technologies.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Julia Seidman, a technical marketing consultant and developer in the Seattle area, and talked about her work writing about different technologies, learning by teaching, and embracing the careen over the career. She talks about her career journey from studying anthropology to financial analysis to teaching high school English, ESL and Debate, before landing her current role as a technical writer.</p><h3>Links</h3><ul><li><p><a href=\"https://en.wikipedia.org/wiki/Krugerrand\">Krugerrand</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Doubloon\">Gold Doubloons</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Rhodium\">Rhodium</a></p></li><li><p><a href=\"https://flutter.dev/\">Flutter</a></p></li><li><p><a href=\"https://www.amazon.com/Developer-Marketing-Does-Not-Exist-ebook/dp/B091NK954H\">Developer Marketing Does Not Exist</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0606-julia-episode.jpg",
+    "guests": [
+      {
+        "name": "Julia Seidman",
+        "bio": "<p>Julia Seidman is a technical marketing consultant and developer in the Seattle area. She has 2 terrific kids and a wonderful partner, and her family cos-plays as a “normal” family.</p><p class=\"text-left\">Julia is a believer in the careen, rather than the career.</p><p class=\"text-left\">After studying anthropology and writing a senior thesis on the ethics of museum collections of human skeletal remains, she took the job she could get, which was fundraising for a hospital.</p><p class=\"text-left\">From there, she became a financial analyst and employee educator for 401(k) and pension plans. After that, she got a Master’s in Teaching, and taught high school English, ESL and Debate for most of a decade.</p><p class=\"text-left\">Now, she works as a freelance technical writer and software developer, specializing in technical content marketing.</p><p class=\"text-left\">Along the way, she has learned a lot about a lot of things, including the Python ecosystem.</p>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0606-juila.JPG"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Ryan Kahn - Building Better Teams",
+    "slug": "ryan-kahn-building-better-teams",
+    "id": "1091",
+    "metaDescription": "Season 6, Episode 7 of the Virtual Coffee Podcast",
+    "season": 6,
+    "episode": 7,
+    "buzzsproutId": "11407929",
+    "publishDate": "2022-09-29T04:00:00+00:00",
+    "shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk with Ryan Kahn about building better teams to deliver quality software by practicing empathy and knowledge sharing.</p>",
+    "showNotes": "<p>In today's episode, Bekah and Dan talk to Ryan Kahn, a developer experience and productivity consultant from New York City, about his work as a consultant helping companies to build better software teams. He emphasizes the importance of recognizing that teams are made up of individuals who have different needs and approaches. He also breaks down the difference between quality, technical, knowledge, and innovation debt and the need to identify which most impacts teams as they seek better communication to build a stronger team.</p><h3>Links:</h3><ul><li><p><a href=\"http://adr.github.io\">ADR GitHub organization</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Oblique_Strategies\">Oblique Strategies</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0607-ryan-episode.jpg",
+    "guests": [
+      {
+        "name": "Ryan Kahn",
+        "bio": "<p>Ryan loves solving the human and technical problems of software development, and works on both as a developer experience and productivity consultant. He lives in New York City with his partner, daughter, and dog. Outside of his work he loves Astronomy and Amateur Radio.</p>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0607-ryan.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Shelley McHardy: Junior Dev life",
+    "slug": "shelley-mchardy-junior-dev-life",
+    "id": "1101",
+    "metaDescription": "Season Six, Episode Eight of the Virtual Coffee Podcast",
+    "season": 6,
+    "episode": 8,
+    "buzzsproutId": "11445606",
+    "publishDate": "2022-10-05T04:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Shelley McHardy about navigating a career transition and the challenges of interviewing for your first developer role.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Shelley McHardy, a former chemistry teacher turned front end developer at <a href=\"https://www.rightpoint.com/\">Rightpoint</a>, and talked about the early career developer's journey. She gave insight into what her seven-month interview process looked like, forcing interviewers to interview you, the importance of finding \"your people\", and being picky in your job search.</p><h3>Links:</h3><ul><li><p><a href=\"https://www.edx.org/\">edX</a></p></li><li><p><a href=\"https://the-collab-lab.codes/\">Collab Lab</a></p></li><li><p><a href=\"https://www.studentachievementsolutions.com/what-are-professional-learning-communities-plcs/\">PLCs- Professional learning communities</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0608-shelley-episode.jpg",
+    "guests": [
+      {
+        "name": "Shelley McHardy",
+        "bio": "<p>Shelley is a former chemistry teacher turned front end developer at Rightpoint. A native San Franciscan, she is currently doing her best to stay cool in Atlanta, Georgia. When not crocheting, she and her wife love hiking the Georgia State Parks, geocaching, cooking, baking, and video games.</p><ul><li><p>GitHub: <a href=\"https://github.com/shelleymcq\">@shelleymcq</a></p></li><li><p>Twitter <a href=\"https://twitter.com/shelleymcqDev\">@shelleymcqDev</a></p></li><li><p>LinkedIn <a href=\"https://www.linkedin.com/in/shelleymchardy/\">shelleymchardy</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0608-shelley.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Season Six Finale - Talking Hacktoberfest with Bekah, Dan, and Kirk",
+    "slug": "season-six-finale-talking-hacktoberfest-with-bekah-dan-and-kirk",
+    "id": "1132",
+    "metaDescription": "Season Six, Episode Nine of the Virtual Coffee Podcast",
+    "season": 6,
+    "episode": 9,
+    "buzzsproutId": "11496083",
+    "publishDate": "2022-10-13T04:00:00+00:00",
+    "shortDescription": "<p>It’s the final episode of season six of the podcast and we’re bringing it to you live with Bekah, Dan, and Kirk!</p>",
+    "showNotes": "<p>It’s the final episode of season six of the podcast and we’re bringing it to you live with Bekah, Dan, and Kirk! We talked a lot about Hacktoberfest with many side-tracks and segues in between.</p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0609-finale.jpg",
+    "guests": [],
+    "sponsors": []
+  },
+  {
+    "title": "Jörn Bernhardt - Becoming a Founder",
+    "slug": "jörn-bernhardt-becoming-a-founder",
+    "id": "1626",
+    "metaDescription": "Season Seven, Episode One of the Virtual Coffee Podcast",
+    "season": 7,
+    "episode": 1,
+    "buzzsproutId": "12164997",
+    "publishDate": "2023-02-02T05:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Jörn Bernhardt about his journey as a 2x founder and his lifelong interest in technology.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Jörn Bernhardt, a 2x founder in Germany, about his career path, the challenges of being a founder, and the key traits that have led to his success.</p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Jörn.png",
+    "guests": [
+      {
+        "name": "Jörn Bernhardt",
+        "bio": "<p>Jörn started developing web-based software in the last century when he was still in school. In 2018, he founded his second company <a href=\"http://compose.us\">compose.us</a> where they implement digital solutions and share their knowledge with public administrations. In his spare time Jörn organizes local meetups in Germany and creates at least one open source commit per day to push his side projects.</p><ul><li><p><a href=\"https://compose.us/\">compose.us</a></p></li><li><p><a href=\"https://github.com/Narigo\">Jörn on GitHub</a></p></li><li><p><a href=\"NarigoDF\">Jörn on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/j%C3%B6rn-bernhardt-a04225104/\">Jörn on LinkedIn</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/joern.png"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Joe Karow - Career Transitions and the ADHD Experience",
+    "slug": "joe-karow-career-transitions-and-the-adhd-experience",
+    "id": "1655",
+    "metaDescription": "Season Seven, Episode Two of the Virtual Coffee Podcast",
+    "season": 7,
+    "episode": 2,
+    "buzzsproutId": "12213630",
+    "publishDate": "2023-02-09T05:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Joe Karow about his journey as into tech with 100devs and about his ADHD journey.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Joe Karow, the Lead Engineer at a nonprofit, about his career change from the hospitality industry, his experience with the online bootcamp, 100devs, and about the ADHD experience.</p><h3>Links</h3><ul><li><p><a href=\"https://jobs.all-hands.us/jobs\">All Hands Job Board</a></p></li><li><p><a href=\"https://leonnoel.com/100devs/\">100devs</a></p></li><li><p><a href=\"https://www.resilientcoders.org/\">Resilient Coders</a></p></li><li><p><a href=\"https://twitter.com/leonnoel\">Leon Noel</a></p></li><li><p><a href=\"https://www.cedarpoint.com/\">Cedar Point</a></p></li><li><p><a href=\"https://buschgardens.com/\">Busch Gardens</a></p></li><li><p><a href=\"https://www.kennywood.com/\">Kennywood</a></p></li><li><p><a href=\"https://cssbattle.dev/\">cssbattle.dev</a></p></li><li><p><a href=\"https://remo.co/\">remo</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0702-joe-episode.jpg",
+    "guests": [
+      {
+        "name": "Joe Karow",
+        "bio": "<p>Joe is the Lead Engineer at InReach, a 501(c)3 registered non-profit building world’s first tech platform matching LGBTQ+ people facing discrimination and persecution with safe, verified resources. Formerly a Director of Finance for a large hotel chain, he made the leap in to tech in 2022. Tech was always a part of Joe's life, it just took a global pandemic for him to decide to start getting paid for it.</p><ul><li><p><a href=\"https://joekarow.dev\"><u>joekarow.dev</u></a></p></li><li><p><a href=\"https://github.com/JoeKarow\">@JoeKarow</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/JoeKarow\">@JoeKarow</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/jkarow/\">@jkarow</a> on LinkedIn</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0702-joe.jpeg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Kai Katschthaler - Technical Writing &  Neurodiverse Learning",
+    "slug": "kai-katschthaler-technical-writing-neurodiverse-learning",
+    "id": "1680",
+    "metaDescription": "Season Seven, Episode Three of the Virtual Coffee Podcast",
+    "season": 7,
+    "episode": 3,
+    "buzzsproutId": "12263721",
+    "publishDate": "2023-02-16T05:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Kai Katschthaler about their experience growing their technical writing career and creating content.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Kai Katschthaler, a technical writer and content creator, about their creation process, finding learning approaches that work for them, and mentoring others.</p><h3>Links:</h3><ul><li><p><a href=\"https://www.spreaker.com/user/15541131/kai-ep-final\">Kai's appearance on the Coming Out Pod</a></p></li><li><p><a href=\"https://bau.edu/blog/kinesthetic-learner/\">Kinesthetic Learning</a></p></li><li><p><a href=\"https://www.freecodecamp.org/\">Freecodecamp</a></p></li><li><p><a href=\"https://www.codecademy.com/\">Codecademy</a></p></li><li><p><a href=\"https://learn.co/\">Flatironschool</a></p></li><li><p><a href=\"https://exercism.org/\">Exercism</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0703-kai-episode.jpg",
+    "guests": [
+      {
+        "name": "Kai Katschthaler",
+        "bio": "<p>Kai is a tech content specialist and mental health advocate. They run Taboola Rasa, a mental health awareness project that seeks to erase the stigma connected to mental health.</p><ul><li><p><a href=\"https://linktr.ee/thegrumpyenby\">linktr.ee/thegrumpyenby</a></p></li><li><p><a href=\"https://github.com/thegrumpyenby\">@thegrumpyenby</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/thegrumpyenby\">@thegrumpyenby</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/kaikatschthaler/\">@kaikatschthaler</a> on LinkedIn</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0703-kai.jpeg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Aishwarya Mali - A Journey into Open Source",
+    "slug": "aishwarya-mali-a-journey-into-open-source",
+    "id": "1695",
+    "metaDescription": "Season Seven, Episode Four of the Virtual Coffee Podcast",
+    "season": 7,
+    "episode": 4,
+    "buzzsproutId": "12315603",
+    "publishDate": "2023-02-23T05:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Aishwarya about her journey as a first time contributer during the 2022 Hacktoberfest.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Aishwarya, front-end developer from India, about her first open source contributions and how her perspective on open source changed after her fourth (of ten!) Pull Request during Hacktoberfest.</p><ul><li><p>One word to describe you - <strong>Dedicated</strong></p></li><li><p>One word to describe your developer journey - <strong>Evolving</strong></p></li><li><p><a href=\"https://www.amazon.com/Me-Before-You-Novel-Tie/dp/0143130153\"><em><u>Me Before You</u></em><u> by Jojo Moyes</u></a></p></li><li><p>Open-Source YouTube Videos:</p><ul><li><p><a href=\"https://www.youtube.com/watch?v=yfopPq4354o\">How to Find Beginner-Friendly Open Source Projects</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=_uetV0wZyXM\">4 Beginner Friendly Open Source Projects to Contribute before 2023</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=lnLiD0GfCRE\">5 Beginner friendly Open Source Organisations to start your Open source journey</a></p></li></ul></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0704-aishwara-episode.jpg",
+    "guests": [
+      {
+        "name": "Aishwarya Mali",
+        "bio": "<p>Aishwarya Mali is a front-end developer (React+XState+Redux) based in Pune, India. She loves to read!</p><ul><li><p><a href=\"https://github.com/aishwarya-mali\">@aishwarya-mali</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/aishwaryamali24\">@aishwaryamali24</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/aishwaryamali24/\">@aishwaryamali24</a> on LinkedIn</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0704-aishwara.jpeg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Rebecca Key - From PhD to Frontend",
+    "slug": "rebecca-key-from-phd-to-frontend",
+    "id": "1711",
+    "metaDescription": "Season Seven, Episode Five of the Virtual Coffee Podcast",
+    "season": 7,
+    "episode": 5,
+    "buzzsproutId": "12363084",
+    "publishDate": "2023-03-02T05:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Rebecca Key about her journey from a career in chemistry to Software Engineer and the hobbies that she finds exciting.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Rebecca Key, a PhD in Organic Chemistry and now Software Engineer, and chatted about her career journey, Ham radios, being left-handed, taking notes, and the importance of consistency.</p><h3>Links:</h3><ul><li><p><a href=\"https://en.wikipedia.org/wiki/Brassica_oleracea\">Brassica oleracea</a> (the plant Dan was talking about)</p></li><li><p><a href=\"https://www.sota-at.com/\">SOTA-AT</a>: An interactive map that displays and provides information for peaks along the GA section of the Appalachian Trail that count toward activations for “Summits on the Air”, a ham radio contest.</p></li><li><p><a href=\"https://github.com/rek990/crochet-counter\">Row Counter</a>: A tool to help fiber artists (crocheters, knitters, rug makers, basket weavers, etc.) keep track of the row they are on with a given project. <a href=\"https://dev.to/rek990/virtual-coffees-july-monthly-challenge-live-demo-of-the-progress-toward-my-row-counter-app-3jd7\">Live Demo of the Progress Toward my Row Counter App</a></p></li><li><p>Rebecca's RF Quests: <a href=\"https://www.rfquests.com/\">Blog</a> and <a href=\"https://www.youtube.com/channel/UC5Rtn09KIdwsySkf7B-DPsw\">YouTube Channel</a></p></li><li><p><a href=\"https://parksontheair.com/\">Parks on the Air (POTA)</a></p></li><li><p><a href=\"https://www.sota.org.uk/\">Summits on the Air (SOTA)</a></p></li><li><p><a href=\"https://www.sota.org.uk/Joining-In/Awards\">SOTA Mountain goat award</a></p></li><li><p><a href=\"https://orgmode.org/\">Emacs Org Mode</a></p></li></ul><h4>Left-handed Deep Dive</h4><ul><li><p><a href=\"https://kids.frontiersin.org/articles/10.3389/frym.2014.00013\">Your Left-Handed Brain</a></p></li><li><p><a href=\"https://www.bbc.com/news/health-49579810\">Left-handed DNA found - and it changes brain structure</a></p></li><li><p><a href=\"https://pubmed.ncbi.nlm.nih.gov/1839378/#:~:text=Left%2Dhandedness%20occurs%20in%20about,monozygotic%20twins%20show%20substantial%20discordance\">The inheritance of left-handedness</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0705-rebecca-episode.png",
+    "guests": [
+      {
+        "name": "Rebecca Key",
+        "bio": "<p>Rebecca Key is a Software Engineer based out of Atlanta, GA. She is a first-generation college graduate that went on to obtain a PhD in Organic Chemistry from Georgia Tech. After many years in research (roles ranging from Laboratory Technician to Research Director), she made a career change into the tech field, where she currently works as an Independent Front-End Engineer. When not coding, she enjoys mountain biking, running, weightlifting, crocheting, and knitting!</p><ul><li><p><a href=\"http://rebeccakeyphd.com/\">rebeccakeyphd.com</a></p></li><li><p><a href=\"https://github.com/rek990\">@rek990</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/rebeccakeyphd\">@rebeccakeyphd</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/rebecca-key/\">@rebecca-key</a> on LinkedIn</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0705-rebecca.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Arthur Doler - The Human Side of Tech",
+    "slug": "arthur-doler-the-human-side-of-tech",
+    "id": "1727",
+    "metaDescription": "Season Seven, Episode Six of the Virtual Coffee Podcast",
+    "season": 7,
+    "episode": 6,
+    "buzzsproutId": "12407750",
+    "publishDate": "2023-03-09T05:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Arthur Doler about team dynamics, motivation, and how to identify problematic situations.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Arthur Doler, a Software Engineer and Community and Culture Steward, and chatted about the human side of tech, the importance of recognizing our emotions, communication styles, and the dynamics of the environments we're working in.</p><h3>Links:</h3><ul><li><p><a href=\"https://www.danpink.com/books/drive/\">Daniel Pink's Drive</a></p></li><li><p><a href=\"https://youtu.be/-XYK8ulQId0\">Arthur's talk: You're Not Just Tired: The Psychology of Burnout</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Aikido\">Aikido</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/List_of_disc_golf_players\">Pro Disc Golfers</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0706-arthur-episode.jpg",
+    "guests": [
+      {
+        "name": "Arthur Doler",
+        "bio": "<p>Arthur (or Art, take your pick) has been a software engineer for 19 years and has worked on things as exciting as analysis software for casinos and things as boring as banking websites. He is an advocate for talking openly about mental health and psychology in the technical world, and he spends a lot of time thinking about <em>how</em> we program and <em>why</em> we program, and about the tools, structures, cultures, and mental processes that help and hinder us from our ultimate goal of writing amazing things. His hair is brown and his thorax is a shiny blue color.</p><ul><li><p><a href=\"https://arthurdoler.com\">arthurdoler.com</a></p></li><li><p><a href=\"https://github.com/doleraj\">@doleraj</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/arthurdoler\">@arthurdoler</a> on Twitter</p></li><li><p><a href=\"https://mastodon.sandwich.net/@arthurdoler\">@arthurdoler</a> on Mastodon</p></li><li><p><a href=\"https://www.linkedin.com/in/arthurdoler/\">@arthurdoler</a> on LinkedIn</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0706-arthur.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Dominic Duffin - Finding value in challenging ourselves",
+    "slug": "dominic-duffin-finding-value-in-challenging-ourselves",
+    "id": "1740",
+    "metaDescription": "Season Seven, Episode Seven of the Virtual Coffee Podcast",
+    "season": 7,
+    "episode": 7,
+    "buzzsproutId": "12453805",
+    "publishDate": "2023-03-16T04:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Dominic Duffin about the impact of non-traditional learning experiences and the importance of community collaboration.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Dominic Duffin, a Full-Stack Developer, Co-founder of ArtTechChat Twitter chat, Salon Host at The Interintellect, and Open Source contributor, and chatted about the the value gained in creating a learning environment wherever you go and the importance of participating in community experiences.</p><ul><li><p>Pass the Pen: <a href=\"https://codepen.io/collection/nZrZLy\">https://codepen.io/collection/nZrZLy</a></p></li><li><p><a href=\"@ArtTechChat on Twitter\"><u>https://twitter.com/arttechchat</u></a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0707-dominic-episode.jpg",
+    "guests": [
+      {
+        "name": "Dominic Duffin",
+        "bio": "<p>Full Stack Developer, community builder, remote worker and aspiring polymath. Passionate about open source everything, decentralization, peer-to-peer tech and cryptocurrency. Also to be found playing board games, studying paper maps and riding public transport.</p><ul><li><p><a href=\"https://dominicduffin.uk\">dominicduffin.uk</a></p></li><li><p><a href=\"https://github.com/dominicduffin1\">@dominicduffin1</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/DominicDuffin1\">@DominicDuffin1</a> on Twitter</p></li><li><p><a href=\"https://toot.cafe/@dominicduffin1\">@dominicduffin1</a> on Mastadon</p></li><li><p><a href=\"https://www.linkedin.com/in/dominic-duffin-a992b0225\">@dominic-duffin</a> on LinkedIn</p></li><li><p><a href=\"https://www.polywork.com/dominic\">@dominic</a> on Polywork</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0707-dominic.png"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Ramón Huidobro - Thoughtful Learning",
+    "slug": "ramón-huidobro-thoughtful-learning",
+    "id": "1756",
+    "metaDescription": "Season Seven, Episode Eight of the Virtual Coffee Podcast",
+    "season": 7,
+    "episode": 8,
+    "buzzsproutId": "12503114",
+    "publishDate": "2023-03-23T04:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Ramón Huidobro about asking good questions about your code and how to ask for help.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Ramón Huidobro, a developer advocate and DevEd enthusiast, and chatted about the process of learning and growing and how asking questions and knowing what questions to ask is an important part of the tech experience.</p><p>Check out Ramón's article <a href=\"https://ramonh.dev/2022/11/13/asking-for-help/\">about reaching out for help</a>!</p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0708-ramon-episode.jpg",
+    "guests": [
+      {
+        "name": "Ramón Huidobro",
+        "bio": "<p>Ramón Huidobro is a developer advocate and DevEd enthusiast. He thrives on lifting others up in their tech careers and loves a good CSS challenge. Always excited to talk about teaching tech, especialmente en Español, oder auf Deutsch.</p><ul><li><p><a href=\"https://https://ramonh.dev\">ramonh.dev</a></p></li><li><p><a href=\"https://github.com/hola-soy-milk\">@hola-soy-milk</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/hola_soy_milk\">@hola_soy_milk</a> on Twitter</p></li><li><p><a href=\"https://hachyderm.io/@hola_soy_milk\">@hola_soy_milk</a> on Mastadon</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0708-ramon.jpg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Season Seven Finale - Live with Nick Taylor",
+    "slug": "season-seven-finale-live-with-nick-taylor",
+    "id": "1772",
+    "metaDescription": "Season Seven, Episode Nine of the Virtual Coffee Podcast",
+    "season": 7,
+    "episode": 9,
+    "buzzsproutId": "12558497",
+    "publishDate": "2023-03-31T04:00:00+00:00",
+    "shortDescription": "<p>Join Bekah, Dan, and Special Guest Nick Taylor for a live-streamed episode of the Season Seven Finale!</p>",
+    "showNotes": "<p>Join Bekah, Dan, and Special Guest Nick Taylor for a live-streamed episode of the Season Seven Finale!</p><p>Watch the video replay here: <a href=\"https://www.youtube.com/watch?v=0Wj-zlORvm8\">https://www.youtube.com/watch?v=0Wj-zlORvm8</a></p><p>Watch our 2023 Spring Lightning Talks here: <a href=\"https://www.youtube.com/watch?v=O2CsTN-WEZ0\">https://www.youtube.com/watch?v=O2CsTN-WEZ0</a></p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0709-finale.png",
+    "guests": [],
+    "sponsors": []
+  },
+  {
+    "title": "VC Maintainers - Importance of Culture Citizenship",
+    "slug": "vc-maintainers-importance-of-culture-citizenship",
+    "id": "1796",
+    "metaDescription": "Season Eight, Episode One of the Virtual Coffee Podcast",
+    "season": 8,
+    "episode": 1,
+    "buzzsproutId": "12988617",
+    "publishDate": "2023-06-07T04:00:00+00:00",
+    "shortDescription": "<p><span>We're starting the new season with a conversation with our maintainers, including our new maintainer, Julia Seidman! We share our thought process for adding a maintainer and walk through our culture citizenship statement to share how we intend to create a positive community.</span></p>",
+    "showNotes": "<p><span>Starting off this new season, we're bringing in all of our maintainers, Bekah Hawrot Weigel, Dan Ott, Kirk Shillingford, and Julia Seidman. We walk through the importance of understanding communities, members, and how to create a positive community experience.</span></p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0801-Cover.jpeg",
+    "guests": [
+      {
+        "name": "Julia Seidman",
+        "bio": "<p><span>Julia Seidman is a developer education consultant based in the Seattle area. Julia is a believer in embracing the 'careen' over the career. </span></p>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Julia-Headshot.jpeg"
+      },
+      {
+        "name": "Kirk Shillingford",
+        "bio": "<p><span>A full stack developer in the Caribbean interested in Functional Programming, Domain Driven Development, and Security.</span></p>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Kirk-Headshot.jpeg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Alex Curtis-Slep - Enriching Your Life as a Developer",
+    "slug": "alex-curtis-slep-enriching-your-life-as-a-developer",
+    "id": "1827",
+    "metaDescription": "Season Eight, Episode Two of the Virtual Coffee Podcast",
+    "season": 8,
+    "episode": 2,
+    "buzzsproutId": "13038514",
+    "publishDate": "2023-06-15T04:00:00+00:00",
+    "shortDescription": "<p><span>In today's episode, Dan and Bekah talk to Alex about his gratifying journey as a self-taught developer and tools you can use to maintain a positive attitude, create balance, decrease stress, and form good habits to enrich your life.</span></p>",
+    "showNotes": "<p><span>This week Bekah and Dan sat down with Alex Curtis-Slep, long time member and volunteer and self-taught developer, about documenting the small wins, falling in love with the process, and aligning your goals to maintain a healthy life while job searching and during your tech career.</span></p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe.png",
+    "guests": [
+      {
+        "name": "Alex Curtis-Slep",
+        "bio": "<p>Alex Curtis-Slep is a self taught software developer. After getting his initial tastes of HTML and CSS in the early 2000’s on his basketball blog, Alex jumped into coding in early 2019. He heard about a course Madison Kanna created on roadmapping to become a developer and took the plunge. Following a few years of learning, creating, contributing to open source, and much more, Alex landed his first job in tech at Paypixl. When he’s not coding and hyping up his developer friends, he loves everything basketball, tropical fruit, vegan, travel, family, friend, and foreign language related!</p><ul><li><p><a href=\"http://alexcurtisslep.com\">alexcurtisslep.com</a></p></li><li><p><a href=\"https://github.com/AlexVCS\" rel=\"noopener noreferrer\" target=\"_blank\">@AlexVCS</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/AlexCurtisSlep\" rel=\"noopener noreferrer\" target=\"_blank\">@AlexCurtisSlep</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/alexcurtisslep/\" rel=\"noopener noreferrer\" target=\"_blank\">@alexcurtisslep</a> on LinkedIn</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Alex-Curtis.jpeg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Carmen - Tech Industry Friendships: Leveraging Connections for Growth, Challenges, and Opportunities and DevOps!",
+    "slug": "carmen-tech-industry-friendships-leveraging-connections-for-growth-challenges-and-opportunities-and-devops",
+    "id": "1841",
+    "metaDescription": "Season Eight, Episode Three of the Virtual Coffee Podcast",
+    "season": 8,
+    "episode": 3,
+    "buzzsproutId": "13047459",
+    "publishDate": "2023-06-21T04:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Carmen about the impactful role of friendships in the tech industry. We talked about how these connections positively influenced her professional journeys, helped her overcome challenges, and contributed to career growth in DevOps.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Carmen Kohole, a DevOps Engineer based in Portland, Oregon, to chat about the benefits of collaboration and the valuable opportunities you can gain just by asking for help. We also discussed the benefits of fostering strong relationships in the tech industry, and what it means to be a DevOps engineer.</p><h3>Links:</h3><ul><li><p><a href=\"https://twitter.com/thejonanshow\">Jonan Scheffler</a></p></li><li><p><a href=\"https://twitter.com/nickytonline\">Nick Taylor</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0803-Carmen.png",
+    "guests": [
+      {
+        "name": "Carmen",
+        "bio": "<p>DevOps Engineer based in Portland, Oregon. Big fan of house plants, hiking, hats and cats. Here to help build stuff, break stuff, learn stuff and make friends.</p><ul><li><p><a href=\"https://github.com/carmenkolohe\" rel=\"noopener noreferrer\" target=\"_blank\">@carmenkolohe</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/carmenkolohe\" rel=\"noopener noreferrer\" target=\"_blank\">@carmenkolohe</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/carmenkolohe/\" rel=\"noopener noreferrer\" target=\"_blank\">@carmenkolohe</a> on LinkedIn</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Carmen.jpeg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Caitlin Floyd - Mentorship",
+    "slug": "caitlin-floyd",
+    "id": "1855",
+    "metaDescription": "Season Eight, Episode Four of the Virtual Coffee Podcast",
+    "season": 8,
+    "episode": 4,
+    "buzzsproutId": "13121425",
+    "publishDate": "2023-06-28T04:00:00+00:00",
+    "shortDescription": "<p>In today's episode, Dan and Bekah talk to Caitlin about expanding the definition of tech mentorship. We challenge the traditional one-on-one approach and delve into group and community mentorship, where learning, growth, and curiosity thrive collectively. We discuss how active and empathetic listening fosters understanding and knowledge exchange.</p>",
+    "showNotes": "<p>This week Bekah and Dan sat down with Caitlin Floyd, a front-end developer, to chat about the concept of collective learning and explore new possibilities in the evolving landscape of tech mentorship. Discover firsthand how Caitlin's experiences highlight the power of collaboration, breaking down silos, and leveraging collective knowledge to drive innovation and success.</p><h3>Links:</h3><ul><li><p><a href=\"https://the-collab-lab.codes/\">Collab Lab</a></p></li><li><p><a href=\"https://dev.to/the-collab-lab/tcl-22-recap-211m/\">Recap of a Collab Lab cohort that Caitlin participated in</a></p></li><li><p><a href=\"https://leaddev.com/mentoring-coaching-feedback/mentor-coach-sponsor-guide-developing-engineers\">Mentor, coach, sponsor: a guide to developing engineers</a> by Neha Batra</p></li><li><p><a href=\"https://kwugirl.blogspot.com/2020/10/secrets-of-stealth-mentee.html?m=1\">Secrets of a Stealth Mentee</a> by KWu</p></li><li><p><a href=\"https://larahogan.me/sponsors/\">Mentorship and Sponsorship</a> by Lara Hogan</p></li><li><p><a href=\"https://cate.blog/2017/03/21/sponsorship-can-start-small/\">Sponsorship Can Start Small</a> by Cate</p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe_2023-06-28-031129_uyfo.png",
+    "guests": [
+      {
+        "name": "Caitlin Floyd",
+        "bio": "<p>Caitlin is a front-end developer driven by the power of technology as a force for good. Before entering tech, she worked in linguistics, education, and nonprofit management. When not coding, she loves reading, studying languages, traveling, and most of all doting on her puppy.</p><ul><li><p><a href=\"https://caitlinfoyd.com\">caitlinfoyd.com</a></p></li><li><p><a href=\"https://github.com/cafloyd\" rel=\"noopener noreferrer\" target=\"_blank\">@cafloyd</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/caitlinfloyd\" rel=\"noopener noreferrer\" target=\"_blank\">@caitlinfloyd</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/caitlinfloyd/\" rel=\"noopener noreferrer\" target=\"_blank\">@caitlinfloyd</a> on LinkedIn</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Caitlin.jpeg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Reda - From Maritime Engineer to Self-Taught Front-End Developer",
+    "slug": "reda-from-maritime-engineer-to-self-taught-front-end-developer",
+    "id": "1880",
+    "metaDescription": "Season Eight, Episode Five of the Virtual Coffee Podcast",
+    "season": 8,
+    "episode": 5,
+    "buzzsproutId": "13204285",
+    "publishDate": "2023-07-12T04:00:00+00:00",
+    "shortDescription": "<p>Join hosts Bekah and Dan in this inspiring episode as they talk through the captivating journey of Reda, a self-taught developer. Discover the challenges and triumphs of the world of programming solo, and gain valuable insights on the optimal timing for job applications—because as Reda shares the advice he was given, \"When should you start applying for jobs? Yesterday.\"</p>",
+    "showNotes": "<p><span>Join Bekah and Dan in this week's episode, where they dive into the transformative journey of Reda, a self-taught developer. Hear about the unique challenges and victories Reda faced as he navigated the journey to becoming a front-end developer. Gain valuable advice on the ideal timing for job applications, as Reda shares advice he heard along his journey: \"When should you start applying for jobs? Yesterday.\" Tune in for an enriching conversation that will inspire aspiring self-taught developers and offer practical insights for your career paths.</span></p><h3>Links: </h3><ul><li><p><a href=\"https://www.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Free Code Camp</a></p></li><li><p><a href=\"https://the-collab-lab.codes/\" rel=\"noopener noreferrer\" target=\"_blank\">Collab Lab</a></p></li><li><p><a href=\"https://www.coursera.org/specializations/python\" rel=\"noopener noreferrer\" target=\"_blank\">Python Course</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe_2023-07-11-193524_yhob.png",
+    "guests": [
+      {
+        "name": "Reda",
+        "bio": "<p>I'm a self-taught front-end developer based in Morocco, with a background in Marine Mechanics.</p><ul><li><p><a href=\"https://github.com/redapy\" rel=\"noopener noreferrer\" target=\"_blank\">redapy</a> on GitHub</p></li><li><p><a href=\"https://www.google.com/url?sa=t&amp;rct=j&amp;q=&amp;esrc=s&amp;source=web&amp;cd=&amp;cad=rja&amp;uact=8&amp;ved=2ahUKEwjSsLzRsYeAAxVBmGoFHUEQDNUQFnoECBAQAQ&amp;url=https%3A%2F%2Ftwitter.com%2Fredabaha12&amp;usg=AOvVaw2LtVxW6oDxwQ_Aq1KKL3ik&amp;opi=89978449\" rel=\"noopener noreferrer\" target=\"_blank\">redabaha12</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/redabaha/\" rel=\"noopener noreferrer\" target=\"_blank\">redabaha</a> on LinkedIn</p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Reda.jpeg"
+      }
+    ],
+    "sponsors": []
+  },
+  {
+    "title": "Josh - The Life of a Full Time Open Source Developer",
+    "slug": "josh-the-life-of-a-full-time-open-source-developer",
+    "id": "1895",
+    "metaDescription": "Season Eight, Episode Six of the Virtual Coffee Podcast",
+    "season": 8,
+    "episode": 6,
+    "buzzsproutId": "13247190",
+    "publishDate": "2023-07-19T04:00:00+00:00",
+    "shortDescription": "<p>In this episode, Dan and Bekah explore the fascinating journey of being a full-time open source contributor with Josh Goldberg. We discuss the challenges and rewards of dedicating yourself to the open source ecosystem, TypeScript's growing popularity, and how Josh supports the tech community.</p>",
+    "showNotes": "<p>Join Bekah and Dan in this week's episode, where they talk with Josh Goldberg, an independent full time open source developer working on projects in the TypeScript ecosystem, where he shares valuable tips and insights on how you can get started with contributing to open source, whether you're a seasoned developer or just dipping your toes into OSS. Josh also shares the story of his prolific speaking journey over the last couple of years and how staying involved in the tech community has been a rewarding experience.</p><p><strong>Links:</strong></p><ul><li><p><a href=\"https://typescript-eslint.io/\" rel=\"noopener noreferrer\" target=\"_blank\">typescript-eslint</a></p></li><li><p><a href=\"https://github.com/typescript-eslint/typescript-eslint\" rel=\"noopener noreferrer\" target=\"_blank\">typescript-eslint GitHub</a></p></li><li><p><a href=\"https://www.codecademy.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Code Academy</a></p></li><li><p><a href=\"https://sway.office.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Microsoft Sway</a> </p></li><li><p>Josh's Blog posts about applying to conferences:</p><ul><li><p><a href=\"https://blog.joshuakgoldberg.com/how-i-apply-to-conferences/\" rel=\"noopener noreferrer\" target=\"_blank\">How I Apply to Conferences</a></p></li><li><p><a href=\"https://blog.joshuakgoldberg.com/how-i-apply-to-conferences-faqs/\" rel=\"noopener noreferrer\" target=\"_blank\">How I Apply to Conferences: FAQs</a></p></li></ul></li><li><p>Josh's Book: <a href=\"https://www.learningtypescript.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Learning Typescript</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe_2023-07-19-033240_jrwt.png",
+    "guests": [
+      {
+        "name": "Josh Golberg",
+        "bio": "<p>Hi, I’m Josh! I’m an independent full time open source developer. I work on projects in the TypeScript ecosystem, most notably typescript-eslint: the tooling that enables ESLint and Prettier to run on TypeScript code. I’m also the author of the O’Reilly Learning TypeScript book, a Microsoft MVP for developer technologies, and an active conference speaker.</p>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Josh.jpeg"
+      }
+    ],
+    "sponsors": [
+      {
+        "title": "LevelUP Financial planning",
+        "url": "https://www.levelupfinancialplanning.com/?vc",
+        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+        "logoWidth": 679,
+        "logoHeight": 525,
+        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+      }
+    ]
+  },
+  {
+    "title": "Taiwo Yusuf - The Importance of Having a Learning Mindset",
+    "slug": "taiwo-yusuf-the-importance-of-having-a-learning-mindset",
+    "id": "1910",
+    "metaDescription": "Season Eight, Episode Seven of the Virtual Coffee Podcast",
+    "season": 8,
+    "episode": 7,
+    "buzzsproutId": "13295814",
+    "publishDate": "2023-07-26T04:00:00+00:00",
+    "shortDescription": "<p>In this episode, Dan and Bekah chat with Taiwo, a backend developer from Nigeria. He shares his journey from Electrical Engineering Major to backend development, and the importance of staying motivated and always being hungry to learn and grow.</p>",
+    "showNotes": "<p>Join Bekah and Dan in this week's episode,  where they talk with Taiwo Yusuf, a back-end engineer with a passion for developing innovative solutions.  Despite being the top of his class in Electrical Engineering, he found his passion in backend development. He shares the importance of always learning, growing, and surrounding yourself with people who are more skilled than you are to find inspiration, support, and motivation.</p><p><strong>Links:</strong></p><ul><li><p><a href=\"https://www.grace.health/\" rel=\"noopener noreferrer\" target=\"_blank\">Grace Health</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe-1.png",
+    "guests": [
+      {
+        "name": "Taiwo Yusuf",
+        "bio": "<p>I'm Taiwo Yusuf, a back-end engineer with a passion for developing innovative solutions. I've been fortunate enough to work with amazing companies like Grace Health, LogicShift, and JufoPay. When I'm not busy coding, I'm an avid fan of generative art, and I adore cats. So, whether you want to talk about tech, art, or felines, let's connect and have a chat!</p>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/3bmcquEcQTRCESX5KIOTJO-AvdRCqPIKvQDtqprXWGY.png"
+      }
+    ],
+    "sponsors": [
+      {
+        "title": "LevelUP Financial planning",
+        "url": "https://www.levelupfinancialplanning.com/?vc",
+        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+        "logoWidth": 679,
+        "logoHeight": 525,
+        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+      }
+    ]
+  },
+  {
+    "title": "Rafi - Exploring Side Projects and AI",
+    "slug": "rafi-exploring-side-projects-and-ai",
+    "id": "1919",
+    "metaDescription": "Season Eight, Episode Eight of the Virtual Coffee Podcast",
+    "season": 8,
+    "episode": 8,
+    "buzzsproutId": "13331830",
+    "publishDate": "2023-08-02T04:00:00+00:00",
+    "shortDescription": "<p>Join Bekah and Dan in this week's episode,  where they talk with Rafi, a full-stack engineer who develops his passion and motivation with side projects.  Rafi highlights the importance of focusing on developing side projects using a time limit and completing tasks. Learn Rafi's approach to using AI as a tool in his toolbox to accelerate the development process.</p>",
+    "showNotes": "<p>Join hosts Bekah and Dan in this episode featuring Rafi, a talented full-stack developer from Bangalore. In this episode, you'll discover how building new things  and making progress helps him find calmness and focus. Learn Rafi's approach to side projects, including his exploration of Blender, mobile development, Chrome extensions, and Ionic framework. Rafi also shares valuable tips on leveraging AI to enhance learning during project work</p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe.png",
+    "guests": [
+      {
+        "name": "Rafi",
+        "bio": "<p>I am a developer, hobbyist who loves JavaScript, Star trek and Cats. I build things, talk tech and write things.</p>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Rafi.png"
+      }
+    ],
+    "sponsors": [
+      {
+        "title": "LevelUP Financial planning",
+        "url": "https://www.levelupfinancialplanning.com/?vc",
+        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+        "logoWidth": 679,
+        "logoHeight": 525,
+        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+      }
+    ]
+  },
+  {
+    "title": "Ayu & Dominic - Hacktoberfest is Coming, Preptember is Here!",
+    "slug": "ayu-dominic-hacktoberfest-is-coming-preptember-is-here",
+    "id": "1940",
+    "metaDescription": "Season 9, Episode 1 of the Virtual Coffee Podcast",
+    "season": 9,
+    "episode": 1,
+    "buzzsproutId": "13611744",
+    "publishDate": "2023-09-18T04:00:00+00:00",
+    "shortDescription": "<p><span>Join hosts Bekah and Dan in this episode featuring Dominic and Ayu as we explore Preptember—the month where we prepare for Hacktoberfest—and the importance of taking the month to prepare, learn more about open source projects, and evaluate open source repositories to recommend to contributors.</span></p>",
+    "showNotes": "<p>Join hosts Bekah and Dan in this episode with monthly challenge Preptember leads, Dominic and Ayu. We talk about the importance of preparing both as a contributor and a maintainer,  some of the challenges you might face as someone new to those roles during Hacktoberfest, and some of the benefits you'll receive by participating in open source.</p><h3>Links</h3><ul><li><p><a href=\"https://virtualcoffee.io/podcast/0303-ayu-adiati\">Ayu's Episode: Working through burnout as a self-taught developer</a></p></li><li><p><a class=\"postlist-title\" href=\"https://virtualcoffee.io/podcast/dominic-duffin-finding-value-in-challenging-ourselves\">Dominic's Episode: Finding value in challenging ourselves</a></p></li><li><p><a href=\"https://github.com/issues\">Your GitHub Issues</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0901-ayu-dominic.png",
+    "guests": [
+      {
+        "name": "Dominic Duffin",
+        "bio": "<p>Dominic is a Full Stack Developer, community builder, remote worker and aspiring polymath. He's passionate about open source everything, decentralization, peer-to-peer tech and cryptocurrency. He's also to be found playing board games, studying paper maps and riding public transport.</p>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0707-dominic.png"
+      },
+      {
+        "name": "Ayu Adiati",
+        "bio": "<p>Ayu is a self-taught front-end developer and technical blogger based in The Netherlands.</p><p class=\"text-left\">She has a strong interest in building projects that are accessible to everyone.</p><p class=\"text-left\">Her passion for life-long learning is what motivates her open-source contributions, project collaboration, and community engagement.</p><p class=\"text-left\">Learning new things is something that fills her with excitement and she's eager to share her learning in public and pass on her knowledge through her blog and Twitter.</p>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0303-ayu.jpg"
+      }
+    ],
+    "sponsors": [
+      {
+        "title": "LevelUP Financial planning",
+        "url": "https://www.levelupfinancialplanning.com/?vc",
+        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+        "logoWidth": 679,
+        "logoHeight": 525,
+        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+      }
+    ]
+  },
+  {
+    "title": "OSS Book Review: Nadia Eghbal's Working in Public - The Making and Maintenance of Open Source Software",
+    "slug": "working-in-public-the-making-and-maintenance-of-open-source-software-book-review",
+    "id": "1967",
+    "metaDescription": "Season Nine, Episode Two of the Virtual Coffee Podcast",
+    "season": 9,
+    "episode": 2,
+    "buzzsproutId": "13668999",
+    "publishDate": "2023-09-26T04:00:00+00:00",
+    "shortDescription": "<p><span>Join hosts Bekah and Dan in this episode featuring Jessica Wilkins and Brian Meeker as we delve into the insights from </span>Nadia Eghbal's book \"Working in Public.\" Discover the intricacies of open source collaboration, the evolving dynamics of digital communities, and the profound impact of individual contributions.</p>",
+    "showNotes": "<p>Join hosts Bekah and Dan in this episode with Nadia Eghbal's \"Working in Public\" enthusiasts Jessica Wilkins and Brian Meeker. We discuss the nuances of open source collaboration highlighted in the book, the challenges and rewards of being both a contributor and a maintainer, and the profound impact of individual contributions in the open source community. Dive into the transformative journey of participating in open source and redefining its true meaning with OpenSauced.</p><h3>Links</h3><ul><li><p><a href=\"https://press.stripe.com/working-in-public\">Working in Public: The Making and Maintenance of Open Source Software by Nadia Eghbal</a></p></li><li><p><a href=\"https://github.com/orgs/Virtual-Coffee/discussions/932\">Virtual Coffee Book Club Discussion</a></p></li><li><p><a href=\"https://qz.com/646467/how-one-programmer-broke-the-internet-by-deleting-a-tiny-piece-of-code\">The left-pad story</a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0902.png",
+    "guests": [
+      {
+        "name": "Jessica Wilkins",
+        "bio": "<p>Jessica Wilkins is a self taught developer and technical writer from Los Angeles, California.</p><p class=\"text-left\">In her previous career, she was a professional oboist, educator and owner of JDW Sheet Music.</p><p class=\"text-left\">Jessica's interest in programming came during the pandemic when she wanted to build the Black Excellence Music Project which celebrates black artists from the jazz and classical fields.</p><p class=\"text-left\">She now works for freeCodeCamp on the curriculum team.</p><ul><li><p class=\"text-left\"><a href=\"https://github.com/jdwilkin4\"><u>@jdwilkin4 on GitHub</u></a></p></li><li><p class=\"text-left\"><a href=\"https://twitter.com/codergirl1991?lang=en\"><u>@codergirl1991 on Twitter</u></a></p></li><li><p class=\"text-left\"><a href=\"https://www.linkedin.com/in/jessica-wilkins-developer\"><u>@jessica-wilkins-developer on LinkedIn</u></a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0407-jessica.jpg"
+      },
+      {
+        "name": "Brian Meeker",
+        "bio": "<p>Brian Meeker is a full stack engineer who occasionally leaves his basement in Indiana. Currently, he works as a Senior Engineer at Online Rewards. He works mostly in Elixir these days, but has a past littered with a wide variety of technologies and platforms. Outside of work, Brian is a devoted father, avid nerd, and lover of metal.</p><ul><li><p><a href=\"https://brianmeeker.me/\"><u>brianmeeker.me</u></a></p></li><li><p><a href=\"https://github.com/CuriousCurmudgeon\"><span>@CuriousCurmudgeon on GitHub</span></a></p></li><li><p><a href=\"https://twitter.com/CuriousCurmudge\">@CuriousCurmudge on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/brianmeeker\">@brianmeeker on LinkedIn</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/headshot_cropped.png"
+      }
+    ],
+    "sponsors": [
+      {
+        "title": "LevelUP Financial planning",
+        "url": "https://www.levelupfinancialplanning.com/?vc",
+        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+        "logoWidth": 679,
+        "logoHeight": 525,
+        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+      }
+    ]
+  },
+  {
+    "title": "Open Source Licenses with Matt McInnis, Tom Cudd, and Ray Deck",
+    "slug": "open-source-licenses-with-matt-mcinnis-tom-cudd-and-ray-deck",
+    "id": "2044",
+    "metaDescription": "Season 9, Episode 3 of the Virtual Coffee Podcast",
+    "season": 9,
+    "episode": 3,
+    "buzzsproutId": "13757456",
+    "publishDate": "2023-10-11T04:00:00+00:00",
+    "shortDescription": "<p>Join hosts Bekah and Dan in this special episode where we sit down with Matt McInnis, Ray Deck, and Tom Cudd to explore the often overlooked but crucial topic of open source licenses. We'll discuss the nuances of choosing the right license for your project, the implications it has for contributors and maintainers, and the scenarios where leaving the license blank might actually be a strategic move.</p>",
+    "showNotes": "<p>Join hosts Bekah and Dan with guests Matt McInnis, Ray Deck, and Tom Cudd, as they chat about the complicated topic of open source software (OSS) licenses. They share insights into how to choose the appropriate license, how to understand licenses on other projects, and general guidelines for maintainers and contributors.</p><h3>Links:</h3><ul><li><p><a href=\"http://ChooseALicense.com\"><u>ChooseALicense.com</u></a> by GitHub</p></li><li><p>Example of clarifying subfolders in the LICENSE: <a href=\"https://github.com/tensorflow/models/blob/master/LICENSE\" rel=\"noopener noreferrer\" target=\"_blank\"><u>TensorFlow’s </u></a><code>models</code><a href=\"https://github.com/tensorflow/models/blob/master/LICENSE\" rel=\"noopener noreferrer\" target=\"_blank\"><u> repo</u></a>.</p></li><li><p>Example of a License section in the README indicating what parts of the repo the license applies to: <a href=\"https://github.com/openai/whisper/blob/e8622f9afc4eba139bf796c210f5c01081000472/README.md\" rel=\"noopener noreferrer\" target=\"_blank\"><u>OpenAI’s Whisper model</u></a>. “Whisper’s code and model weights are released under the MIT License.”</p></li><li><p>Example of a paid product with an open source license: <a href=\"https://github.com/craftcms/craft/blob/main/LICENSE.md\" rel=\"noopener noreferrer\" target=\"_blank\"><u>CraftCMS</u></a></p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0903.png",
+    "guests": [
+      {
+        "name": "Matt McInnis",
+        "bio": "<p>Full-stack developer (Rails+React) at Typist based in Toronto, Canada. Former artificial intelligence lead at IBM and Microsoft, mathematics professor at Centennial College and Saskatchewan Polytechnic. I really love brunch.</p><ul><li><p><a href=\"https://github.com/MattyMc\">@MattyMc on GitHub</a></p></li><li><p><a href=\"https://twitter.com/MattLovesMath\">@MattLovesMath on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/mattmcinnis\">mattmcinnis on LinkedIn</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/1581513771937-1.jpeg"
+      },
+      {
+        "name": "Tom Cudd",
+        "bio": "<p>As an advocate for DevOps within teams and communities, I strive to bring positive change in the way Development and Operations teams work together. I love to help people learn about teams, leadership, infrastructure, cloud, and automation.</p><ul><li><p><a href=\"https://tomcudd.com\">tomcudd.com</a></p></li><li><p><a href=\"https://github.com/tomcudd\">@tomcudd on GitHub</a></p></li><li><p><a href=\"https://twitter.com/tomcudd\">@tomcudd on Twitter</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/dZU1npoqScZd494fteFw.jpg"
+      },
+      {
+        "name": "Ray Deck",
+        "bio": "<p>Veteran leader of technology teams and startup companies over the last 20 years. Most recently founder of <a href=\"http://Statechange.ai\">Statechange.ai</a>, a learning community for solving the hardest 5% of no-code/low-code/AI-code challenges.</p><ul><li><p><a href=\"https://raydeck.com\">raydeck.com</a></p></li><li><p><a href=\"https://statechange.ai\">statechange.ai</a></p></li><li><p><a href=\"https://github.com/rhdeck\">@rhdeck on GitHub</a></p></li><li><p><a href=\"https://twitter.com/ray_deck\">@ray_deck on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/raydeck\">raydeck on LinkedIn</a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/2016-11-27-11.25.20-1.jpg"
+      }
+    ],
+    "sponsors": [
+      {
+        "title": "LevelUP Financial planning",
+        "url": "https://www.levelupfinancialplanning.com/?vc",
+        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+        "logoWidth": 679,
+        "logoHeight": 525,
+        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+      }
+    ]
+  },
+  {
+    "title": "Jessica Wilkins - Using Open Source to Create Connections",
+    "slug": "jessica-wilkins-using-open-source-to-create-connections",
+    "id": "2105",
+    "metaDescription": "Season 9, Episode 4 of the Virtual Coffee Podcast",
+    "season": 9,
+    "episode": 4,
+    "buzzsproutId": "13897541",
+    "publishDate": "2023-11-02T04:00:00+00:00",
+    "shortDescription": "<p>Join hosts Bekah and Dan in this enlightening episode with Jessica Wilkins. Dive deep into the art of nurturing relationships in the open source community. Learn the intricacies of collaborating with maintainers, the value of non-traditional skillsets, and the journey of personal growth as a contributor. </p>",
+    "showNotes": "<p>Join hosts Bekah and Dan as they engage in a captivating conversation with Jessica Wilkins, a prominent figure from freeCodeCamp. In this episode, Jessica shares her invaluable insights on nurturing and developing relationships within the open source community. Delve into the nuances of effective collaboration with maintainers, understand the significance of embracing non-traditional skillsets, and discover the pathways to flourish as a contributor. Jessica's experiences with freeCodeCamp provide a unique perspective on the human dynamics and interpersonal relationships that form the backbone of successful open source projects.</p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0904-jessica.png",
+    "guests": [
+      {
+        "name": "Jessica Wilkins",
+        "bio": "<p>Jessica Wilkins is a self taught developer and technical writer from Los Angeles, California.</p><p class=\"text-left\">In her previous career, she was a professional oboist, educator and owner of JDW Sheet Music.</p><p class=\"text-left\">Jessica's interest in programming came during the pandemic when she wanted to build the Black Excellence Music Project which celebrates black artists from the jazz and classical fields.</p><p class=\"text-left\">She now works for freeCodeCamp on the curriculum team.</p><ul><li><p class=\"text-left\"><a href=\"https://github.com/jdwilkin4\"><u>@jdwilkin4 on GitHub</u></a></p></li><li><p class=\"text-left\"><a href=\"https://twitter.com/codergirl1991?lang=en\"><u>@codergirl1991 on Twitter</u></a></p></li><li><p class=\"text-left\"><a href=\"https://www.linkedin.com/in/jessica-wilkins-developer\"><u>@jessica-wilkins-developer on LinkedIn</u></a></p></li></ul>",
+        "headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0904-jessica.png"
+      }
+    ],
+    "sponsors": [
+      {
+        "title": "LevelUP Financial planning",
+        "url": "https://www.levelupfinancialplanning.com/?vc",
+        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+        "logoWidth": 679,
+        "logoHeight": 525,
+        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+      }
+    ]
+  },
+  {
+    "title": "Remote Collaboration Tools and Techniques",
+    "slug": "remote-collaboration-tools-and-techniques",
+    "id": "2142",
+    "metaDescription": "Season 10, Episode 1 of the Virtual Coffee Podcast",
+    "season": 10,
+    "episode": 1,
+    "buzzsproutId": "15727596",
+    "publishDate": "2024-09-10T04:00:00+00:00",
+    "shortDescription": "<p><span>In the first episode of Season 10 of the Virtual Coffee Podcast, hosts Bekah and Dan introduce the new format focusing on </span>\"back pocket topics\" from Virtual Coffee <span>community discussions, beginning with a discussion on tools and techniques for remote collaboration.</span></p>",
+    "showNotes": "<p><span>In the first episode of Season 10 of the Virtual Coffee podcast, hosts Bekah and Dan introduce the new format focusing on \"back pocket topics\" from Virtual Coffee community discussions. They delve into common remote collaboration tools and techniques, sharing insights from their experiences in tech. Topics include effective communication, the importance of documentation, and how different company cultures influence remote work. The episode also touches on the role of community members in improving knowledge sharing, both in work settings and open-source projects.</span></p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E01.png",
+    "guests": [],
+    "sponsors": [
+      {
+        "title": "LevelUP Financial planning",
+        "url": "https://www.levelupfinancialplanning.com/?vc",
+        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+        "logoWidth": 679,
+        "logoHeight": 525,
+        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+      }
+    ]
+  },
+  {
+    "title": "How to Build Trust Capital",
+    "slug": "how-to-build-trust-capital",
+    "id": "2146",
+    "metaDescription": "Season 10, Episode 2 of the Virtual Coffee Podcast",
+    "season": 10,
+    "episode": 1,
+    "buzzsproutId": "15762421",
+    "publishDate": "2024-09-16T04:00:00+00:00",
+    "shortDescription": "<p>Bekah and Dan discuss the concept of 'trust capital' and its importance in tech communities.</p>",
+    "showNotes": "<p><span>In Episode 2 of Season 10 of the Virtual Coffee podcast, hosts Bekah and Dan discuss the concept of 'trust capital' and its importance in tech communities. They define trust capital as the value and trustworthiness one has with others. The hosts explore how to build trust through consistent actions, showing up, transparency, and effective communication. They highlight the difference between networking and building genuine relationships, emphasizing practical ways to accumulate trust capital, such as writing blog posts, mentoring, and being an active, dependable community member. The episode underscores the benefits of trust capital in fostering credibility, enhancing professional relationships, and reducing barriers to collaborative progress.</span></p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E02.png",
+    "guests": [],
+    "sponsors": [
+      {
+        "title": "LevelUP Financial planning",
+        "url": "https://www.levelupfinancialplanning.com/?vc",
+        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+        "logoWidth": 679,
+        "logoHeight": 525,
+        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+      }
+    ]
+  },
+  {
+    "title": "'Big M' versus 'Little m' Mentorship",
+    "slug": "big-m-versus-little-m-mentorship",
+    "id": "2154",
+    "metaDescription": "Season 10, Episode 3 of the Virtual Coffee Podcast",
+    "season": 10,
+    "episode": 3,
+    "buzzsproutId": "15809647",
+    "publishDate": "2024-09-24T04:00:00+00:00",
+    "shortDescription": "<p><span>Bekah and Dan discuss the differences between formal and informal mentorship, sharing insights on how community and personal connections play a role in effective mentorship.</span></p>",
+    "showNotes": "<p><span>In Season 10, Episode 3 of the Virtual Coffee Podcast, hosts Bekah and Dan explore the topic of 'Big M' versus 'Little m' Mentorship. They distinguish between formal, one-on-one mentorship ('Big M') and more informal, community-based mentorship ('Little M'). They discuss the advantages and potential pitfalls of each approach, emphasizing the importance of finding the right mentorship fit. They also touch on the role of coaches, the value of community support in events like Hacktoberfest, and the concept of a personal 'board of mentors.' </span></p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E03.png",
+    "guests": [],
+    "sponsors": [
+      {
+        "title": "LevelUP Financial planning",
+        "url": "https://www.levelupfinancialplanning.com/?vc",
+        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+        "logoWidth": 679,
+        "logoHeight": 525,
+        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+      }
+    ]
+  },
+  {
+    "title": "How to Make a Positive Impact during Hacktoberfest",
+    "slug": "how-to-make-a-positive-impact-during-hacktoberfest",
+    "id": "2161",
+    "metaDescription": "Season 10, Episode 4 of the Virtual Coffee Podcast",
+    "season": 10,
+    "episode": 4,
+    "buzzsproutId": "15841150",
+    "publishDate": "2024-09-30T04:00:00+00:00",
+    "shortDescription": "<p>Welcome to Hacktoberfest!</p>",
+    "showNotes": "<p>Bekah and Dan explore the community's engagement with Hacktoberfest, a month-long event encouraging open source contributions. They discuss what Hacktoberfest is and what it means to be a positive contributor in the open source community. They highlight the importance of meaningful contributions, respecting maintainers' time, and provides tips for navigating and contributing to open source projects, and touches on ways to be a good open source citizen and the benefits of contributing consistently to a single project or organization. The episode emphasizes understanding project documentation and being patient with maintainers, while exploring various ways to support open source initiatives beyond writing code.</p><ul><li><p><code>00:00</code> Welcome to the Virtual Coffee Podcast</p></li><li><p><code>00:25</code> Introduction to Hacktoberfest</p></li><li><p><code>00:45</code> Sponsorship Shoutout</p></li><li><p><code>01:08</code> Getting Started with Hacktoberfest</p></li><li><p><code>02:01</code> The Origins of Virtual Coffee and Hacktoberfest</p></li><li><p><code>05:01</code> How to Contribute Positively</p></li><li><p><code>13:02</code> The Importance of Documentation</p></li><li><p><code>18:04</code> Non-Code Contributions</p></li><li><p><code>24:02</code> Building Relationships in Open Source</p></li><li><p><code>26:25</code> Closing Remarks and Contact Information</p></li></ul>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E04.png",
+    "guests": [],
+    "sponsors": [
+      {
+        "title": "LevelUP Financial planning",
+        "url": "https://www.levelupfinancialplanning.com/?vc",
+        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+        "logoWidth": 679,
+        "logoHeight": 525,
+        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+      }
+    ]
+  },
+  {
+    "title": "Open Source Maintainer Challenges and Benefits",
+    "slug": "open-source-maintainer-challenges-and-benefits",
+    "id": "2167",
+    "metaDescription": "Season 10, Episode 5 of the Virtual Coffee Podcast",
+    "season": 10,
+    "episode": 5,
+    "buzzsproutId": "15891752",
+    "publishDate": "2024-10-08T04:00:00+00:00",
+    "shortDescription": "<p><span>Bekah and Dan share personal experiences of maintaining open source projects, highlight the benefits of creating a community of contributors, and offer insights into tools and strategies for effective project management and collaboration.</span></p>",
+    "showNotes": "<p>In this episode of the Virtual Coffee Podcast, hosts Bekah and Dan delve into the benefits and challenges of being a maintainer in open source projects, particularly during Hacktoberfest. They discuss the excitement and responsibility of maintaining projects, the joy of welcoming new contributors, and the importance of community building. The hosts also highlight the preparation involved in enhancing project onboarding and documentation, and the growth opportunities for maintainers. The episode also emphasizes strategies to attract contributors and the impact of efficiently managing open source projects.</p><h3>Links:</h3><ul><li><p><a href=\"https://opensauced.pizza/learn\">https://opensauced.pizza/learn</a></p></li><li><p>Becoming an Open Source Maintainer</p></li></ul><p></p><p>00:00 Welcome to Virtual Coffee Podcast</p><p>00:26 Hacktoberfest Excitement and Open Source</p><p>00:43 Sponsorship Shoutout</p><p>01:06 Grab Your Drink and Settle In</p><p>01:34 Maintainer Experiences and Challenges</p><p>03:44 The Joy of Hacktoberfest</p><p>05:08 Maintaining Beyond Hacktoberfest</p><p>08:13 The Importance of Onboarding</p><p>09:29 PrepTember and Readiness</p><p>11:01 Building Trust and Community</p><p>12:18 The Benefits of Being a Maintainer</p><p>17:32 Growing as a Maintainer</p><p>18:40 Marketing Your Open Source Project</p><p>21:06 Community Support and Resources</p><p>23:44 Wrapping Up and Final Thoughts</p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E05.png",
+    "guests": [],
+    "sponsors": [
+      {
+        "title": "LevelUP Financial planning",
+        "url": "https://www.levelupfinancialplanning.com/?vc",
+        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+        "logoWidth": 679,
+        "logoHeight": 525,
+        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+      }
+    ]
+  },
+  {
+    "title": "Building Relationships in Open Source",
+    "slug": "building-relationships-in-open-source",
+    "id": "2172",
+    "metaDescription": "Season 10, Episode 6 of the Virtual Coffee Podcast",
+    "season": 10,
+    "episode": 6,
+    "buzzsproutId": "15931952",
+    "publishDate": "2024-10-15T04:00:00+00:00",
+    "shortDescription": "<p>The Virtual Coffee Podcast explores the significance of relationship-building and mentorship in open-source communities during Hacktoberfest, underlining practical advice, effective communication, and providing support to foster a welcoming environment for contributors.</p>",
+    "showNotes": "<p><span>In Season 10, Episode 6 of the Virtual Coffee Podcast, hosts Bekah and Dan explore the multifaceted aspects of building and nurturing relationships within the open source community, particularly during Hacktoberfest. The episode highlights the significance of effective networking, making meaningful connections, and becoming a valued repeat contributor. The hosts provide practical advice for newcomers, stressing the importance of understanding projects, submitting quality pull requests, and contributing beyond code through community management and content creation. Emphasizing mentorship, they discuss how maintainers can aid first-time contributors via comprehensive readme files, contributing guides, and constructive feedback. The importance of communication, relationship-building, and the impact of small gestures like a simple thank you are also covered to foster a supportive and efficient open source community.</span></p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E06.png",
+    "guests": [],
+    "sponsors": [
+      {
+        "title": "LevelUP Financial planning",
+        "url": "https://www.levelupfinancialplanning.com/?vc",
+        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+        "logoWidth": 679,
+        "logoHeight": 525,
+        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+      }
+    ]
+  },
+  {
+    "title": "Climbing the Contributor Ladder",
+    "slug": "climbing-the-contributor-ladder",
+    "id": "2175",
+    "metaDescription": "Season 10, Episode 7 of the Virtual Coffee Podcast",
+    "season": 10,
+    "episode": 7,
+    "buzzsproutId": "15975962",
+    "publishDate": "2024-10-23T04:00:00+00:00",
+    "shortDescription": "<p><span>Dan and Bekah discuss strategies for advancing from contributor to maintainer in open source projects by engaging with the community, understanding contribution guidelines, handling issues effectively, and collaborating respectfully.</span></p>",
+    "showNotes": "<p><span>In this episode of the Virtual Coffee Podcast, hosts Bekah Hawrot Weigel and Dan Ott delve into the journey of climbing the contributor ladder in open-source projects. They explore the progression from contributor to maintainer, focusing on the importance of trust-building, consistent contributions, and respectful interactions within the community. Key strategies discussed include engaging with project documentation, reproducing bugs, and effective communication. The episode also highlights how projects like Astro and Nuxt guide contributors and the role of events like Hacktoberfest in encouraging new participation. Real-life examples illustrate how proactive engagement can lead to managing more complex tasks and even job opportunities. Sponsored by Level Up Financial Planning, this insightful episode is a must-listen for anyone looking to make significant strides in the open-source community.</span><br><br><span>Visit <a href=\"https://virtualcoffee.io/resources/developer-resources/open-source\">https://virtualcoffee.io/resources/developer-resources/open-source</a> for additional resources.</span></p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E07.png",
+    "guests": [],
+    "sponsors": [
+      {
+        "title": "LevelUP Financial planning",
+        "url": "https://www.levelupfinancialplanning.com/?vc",
+        "logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+        "logoWidth": 679,
+        "logoHeight": 525,
+        "description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+      }
+    ]
+  },
+  {
+    "title": "Open Sourcing a Private Repo",
+    "slug": "open-sourcing-a-private-repo",
+    "id": "2178",
+    "metaDescription": "Season 10, Episode 8 of the Virtual Coffee Podcast",
+    "season": 10,
+    "episode": 8,
+    "buzzsproutId": "16019031",
+    "publishDate": "2024-10-30T04:00:00+00:00",
+    "shortDescription": "<p><span>Bekah and Dan discuss the considerations and steps involved in open sourcing a private repository, sharing insights from their own experience with the Virtual Coffee community docs.</span></p>",
+    "showNotes": "<p><span>In Episode 8 of Season 10 of the Virtual Coffee Podcast, hosts Bekah and Dan delve into the intricate process of open sourcing a private repository. Drawing from their experience with Virtual Coffee's community docs, they discuss considerations like verifying the safety of repository content, ensuring appropriate permissions, and maintaining the privacy of sensitive discussions. They also touch on the importance of updating READEMEs, licensing, and providing clear guidelines for new contributors.</span></p>",
+    "episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E08.png",
+    "guests": [],
+    "sponsors": []
+  }
+]

--- a/src/data/podcast/episodes.json
+++ b/src/data/podcast/episodes.json
@@ -1,1530 +1,32 @@
 [
 	{
-		"title": "Virtual Coffee Podcast Trailer",
-		"slug": "0000-trailer",
-		"id": "271",
-		"metaDescription": "Welcome to the Virtual Coffee Podcast!",
-		"season": 1,
-		"episode": 0,
-		"buzzsproutId": "7119532",
-		"publishDate": "2021-01-04T05:00:00+00:00",
-		"shortDescription": "<p>Welcome to the Virtual Coffee Podcast!</p>",
-		"showNotes": "<p>This is the Virtual Coffee Podcast, hosted by Bekah Hawrot Weigel and Dan Ott. You'll find interviews with members of our community to learn more about their stories, who they are, how they found Virtual Coffee, and how it has influenced their lives as developers. We want to bring everything that's special about Virtual Coffee, the intimacy and the friendships we’ve built, and share that with everyone through the podcast. We’re always growing and learning together as a group, and there’s something really special about being able to do that knowing that you’ll have the full support of the community around you. And that’s what this podcast is about too.</p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/virtual-coffee-mug-square.png",
-		"guests": [
-			{
-				"name": "Virtual Coffee IO",
-				"bio": "<ul><li><p><a href=\"https://virtualcoffee.io/podcast\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee Podcast</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/virtual-coffee-mug-square.png"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Nick Taylor: Open Source, Live Streaming, and Structured YOLO",
-		"slug": "0101-nickyt",
-		"id": "284",
-		"metaDescription": "Season One, Episode One of the Virtual Coffee Podcast",
-		"season": 1,
-		"episode": 1,
-		"buzzsproutId": "7238548",
-		"publishDate": "2021-01-11T05:00:00+00:00",
-		"shortDescription": "<p>Dan and Bekah welcome Nick Taylor (Senior Software Engineer at Forem/DEV) to talk about his journey into tech, open source, and the importance of community</p>",
-		"showNotes": "<p>Dan and Bekah welcome Nick Taylor (Senior Software Engineer at Forem/DEV) to talk about his journey into tech, open source, and the importance of community. Nick talks about his journey through University and into tech, how the landscape of tech has changed with increased resources and community, and how his idea of \"structured YOLO\" has lead him to this point in his career. He talks about how his job at Forem and how the pandemic led to his livestreaming, where he tries to make coding as realistic as possible. His hour and a half livestreams focus on one issue, but realistically those issues won't be solved during that time. And that's ok, because coding takes time, and working through issues won't always be a simple solution. His approach to teaching includes learning as you go, which made him an amazing contributor, mentor, and maintainer for the Virtual Coffee Hacktoberfest Initiative. Every conversation with Nick is an interesting one, and this one isn't an exception.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Nick: <a href=\"https://dev.to/nickytonline\" rel=\"noopener noreferrer\" target=\"_blank\">https://dev.to/nickytonline</a></p></li><li><p>Forem: <a href=\"https://www.forem.com/\" rel=\"noopener noreferrer\" target=\"_blank\">https://www.forem.com/</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0101-nickyt-episode.jpg",
-		"guests": [
-			{
-				"name": "Nick Taylor",
-				"bio": "<p>Senior Software Engineer at <a href=\"https://www.forem.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Forem</a>, the software that powers <a href=\"https://dev.to/\" rel=\"noopener noreferrer\" target=\"_blank\">DEV</a>, working on all things Forem.</p><ul><li><p><a href=\"https://iamdeveloper.com/\" rel=\"noopener noreferrer\" target=\"_blank\">iamdeveloper.com</a></p></li><li><p><a href=\"https://livecoding.ca/\" rel=\"noopener noreferrer\" target=\"_blank\">livecoding.ca</a></p></li><li><p><a href=\"https://twitter.com/nickytonline\" rel=\"noopener noreferrer\" target=\"_blank\">twitter.com/nickytonline</a></p></li><li><p><a href=\"https://dev.to/nickytonline\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/nickytonline</a></p></li><li><p><a href=\"https://iamdeveloper.com/hacktoberfest2020\" rel=\"noopener noreferrer\" target=\"_blank\">Getting the Most Out of Open Source</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0101-nickyt.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Marie Antons: From Chef to Tech",
-		"slug": "0102-marieantons",
-		"id": "291",
-		"metaDescription": "Season One, Episode Two of the Virtual Coffee Podcast",
-		"season": 1,
-		"episode": 2,
-		"buzzsproutId": "7323430",
-		"publishDate": "2021-01-18T05:00:00+00:00",
-		"shortDescription": "<p>In this episode, Marie Antons talks with Dan, Bekah, and Kirk about how she went from being a chef to a junior developer.</p>",
-		"showNotes": "<p>In this episode, Marie Antons talks with Dan, Bekah, and Kirk about how she went from being a chef to a junior developer. With more and more developers coming into tech from non-traditional backgrounds, Marie shares her own unique story and how taking her past experience as a chef allowed her to understand coding in her own way. There are ingredients and steps to follow with recipes, and similarly, as you learn to code, you'll find what you need to get your code to work and the process you need to take to get there. She also talks about the challenges of coming into her first job from a bootcamp, and what she wishes she would've known before starting that job.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p><a href=\"https://www.deltavcodeschool.com/\" rel=\"noopener noreferrer\" target=\"_blank\">DeltaV Code School</a></p></li><li><p><a href=\"https://stratafolio.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Stratafolio</a></p></li><li><p><a href=\"https://d3js.org/\" rel=\"noopener noreferrer\" target=\"_blank\">D3 javascript library</a></p></li><li><p><a href=\"https://wattenberger.com/blog/css-percents\" rel=\"noopener noreferrer\" target=\"_blank\">Amy Wattenberger</a> (the blogger Dan couldn't remember!)</p></li><li><p><a href=\"https://twitter.com/MarieAntons\" rel=\"noopener noreferrer\" target=\"_blank\">@MarieAntons</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/marie\" rel=\"noopener noreferrer\" target=\"_blank\">Marie Antons</a> on LinkedIn</p></li><li><p>Kirk: <a href=\"https://twitter.com/tkshillinz\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshillinz</a> on Twitter</p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0102-marie-episode.jpg",
-		"guests": [
-			{
-				"name": "Marie Antons",
-				"bio": "<p>Marie is a C#/.NET developer working for a small start-up called Stratafolio.</p><ul><li><p><a href=\"https://twitter.com/MarieAntons\" rel=\"noopener noreferrer\" target=\"_blank\">@MarieAntons</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/marie\" rel=\"noopener noreferrer\" target=\"_blank\">Marie Antons</a> on LinkedIn</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0102-marie.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Tori Crawford: Interviewing — If it's broke, fix it",
-		"slug": "0103-tori-crawford",
-		"id": "298",
-		"metaDescription": "Season One, Episode Three of the Virtual Coffee Podcast",
-		"season": 1,
-		"episode": 3,
-		"buzzsproutId": "7474594",
-		"publishDate": "2021-01-25T05:00:00+00:00",
-		"shortDescription": "<p>In this episode, Dan and Bekah welcome Tori Crawford to talk about her journey through the interview process that included about 53 interviews, 430 applications, and a pandemic offer that ultimately led to her being ghosted by the company.</p>",
-		"showNotes": "<p>In this episode, Dan and Bekah welcome Tori to talk about her journey through the interview process that included about 53 interviews, 430 applications, and a pandemic offer that ultimately led to her being ghosted by the company. She gives her tips and tricks, including recognizing that interviews are a two-way street; you should also be interviewing the companies that are interviewing you. She talks about the problems of technical interviewing, how she's hopeful that the industry can make changes, and how the job she ultimately landed has been a great experience, starting with the interview.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Tori: <a href=\"https://dev.to/torianne02\" rel=\"noopener noreferrer\" target=\"_blank\">DEV</a>, <a href=\"https://twitter.com/_torrborr\" rel=\"noopener noreferrer\" target=\"_blank\">Twitter</a></p></li><li><p>Article Tori wrote detailing her interview journey: <a href=\"https://dev.to/torianne02/444-days-later-tori-hit-the-jackpot-3o4p\" rel=\"noopener noreferrer\" target=\"_blank\">444 Days Later, Tori Hit the Jackpot</a></p></li><li><p>Udemy course mentioned: <a href=\"https://www.udemy.com/course/master-the-coding-interview-data-structures-algorithms/\" rel=\"noopener noreferrer\" target=\"_blank\">Master the Coding Interview: Data Structures + Algorithms</a></p></li><li><p><a href=\"https://flatironschool.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Flatiron School</a></p></li><li><p><a href=\"https://firehydrant.io/\" rel=\"noopener noreferrer\" target=\"_blank\">FireHydrant</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0103-tori-episode.jpg",
-		"guests": [
-			{
-				"name": "Tori Crawford",
-				"bio": "<p>Software Engineer at <a href=\"https://firehydrant.io/\" rel=\"noopener noreferrer\" target=\"_blank\">FireHydrant</a>.</p><ul><li><p><a href=\"https://twitter.com/_torrborr\" rel=\"noopener noreferrer\" target=\"_blank\">@_torrborr</a> on Twitter</p></li><li><p><a href=\"https://dev.to/torianne02\" rel=\"noopener noreferrer\" target=\"_blank\">torianne02</a> on DEV</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0103-tori.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Vic Vijayakumar: Indie Hacking",
-		"slug": "0104-vic-vijayakumar",
-		"id": "305",
-		"metaDescription": "Season One, Episode Four of the Virtual Coffee Podcast",
-		"season": 1,
-		"episode": 4,
-		"buzzsproutId": "7564483",
-		"publishDate": "2021-02-01T05:00:00+00:00",
-		"shortDescription": "<p>In this episode, Vic talks about Indie Hacking and gives us his take on when to ship, what to focus on, and the value of diverse opinions in your community.</p>",
-		"showNotes": "<p>In this episode, Vic talks about Indie Hacking and gives us his take on when to ship, what to focus on, and the value of diverse opinions in your community. He also talks about treating life as a lot of drafts and about building things that you're passionate about as well as things that others find valuable. He cautions against the danger of survivorship bias, recognizing that it's difficult to find a path in indie hacking and that many of the popular voices have worked through challenges and no longer effectively represent how difficult it is to create a product that's successful.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><h5 class=\"text-left\"><strong>Vic:</strong></h5><ul><li><p><a href=\"https://vicvijayakumar.com/\" rel=\"noopener noreferrer\" target=\"_blank\">vicvijayakumar.com</a></p></li><li><p><a href=\"https://twitter.com/vicvijayakumar\" rel=\"noopener noreferrer\" target=\"_blank\">@vicvijayakumar</a> on Twitter</p></li></ul><h5 class=\"text-left\"><strong>Vic's Projects:</strong></h5><ul><li><p><a href=\"https://www.everyoak.com/\" rel=\"noopener noreferrer\" target=\"_blank\">EveryOak</a></p></li><li><p><a href=\"https://meetsweats.com/\" rel=\"noopener noreferrer\" target=\"_blank\">MeetSweats.com</a></p></li><li><p><a href=\"https://dogears.xyz/\" rel=\"noopener noreferrer\" target=\"_blank\">Dog Ears</a></p></li></ul><h5 class=\"text-left\"><strong>Low-Code Tools:</strong></h5><ul><li><p><a href=\"https://carrd.co/\" rel=\"noopener noreferrer\" target=\"_blank\">Carrd</a></p></li><li><p><a href=\"https://zapier.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Zapier</a></p></li><li><p><a href=\"https://airtable.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Airtable</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0104-vic-episode.jpg",
-		"guests": [
-			{
-				"name": "Vic Vijayakumar",
-				"bio": "<p>Principal software engineer at <a href=\"https://www.researchsquare.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Research Square</a>, a preprint platform</p><ul><li><p><a href=\"https://vicvijayakumar.com/\" rel=\"noopener noreferrer\" target=\"_blank\">vicvijayakumar.com</a></p></li><li><p><a href=\"https://twitter.com/vicvijayakumar\" rel=\"noopener noreferrer\" target=\"_blank\">@vicvijayakumar</a> on Twitter</p></li><li><p><a href=\"https://www.everyoak.com/\" rel=\"noopener noreferrer\" target=\"_blank\">EveryOak</a></p></li><li><p><a href=\"https://meetsweats.com/\" rel=\"noopener noreferrer\" target=\"_blank\">MeetSweats.com</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0104-vic.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Cameron Bardell and Rahat Chowdhury: Mental Health & Tech",
-		"slug": "0105-cameron-rahat",
-		"id": "312",
-		"metaDescription": "Season One, Episode Five of the Virtual Coffee Podcast",
-		"season": 1,
-		"episode": 5,
-		"buzzsproutId": "7741411",
-		"publishDate": "2021-02-08T05:00:00+00:00",
-		"shortDescription": "<p>In this episode, Bekah and Dan talk about mental health with Cameron Bardell, an iOS developer in the healthcare industry, and Rahat Chowdhury, a mental health start-up founder.</p>",
-		"showNotes": "<p>In this episode, Bekah and Dan talk about mental health with Cameron Bardell, an iOS developer in the healthcare industry, and Rahat Chowdhury, a mental health start-up founder. We talk about how sometimes building a product to meet our own needs is a great place to start and the importance of prioritizing mental health, especially in a fast-paced industry like tech. We walk through our own experiences, how mental health recovery isn't linear, and how different approaches to mental health technology create support for more people.</p><p class=\"text-left\">If you or someone else is suffering from mental health issues, you aren't alone. Below are some links to help you find resources or to seek help:</p><ul><li><p><a href=\"https://suicidepreventionlifeline.org/\" rel=\"noopener noreferrer\" target=\"_blank\">National Suicide Prevention Lifeline</a> - 1-800-273-8255</p></li><li><p><a href=\"https://www.samhsa.gov/find-help/national-helpline\" rel=\"noopener noreferrer\" target=\"_blank\">SAMHSA’s National Helpline</a> - 1-800-662-HELP (4357)</p></li><li><p><a href=\"https://cmha.ca/\" rel=\"noopener noreferrer\" target=\"_blank\">CMHA National</a></p></li></ul><h4 class=\"text-left\"><strong>Links:</strong></h4><h5 class=\"text-left\"><strong>Cameron:</strong></h5><ul><li><p><a href=\"https://cambardell.github.io/\" rel=\"noopener noreferrer\" target=\"_blank\">cambardell.github.io</a></p></li><li><p><a href=\"https://twitter.com/cameronbardell\" rel=\"noopener noreferrer\" target=\"_blank\">@cameronbardell</a> on Twitter</p></li></ul><h5 class=\"text-left\"><strong>Rahat:</strong></h5><ul><li><p><a href=\"https://www.rahatcodes.com/\" rel=\"noopener noreferrer\" target=\"_blank\">rahatcodes.com</a></p></li><li><p><a href=\"https://twitter.com/Rahatcodes\" rel=\"noopener noreferrer\" target=\"_blank\">@Rahatcodes</a> on Twitter</p></li><li><p><a href=\"https://whimser.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Whimser</a></p></li><li><p>Open source mental health resources database: <a href=\"https://www.sylarproject.com/\" rel=\"noopener noreferrer\" target=\"_blank\">The Sylar Project</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0105-camrahat-episode.jpg",
-		"guests": [
-			{
-				"name": "Cameron Bardell",
-				"bio": "<p>iOS developer in the healthcare industry</p><ul><li><p><a href=\"https://cambardell.github.io/\" rel=\"noopener noreferrer\" target=\"_blank\">cambardell.github.io</a></p></li><li><p><a href=\"https://twitter.com/cameronbardell\" rel=\"noopener noreferrer\" target=\"_blank\">@cameronbardell</a> on Twitter</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0105-cameron.jpg"
-			},
-			{
-				"name": "Rahat Chowdhury",
-				"bio": "<p>Mental health start-up founder</p><ul><li><p><a href=\"https://www.rahatcodes.com/\" rel=\"noopener noreferrer\" target=\"_blank\">rahatcodes.com</a></p></li><li><p><a href=\"https://twitter.com/Rahatcodes\" rel=\"noopener noreferrer\" target=\"_blank\">@Rahatcodes</a> on Twitter</p></li><li><p><a href=\"https://whimser.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Whimser</a></p></li><li><p><a href=\"https://www.sylarproject.com/\" rel=\"noopener noreferrer\" target=\"_blank\">The Sylar Project</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0105-rahat.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Drew Clements: Building a career and community",
-		"slug": "0106-drew",
-		"id": "329",
-		"metaDescription": "Season One, Episode Six of the Virtual Coffee Podcast",
-		"season": 1,
-		"episode": 6,
-		"buzzsproutId": "7867681",
-		"publishDate": "2021-02-15T05:00:00+00:00",
-		"shortDescription": "<p>In this episode, Bekah and Dan are joined by Drew Clements to talk about the struggles of junior-level job searching, the importance of supportive company culture, and learning in public while building <a href=\"https://protege.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Protege.dev</a>.</p>",
-		"showNotes": "<p>In this episode, we talk to Drew Clements about the challenges junior developers face, learning through building Protege.dev, and the importance of community support. Drew is a career transitioner, father of two, and full-time developer who spends his spare time building Protege.dev, the platform curated with remote jobs for junior developers. We also talk about approaches to problem-solving, when to ask questions, and using live-streaming as an accountability tool.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><h5 class=\"text-left\"><strong>Drew:</strong></h5><ul><li><p><a href=\"https://twitter.com/drewclemcr8\" rel=\"noopener noreferrer\" target=\"_blank\">@drewclemcr8</a> on Twitter</p></li><li><p><a href=\"https://protege.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Protege.dev</a></p></li><li><p><a href=\"https://github.com/drewclem/\" rel=\"noopener noreferrer\" target=\"_blank\">drewclem</a> on GitHub</p></li><li><p><a href=\"https://dev.to/drewclem/\" rel=\"noopener noreferrer\" target=\"_blank\">drewclem</a> on DEV</p></li></ul><h5 class=\"text-left\"><strong>Stu the Rubber Duck!</strong></h5><p class=\"text-left\"></p><img src=\"http://storage.googleapis.com/virtualcoffeeio-assets/images/_podcastShowNotesImage/0106-drew-duck.jpg\" alt=\"Drew holding Stu the Rubber Duck!\" title=\"\">",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0106-drew-episode.jpg",
-		"guests": [
-			{
-				"name": "Drew Clements",
-				"bio": "<p>Frontend Engineer at <a href=\"https://www.fostercommerce.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Foster Commerce</a>, co-founder of <a href=\"https://protege.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Protege.dev</a></p><ul><li><p><a href=\"https://twitter.com/drewclemcr8\" rel=\"noopener noreferrer\" target=\"_blank\">@drewclemcr8</a> on Twitter</p></li><li><p><a href=\"https://protege.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Protege.dev</a></p></li><li><p><a href=\"https://github.com/drewclem/\" rel=\"noopener noreferrer\" target=\"_blank\">drewclem</a> on GitHub</p></li><li><p><a href=\"https://dev.to/drewclem/\" rel=\"noopener noreferrer\" target=\"_blank\">drewclem</a> on DEV</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0106-drew.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Colleen Schnettler -- Tech: It's hard, but it's worth it",
-		"slug": "0107-colleen",
-		"id": "337",
-		"metaDescription": "Season One, Episode Seven of the Virtual Coffee Podcast",
-		"season": 1,
-		"episode": 7,
-		"buzzsproutId": "8007425",
-		"publishDate": "2021-02-22T05:00:00+00:00",
-		"shortDescription": "<p>In this episode, Bekah and Dan are joined by Colleen Schnettler to talk about the challenges women face in the workplace, the benefits of working for yourself, and growing her SaaS business.</p>",
-		"showNotes": "<p>In this episode, we talk to Colleen Schnettler about the challenges of being a woman in the workplace, the benefits of working for yourself, and building her own SaaS business. Colleen is a Ruby on Rails consultant, who recently launched her <a href=\"https://www.simplefileupload.com/\" rel=\"noopener noreferrer\" target=\"_blank\">first product</a>, a career changer, and a mom. Colleen talks about how difficult it is to learn to code; it will take time and commitment, but when you get there, it will all be worth it.</p><h5 class=\"text-left\"><strong>Colleen:</strong></h5><ul><li><p><a href=\"https://twitter.com/leenyburger\" rel=\"noopener noreferrer\" target=\"_blank\">@leenyburger</a> on Twitter</p></li><li><p><a href=\"http://www.bitmappeddesigns.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Bitmapped Designs</a></p></li><li><p><a href=\"https://www.simplefileupload.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Simple File Upload</a></p></li><li><p><a href=\"https://twitter.com/softwaresocpod\" rel=\"noopener noreferrer\" target=\"_blank\">@softwaresocpod</a> - Software Social Podcast</p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0107-colleen-episode.jpg",
-		"guests": [
-			{
-				"name": "Colleen Schnettler",
-				"bio": "<p>Ruby on Rails consultant at <a href=\"http://www.bitmappeddesigns.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Bitmapped Designs</a>.</p><ul><li><p><a href=\"https://twitter.com/leenyburger\" rel=\"noopener noreferrer\" target=\"_blank\">@leenyburger</a> on Twitter</p></li><li><p><a href=\"http://www.bitmappeddesigns.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Bitmapped Designs</a></p></li><li><p><a href=\"https://www.simplefileupload.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Simple File Upload</a></p></li><li><p><a href=\"https://twitter.com/softwaresocpod\" rel=\"noopener noreferrer\" target=\"_blank\">@softwaresocpod</a> - Software Social Podcast</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0107-colleen.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Kirk Shillingford: On Making Mistakes, Growth, and the Importance of Community",
-		"slug": "0108-kirk",
-		"id": "344",
-		"metaDescription": "Season One, Episode Eight of the Virtual Coffee Podcast",
-		"season": 1,
+		"title": "Open Sourcing a Private Repo",
+		"slug": "open-sourcing-a-private-repo",
+		"id": "2178",
+		"metaDescription": "Season 10, Episode 8 of the Virtual Coffee Podcast",
+		"season": 10,
 		"episode": 8,
-		"buzzsproutId": "8052553",
-		"publishDate": "2021-03-01T05:00:00+00:00",
-		"shortDescription": "<p>In this episode, Dan and Bekah talk to Kirk Shillingford, a software developer (and Community Maintainer at Virtual Coffee), about the importance of making mistakes and the growth that comes with it.</p>",
-		"showNotes": "<p>In this episode, Dan and Bekah talk to Kirk Shillingford, a software developer (and Community Maintainer at Virtual Coffee), who has been \"haphazardly writing code for about seven years,\" about the importance of making mistakes and the growth that comes with it. We also talk about empathy being a key indicator of a senior developer and the importance of having a supportive community.</p><h5 class=\"text-left\"><strong>Links:</strong></h5><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://twitter.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Neverwinter_Nights\" rel=\"noopener noreferrer\" target=\"_blank\">Never Winter Nights</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0108-kirk-episode.jpg",
-		"guests": [
-			{
-				"name": "Kirk Shillingford",
-				"bio": "<p>Software Developer, and Community Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://twitter.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0108-kirk.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Dan and Bekah: Season One Wrap-Up",
-		"slug": "0109-bekah-dan",
-		"id": "353",
-		"metaDescription": "Season One, Episode Nine of the Virtual Coffee Podcast",
-		"season": 1,
-		"episode": 9,
-		"buzzsproutId": "8096247",
-		"publishDate": "2021-03-07T05:00:00+00:00",
-		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah switch things up. Since it's last episode of season one, they share a bit about their origin stories, when their paths connected, and how that led to where Virtual Coffee is today.</p>",
-		"showNotes": "<p>In this episode of the podcast, Dan and Bekah switch things up. Since it's last episode of season one, they share a bit about their origin stories, when their paths connected, and how that led to where Virtual Coffee is today. They talk about the challenges of the last year, how Virtual Coffee has been a light during dark times, and how growing can be painful, but also the process that allows you to become more than you could've imagined. And they also drop some of their favorite Virtual Coffee moments of the last year.</p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0109-bekahdan-episode.jpg",
-		"guests": [
-			{
-				"name": "Bekah Hawrot Weigel",
-				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dev.to/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/bekahhw</a></p></li><li><p><a href=\"https://twitter.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">@bekahhw</a> on Twitter</p></li><li><p><a href=\"https://www.instagram.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">bekahhw</a> on Instagram</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0109-bekah.jpg"
-			},
-			{
-				"name": "Dan Ott",
-				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dtott.com/\" rel=\"noopener noreferrer\" target=\"_blank\">dtott.com</a></p></li><li><p><a href=\"https://twitter.com/danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">@danieltott</a> on Twitter</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0109-dan.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Gant Laborde: Finding your Voice",
-		"slug": "0201-gant",
-		"id": "370",
-		"metaDescription": "Season Two, Episode One of the Virtual Coffee Podcast",
-		"season": 2,
-		"episode": 1,
-		"buzzsproutId": "8281596",
-		"publishDate": "2021-04-06T04:00:00+00:00",
-		"shortDescription": "<p>We're back! In this episode of the Virtual Coffee podcast, Dan and Bekah talk to Gant Laborde, an owner of Infinite Red, mentor, adjunct professor, published author, and award-winning speaker, about overcoming challenges, being authentic, and finding your voice.</p>",
-		"showNotes": "<p>In this episode of the Virtual Coffee podcast, Dan and Bekah talk to Gant Laborde, an owner of Infinite Red, mentor, adjunct professor, published author, and award-winning speaker, about overcoming challenges, being authentic, and finding your voice. They share some of the struggles they've faced, talk about how practice can lead to growth, and the importance of recognizing your body's signals in the process.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Gant: <a href=\"https://gantlaborde.com/\" rel=\"noopener noreferrer\" target=\"_blank\">gantlaborde.com</a>, <a href=\"https://twitter.com/GantLaborde\" rel=\"noopener noreferrer\" target=\"_blank\">@GantLaborde</a></p></li><li><p>Some blog posts about public speaking by Gant:</p><ul><li><p><a href=\"https://gantlaborde.medium.com/open-your-speech-and-make-it-marvelous-e031cfa18858\" rel=\"noopener noreferrer\" target=\"_blank\">Open your speech, and make it marvelous</a></p></li><li><p><a href=\"https://medium.com/hackernoon/5-conference-speaking-tips-from-tech-gurus-2f7d1a250af3\" rel=\"noopener noreferrer\" target=\"_blank\">5 Conference Speaking Tips from Tech Gurus</a></p></li><li><p><a href=\"https://shift.infinite.red/the-road-to-distinguished-c9e458da091c\" rel=\"noopener noreferrer\" target=\"_blank\">The Road to Distinguished: From Afraid to Awarded — The path to public speaking success</a></p></li></ul></li><li><p><a href=\"https://cryptozombies.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Cryptozombies</a></p></li><li><p><a href=\"https://geddski.teachable.com/p/flexbox-zombies\" rel=\"noopener noreferrer\" target=\"_blank\">Flexbox zombies</a></p></li><li><p><a href=\"https://infinite.red/\" rel=\"noopener noreferrer\" target=\"_blank\">Infinite Red</a></p></li><li><p><a href=\"https://www.toastmasters.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Toastmasters</a></p></li><li><p><a href=\"https://www.amazon.com/gp/product/1492090794/ref=as_li_qf_asin_il_tl?ie=UTF8&amp;tag=gant0d-20&amp;creative=9325&amp;linkCode=as2&amp;creativeASIN=1492090794&amp;linkId=9b7b356b7b13efdaf9d34bfa47f7a6ee\" rel=\"noopener noreferrer\" target=\"_blank\">Learning TensorFlow.js: Powerful Machine Learning in JavaScript by Gant Laborde</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0201-gant-episode.jpg",
-		"guests": [
-			{
-				"name": "Gant Laborde",
-				"bio": "<p>Gant Laborde is an owner of Infinite Red, mentor, adjunct professor, published author, and award-winning speaker. For 20 years, he has been involved in software development and continues strong today. He is recognized as a Google Developer Expert in Web and Machine Learning, but informally he is an “open sourcerer” and aspires to one day become a mad scientist. He blogs, videos, and maintains popular repositories for the community. Follow Gant’s adventures at <a href=\"https://gantlaborde.com/\" rel=\"noopener noreferrer\" target=\"_blank\">gantlaborde.com</a>.</p>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0201-gant.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Lucia Cerchie: Mom life and finding your confidence",
-		"slug": "0202-lucia",
-		"id": "377",
-		"metaDescription": "Season Two, Episode Two of the Virtual Coffee Podcast",
-		"season": 2,
-		"episode": 2,
-		"buzzsproutId": "8315337",
-		"publishDate": "2021-04-11T04:00:00+00:00",
-		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk with Lucia Cercie, a Software Engineer, about the importance of having a growth-mindset, asking questions, and pair programming.</p>",
-		"showNotes": "<p>In this episode of the podcast, Dan and Bekah talk with Lucia Cercie, a Software Engineer at <a href=\"https://stepzen.com/\" rel=\"noopener noreferrer\" target=\"_blank\">StepZen</a>, mom, and Arizona transplant, about the importance of having a growth-mindset, asking questions, and pair programming. We also talk about the power of community and feeling comfortable asking questions and asking for help. When she's not coding, Lucia likes to make her baby laugh.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Lucia: <a href=\"https://luciacerchie.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">luciacerchie.dev</a>, <a href=\"https://twitter.com/CerchieLucia\" rel=\"noopener noreferrer\" target=\"_blank\">@CerchieLucia</a> on Twitter, <a href=\"https://dev.to/cerchie\" rel=\"noopener noreferrer\" target=\"_blank\">cerchi</a> on DEV</p></li><li><p><a href=\"https://stepzen.com/\" rel=\"noopener noreferrer\" target=\"_blank\">StepZen</a></p></li><li><p><a href=\"https://hbr.org/2016/01/what-having-a-growth-mindset-actually-means\" rel=\"noopener noreferrer\" target=\"_blank\"><em>What Having a “Growth Mindset” Actually Means</em></a><a href=\"https://hbr.org/2016/01/what-having-a-growth-mindset-actually-means\" rel=\"noopener noreferrer\" target=\"_blank\"> </a>by Carol Dweck</p></li><li><p><a href=\"https://martinfowler.com/articles/on-pair-programming.html\" rel=\"noopener noreferrer\" target=\"_blank\"><em>On Pair Programming</em></a> by Martin Fowler</p></li><li><p><a href=\"https://www.youtube.com/watch?v=u8qgehH3kEQ\" rel=\"noopener noreferrer\" target=\"_blank\">NCIS \"pair programming\"</a></p></li><li><p><a href=\"https://lindastone.net/2014/11/24/are-you-breathing-do-you-have-email-apnea/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Are You Breathing? Do You Have Email Apnea?</em></a> by Linda Stone</p></li><li><p><a href=\"https://oisinmoran.com/quinetweet\" rel=\"noopener noreferrer\" target=\"_blank\"><em>How I Made a Self-Quoting Tweet</em></a><a href=\"https://oisinmoran.com/quinetweet\" rel=\"noopener noreferrer\" target=\"_blank\"> </a>by Oisín Moran</p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0202-lucia-episode.jpg",
-		"guests": [
-			{
-				"name": "Lucia Cerchie",
-				"bio": "<p>Lucia Cerchie is a software engineer from Phoenix, AZ. She spends a lot of time orbiting outside her comfort zone and when she's not coding, she likes to make her baby laugh.</p>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0202-lucia.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Glen McCallum: From IC to Engineering Manager, and the lessons learned along the way",
-		"slug": "0203-glen",
-		"id": "384",
-		"metaDescription": "Season Two, Episode Three of the Virtual Coffee Podcast",
-		"season": 2,
-		"episode": 3,
-		"buzzsproutId": "8370318",
-		"publishDate": "2021-04-20T04:00:00+00:00",
-		"shortDescription": "<p>In this episode, Dan and Bekah talk to Glen McCallum, a Software engineer and manager from Victoria, Canada, about his unexpected career journey, the hard decisions he's had to make, and using open-source software with his artificial pancreas.</p>",
-		"showNotes": "<p>In this episode, Dan and Bekah talk to Glen McCallum, a Software engineer from Victoria, Canada who manages a team of 8 engineers for the 2nd largest independent book distributor in the US, about his unexpected career journey, the hard decisions he's had to make, and using open-source software with his artificial pancreas. Glen also talks about his near-death experience in his first IT job and the decision to move from Independent Contributor to Management.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Glen: <a href=\"https://glenmccallum.com/\" rel=\"noopener noreferrer\" target=\"_blank\">glenmccallum.com</a>, <a href=\"https://twitter.com/glenmccallumcan\" rel=\"noopener noreferrer\" target=\"_blank\">@glenmccallumcan</a> on Twitter,</p></li><li><p>Glen's Lightning Talk: <a href=\"https://youtu.be/2hIBz5Ogi3o\" rel=\"noopener noreferrer\" target=\"_blank\">From independent contributor to engineering manager</a></p></li><li><p><a href=\"https://www.healthline.com/health/diabetesmine/innovation/we-are-not-waiting#About-the-#WeAreNotWaiting-Movement\" rel=\"noopener noreferrer\" target=\"_blank\">We are not waiting movement</a></p></li><li><p><a href=\"https://openaps.org/\" rel=\"noopener noreferrer\" target=\"_blank\">OpenAPS</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0203-glen-episode.jpg",
-		"guests": [
-			{
-				"name": "Glen McCallum",
-				"bio": "<p>Glen McCallum is a Software engineer from Victoria, Canada. For the past 7 years he's been doing backend development in C# and SQL. Earlier, he did projects in Java and Rails. He's always learning, currently exploring big data with hadoop, python, and spark. Day-to-day he manages a team of 8 engineers for the 2nd largest independent book distributor in the United States.</p>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0203-glen.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Debra-Kaye Elliott: The Self-Taught Developer Journey",
-		"slug": "0204-debra-kaye",
-		"id": "391",
-		"metaDescription": "Season Two, Episode Four of the Virtual Coffee Podcast",
-		"season": 2,
-		"episode": 4,
-		"buzzsproutId": "8413543",
-		"publishDate": "2021-04-27T04:00:00+00:00",
-		"shortDescription": "<p>In this episode of the podcast, we talk to Debra-Kaye Elliott about what it's like to be on the self-taught developer journey, imposter syndrome, and some of the key things she's learned along the way.</p>",
-		"showNotes": "<p>In this episode of the podcast, we talk to Debra-Kaye Elliott, a self-taught frontend developer making her way through Frontend Masters Web Development Bootcamp, about what it's like to be on the self-taught developer journey, how she navigates imposter syndrome, and the lessons she's learned a long the way. She talks about the impact of being able to learn with support, choosing the resources that work best for you, and how blogging has been a part of her journey.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Debra-Kaye: <a href=\"https://twitter.com/debrakayelliott\" rel=\"noopener noreferrer\" target=\"_blank\">@debrakayelliott</a> on Twitter, <a href=\"https://www.linkedin.com/in/debrakayeelliott\" rel=\"noopener noreferrer\" target=\"_blank\">@debrakayeelliott</a> on LinkedIn, and <a href=\"https://dev.to/debrakayeelliott\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/debrakayeelliott</a>.</p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0204-debra-kaye-episode.jpg",
-		"guests": [
-			{
-				"name": "Debra-Kaye Elliott",
-				"bio": "<p>Debra-Kaye Elliott is a Front End Developer going through a bootcamp, who's adding community-learning to her learning process. She's a career changer from the administrative field and always wanted to be in tech.</p>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0204-debra-kaye.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Tom Cudd - Psychological Safety and DevOps",
-		"slug": "0205-tom-cudd",
-		"id": "399",
-		"metaDescription": "Season Two, Episode Five of the Virtual Coffee Podcast",
-		"season": 2,
-		"episode": 5,
-		"buzzsproutId": "8456725",
-		"publishDate": "2021-05-04T04:00:00+00:00",
-		"shortDescription": "<p>In this episode of the podcast, we talk to Tom Cudd about his experiences with DevOps, the importance of building psychological safety in to your team building and workflows.</p>",
-		"showNotes": "<p>In this episode of the podcast, we talk to Tom Cudd, a systems architect and 20-year veteran in technology. We talked about his experiences with DevOps and how it has changed over the years, about psychological safety: what it means to Tom, and how important it is to build in to your team and workflows, and about the dangers of \"hero culture\" in the workplace.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Tom Cudd: <a href=\"https://twitter.com/tomcudd\" rel=\"noopener noreferrer\" target=\"_blank\">@tomcudd</a> on Twitter, <a href=\"https://tomcudd.com/\" rel=\"noopener noreferrer\" target=\"_blank\">tomcudd.com</a></p></li></ul><h5 class=\"text-left\"><strong>Mentioned in the Episode:</strong></h5><ul><li><p><a href=\"https://www.goodreads.com/book/show/17255186-the-phoenix-project\" rel=\"noopener noreferrer\" target=\"_blank\">The Phoenix Project</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/44333183-the-unicorn-project\" rel=\"noopener noreferrer\" target=\"_blank\">the Unicorn Project</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/18167218-lean-enterprise\" rel=\"noopener noreferrer\" target=\"_blank\">Lean Enterprise</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/35747076-accelerate\" rel=\"noopener noreferrer\" target=\"_blank\">Accelerate</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/29939161-radical-candor\" rel=\"noopener noreferrer\" target=\"_blank\">Radical Candor</a></p></li><li><p><a href=\"https://softwaresocial.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Software Social Podcast</a></p></li><li><p><a href=\"https://www.manager-tools.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Manager Tools</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0205-tomcudd-episode.jpg",
-		"guests": [
-			{
-				"name": "Tom Cudd",
-				"bio": "<p>Tom Cudd is a Systems Architect and a reformed Systems Administrator for an ad agency in the Kansas City area. He has been employed in technology for nearly 20 years, but has been using computers and the internet for most of his life. Tom is a huge fan of DevOps, lean processes, learning mindsets, and empathy with action. He also rabidly follows Husker football and the Chiefs.</p>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0205-tomcudd.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Courtney Landau - On being quiet in a loud tech world",
-		"slug": "0206-courtney-landau",
-		"id": "406",
-		"metaDescription": "Season Two, Episode Six of the Virtual Coffee Podcast",
-		"season": 2,
-		"episode": 6,
-		"buzzsproutId": "8499055",
-		"publishDate": "2021-05-11T04:00:00+00:00",
-		"shortDescription": "<p>In this episode of the podcast, we talk to Courtney Landau about how the trend of constant self-marketing in tech has impacted her career, her experience as a developer, and what's it's been like to take on a variety of roles as a Virtual Coffee contributor.</p>",
-		"showNotes": "<p>In this episode of the podcast, we talk to Courtney Landau, a software engineer currently working at an early-stage startup in the Education Technology space. We talked about her experience with being quiet in tech with the constant push for self-marketing and how she learns new things. We also dive into her experience as a mentor, speaker, lightning talk team member, and the other roles she's played as part of Virtual Coffee.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Courtney Landau: <a href=\"https://twitter.com/sosuperc\" rel=\"noopener noreferrer\" target=\"_blank\">@sosuperc</a> on Twitter, <a href=\"http://www.celandau.com/\" rel=\"noopener noreferrer\" target=\"_blank\">celandau.com</a></p></li></ul><h5 class=\"text-left\"><strong>Mentioned in the Episode:</strong></h5><ul><li><p><a href=\"https://twitter.com/sosuperc/status/1372529647947288588?s=20\" rel=\"noopener noreferrer\" target=\"_blank\">Quiet & soft-spoken =/= inexperienced.</a></p></li><li><p>Courtney's Lightning Talk from 2021: <a href=\"https://www.youtube.com/watch?v=ghFNiCMy67M\" rel=\"noopener noreferrer\" target=\"_blank\">Breaking down coding problems in interviews</a></p></li><li><p><a href=\"https://chrome.google.com/webstore/detail/learnics-teacher-link/nhdacjmkhimeohpnahfmdmcknaneeffk\" rel=\"noopener noreferrer\" target=\"_blank\">Learnics Teacher Link Chrome Extension</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0206-courtney-episode.jpg",
-		"guests": [
-			{
-				"name": "Courtney Landau",
-				"bio": "<p>Courtney is a software engineer currently working at an early-stage startup in the Education Technology space. Previously in the medical imaging field, she’s been working in the industry since 2019 after obtaining her Master’s in Information Sciences. She works on full-stack web applications using primarily TypeScript and JavaScript, built on a cloud platform. For fun she likes to run, play board games with her family, and patronize local independent restaurants and breweries.</p>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0206-courtney.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Nerando Johnson - Keeping Momentum, Community, and Socialization as a Service",
-		"slug": "0207-nerando-johnson",
-		"id": "413",
-		"metaDescription": "Season Two, Episode Seven of the Virtual Coffee Podcast",
-		"season": 2,
-		"episode": 7,
-		"buzzsproutId": "8542053",
-		"publishDate": "2021-05-18T04:00:00+00:00",
-		"shortDescription": "<p>In this episode of the podcast we talk to Nerando Johnson, a full stack developer, about running freeCodeCamp meetups in Atlanta, learning through hackathons, and how his next endeavor should be socialization as a service for tech events.</p>",
-		"showNotes": "<p>In this episode of the podcast, Dan and Bekah talk with Nerando Johnson, a full stack developer looking for his next job, about running freeCodeCamp meetups in Atlanta, learning through hackathons (including that one time his team won the hackathon and donated the $40,000 in winnings to charity) and how his next endeavor should be socialization as a service for tech events. We also talk about the importance of having a solid support system and we laugh...a lot.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Nerando Johnson: <a href=\"https://twitter.com/nerajno\" rel=\"noopener noreferrer\" target=\"_blank\">@nerajno</a> on Twitter, <a href=\"https://dev.to/nerajno/\" rel=\"noopener noreferrer\" target=\"_blank\">nerajno</a> on DEV, <a href=\"https://github.com/Nerajno\" rel=\"noopener noreferrer\" target=\"_blank\">Nerajno</a> on GitHub</p></li></ul><h5 class=\"text-left\"><strong>Mentioned in the Episode:</strong></h5><ul><li><p><a href=\"https://www.itsmarta.com/marta-hackathon.aspx\" rel=\"noopener noreferrer\" target=\"_blank\">MARTA Hackathon</a></p></li><li><p>freeCodeCamp Atlanta - <a href=\"https://www.facebook.com/groups/free.code.camp.atlanta/\" rel=\"noopener noreferrer\" target=\"_blank\">Facebook</a> - <a href=\"https://study-group-directory.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Find your FCC Meetup</a>:</p></li><li><p>Reactadelphia - <a href=\"https://twitter.com/reactadelphia\" rel=\"noopener noreferrer\" target=\"_blank\">@reactadelphia</a></p></li><li><p><a href=\"https://connect.tech/\" rel=\"noopener noreferrer\" target=\"_blank\">Connect.Tech</a></p></li><li><p><a href=\"https://twitter.com/garyvee\" rel=\"noopener noreferrer\" target=\"_blank\">Gary Vee</a></p></li><li><p><a href=\"https://twitter.com/xirclebox\" rel=\"noopener noreferrer\" target=\"_blank\">Homer Gaines</a></p></li><li><p><a href=\"https://twitter.com/techieEliot\" rel=\"noopener noreferrer\" target=\"_blank\">Eliot Sanford</a></p></li><li><p><a href=\"https://twitter.com/DThompsonDev\" rel=\"noopener noreferrer\" target=\"_blank\">Danny Thompson</a></p></li><li><p><a href=\"https://twitter.com/Career_Karma\" rel=\"noopener noreferrer\" target=\"_blank\">Career Karma</a></p></li><li><p><a href=\"https://www.jim-butcher.com/books/Dresden\" rel=\"noopener noreferrer\" target=\"_blank\">Dresden Files</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/27213329-grit\" rel=\"noopener noreferrer\" target=\"_blank\">Grit: The Power of Passion and Perseverance</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0207-nerando-episode.jpg",
-		"guests": [
-			{
-				"name": "Nerando Johnson",
-				"bio": "<p>This is Nerando, he likes to use programming to solve problems, (Yup, he is a developer). Nerando has been a community organizer for <a href=\"https://www.facebook.com/groups/free.code.camp.atlanta/\" rel=\"noopener noreferrer\" target=\"_blank\">freeCodeCamp Atlanta</a> for over the last two years. He has been to a <a href=\"https://medium.com/paratransit-pal/paratransit-pal-won-40-000-at-at-ts-atlanta-civic-coding-challenge-and-gave-it-all-to-charity-30bba157d92d\" rel=\"noopener noreferrer\" target=\"_blank\">few hackathons</a> and is <a href=\"https://dev.to/nerajno\" rel=\"noopener noreferrer\" target=\"_blank\">an infrequent blogger</a>. When not coding, Nerando enjoys coding cooking, reading, the act of creating something from nothing and consuming the odd blog or podcast about the human mind (<a href=\"https://www.npr.org/programs/\" rel=\"noopener noreferrer\" target=\"_blank\">Hi, NPR</a>).</p>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0207-nerando.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Sara McCombs - Learning to leverage your past experience and embrace your whole self",
-		"slug": "0208-sara-mccombs",
-		"id": "420",
-		"metaDescription": "Season Two, Episode Eight of the Virtual Coffee Podcast",
-		"season": 2,
-		"episode": 8,
-		"buzzsproutId": "8584928",
-		"publishDate": "2021-05-25T04:00:00+00:00",
-		"shortDescription": "<p>In this episode of the podcast we talk to Sara McCombs, a software engineer, team lead, and Community Maintainer at Virtual Coffee, about how to leverage your past experience, talk about transferable skills, and owning your wins as an early career developer.</p>",
-		"showNotes": "<p>In this episode of the podcast, Dan and Bekah talk with Sara McCombs. Sara is a software engineer and team lead at <a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a>, and also one of the original organizers, and a current Community Maintainer, at Virtual Coffee. Sara shared her thoughts on how to think and talk about transferable skills, leveraging past experience to differentiate yourself, and the importance of embracing that past experience as part of your journey and strengths. She also talked about the impact of career changes, promotions, and overcoming self-doubt.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Sara McCombs: <a href=\"https://twitter.com/dino_momma\" rel=\"noopener noreferrer\" target=\"_blank\">@dino_momma</a> on Twitter, <a href=\"https://dev.to/saramccombs/\" rel=\"noopener noreferrer\" target=\"_blank\">saramccombs</a> on DEV, <a href=\"https://github.com/saramccombs\" rel=\"noopener noreferrer\" target=\"_blank\">saramccombs</a> on GitHub</p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0208-sara-episode.jpg",
-		"guests": [
-			{
-				"name": "Sara McCombs",
-				"bio": "<p>Sara is a published former research director turned software engineer and team lead at <a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a>, as well as a community engagement leader at <a href=\"https://www.projectalloy.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Project Alloy</a>. She is also one of the original organizers, and a current community maintainer, at <a href=\"https://virtualcoffee.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee</a>. Sara is passionate about diversity and inclusion, and has written frequently about her journey into tech. She has an M.Ag and a B.S.Ag from West Virginia University, and is a 2020 graduate of Flatiron School.</p>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0208-sara.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Season Two Wrap-Up: Code and Community",
-		"slug": "0209-season-two-wrapup",
-		"id": "427",
-		"metaDescription": "Season Two, Episode Nine of the Virtual Coffee Podcast",
-		"season": 2,
-		"episode": 9,
-		"buzzsproutId": "8625475",
-		"publishDate": "2021-06-01T04:00:00+00:00",
-		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah wrap up season two by talking about what they've learned about community, supporting members, and trying to find the right tools to make it happen.</p>",
-		"showNotes": "<p>In this episode of the podcast, Dan and Bekah wrap up season two by talking about what they've learned about community building over the last year and some lessons they've learned along the way. They talk about Virtual Coffee's mission to support its members, and how Virtual Coffee's unique approach presents both challenges and opportunities when it comes to finding tools and guidance as the community grows.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p><a href=\"https://magnoliajs.com/\" rel=\"noopener noreferrer\" target=\"_blank\">MagnoliaJS</a></p></li><li><p><a href=\"https://www.radicalcandor.com/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Radical Candor</em></a> by Kim Scott</p></li><li><p><a href=\"https://twitter.com/kldickenson\" rel=\"noopener noreferrer\" target=\"_blank\">Karen Dickinson</a></p></li><li><p><a href=\"https://orbit.love/\" rel=\"noopener noreferrer\" target=\"_blank\">Orbit model</a></p></li><li><p><a href=\"https://twitter.com/MarieAntons\" rel=\"noopener noreferrer\" target=\"_blank\">Marie Antons</a></p></li><li><p><a href=\"https://twitter.com/ray_deck\" rel=\"noopener noreferrer\" target=\"_blank\">Ray Deck</a></p></li><li><p><a href=\"https://twitter.com/CerchieLucia\" rel=\"noopener noreferrer\" target=\"_blank\">Lucia Cerchie</a></p></li><li><p><a href=\"https://twitter.com/CerchieLucia/status/1397937325464723458\" rel=\"noopener noreferrer\" target=\"_blank\">Lucia's tweet about Hacktoberfest</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0209-season-2-wrapup.jpg",
-		"guests": [
-			{
-				"name": "Bekah Hawrot Weigel",
-				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dev.to/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/bekahhw</a></p></li><li><p><a href=\"https://twitter.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">@bekahhw</a> on Twitter</p></li><li><p><a href=\"https://www.instagram.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">bekahhw</a> on Instagram</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0209-bekah.jpg"
-			},
-			{
-				"name": "Dan Ott",
-				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dtott.com/\" rel=\"noopener noreferrer\" target=\"_blank\">dtott.com</a></p></li><li><p><a href=\"https://twitter.com/danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">@danieltott</a> on Twitter</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0209-dan.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Jono Yeong - Digital Gardening and Tim Tams",
-		"slug": "0301-jono-yeong",
-		"id": "444",
-		"metaDescription": "Season Three, Episode One of the Virtual Coffee Podcast",
-		"season": 3,
-		"episode": 1,
-		"buzzsproutId": "8821435",
-		"publishDate": "2021-07-06T04:00:00+00:00",
-		"shortDescription": "<p>In this episode of the podcast Bekah and Dan talk to Jono Yeong about digital gardening, learning Elixir, and how he brings learning new things to what he's doing with Rails. And for a bonus, he even walks us through how to do a proper Tim Tam slam.</p>",
-		"showNotes": "<p>In this episode of the podcast Bekah and Dan talk to Jono Yeong, a senior software engineer originally from Australia, but currently based in Seattle, USA, about how digital gardening leaves room for growth, allows you to develop what you enjoy, and is an investment in communication skills. We also talk about learning Elixir, the process he goes through as he's learning something new, and how he brings learning new things to what he's doing with Rails. Bonus: he even walks us through how to do a proper Tim Tam slam.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p><a href=\"https://www.jonathanyeong.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Jono's website</a></p></li><li><p><a href=\"https://www.descript.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Descript</a></p></li><li><p><a href=\"https://maggieappleton.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Maggie Appleton</a></p></li><li><p><a href=\"https://www.jonathanyeong.com/garden/using-github-and-notion-to-organise-side-projects\" rel=\"noopener noreferrer\" target=\"_blank\">Github and notion blogpost</a></p></li><li><p><a href=\"https://twitter.com/VicVijayakumar\" rel=\"noopener noreferrer\" target=\"_blank\">Vic Vijayakumar</a></p></li><li><p><a href=\"https://twitter.com/nickytonline\" rel=\"noopener noreferrer\" target=\"_blank\">NickyT</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=jhXJCqQBz04\" rel=\"noopener noreferrer\" target=\"_blank\">Building a social network for puppies</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=k8hEo4N8Nhs\" rel=\"noopener noreferrer\" target=\"_blank\">TimTams slams</a></p></li><li><p><a href=\"https://www.arnotts.com/products/tim-tam\" rel=\"noopener noreferrer\" target=\"_blank\">TimTams</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0301-jono-episode.jpg",
-		"guests": [
-			{
-				"name": "Jonathan Yeong",
-				"bio": "<p>Jonathan Yeong is a senior developer at Shopify. Being from Australia, he often goes by Jono. A Rubyist at heart, he blogs and produces videos about all things programming. He’s passionate about the human connections in technology. And believes that being part of a community, a mentor, and a teacher is one of the most rewarding things you can do.</p><ul><li><p><a href=\"https://twitter.com/JonoYeong\" rel=\"noopener noreferrer\" target=\"_blank\">Twitter</a></p></li><li><p><a href=\"https://www.jonathanyeong.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Website</a></p></li><li><p><a href=\"https://www.youtube.com/c/jonathanyeong\" rel=\"noopener noreferrer\" target=\"_blank\">YouTube</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0301-jono.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Abbey Perini - Finding Confidence and Opportunities",
-		"slug": "0302-abbey-perini",
-		"id": "451",
-		"metaDescription": "Season Three, Episode Two of the Virtual Coffee Podcast",
-		"season": 3,
-		"episode": 2,
-		"buzzsproutId": "8858957",
-		"publishDate": "2021-07-13T04:00:00+00:00",
-		"shortDescription": "<p>On this episode of the podcast, we talk to Abbey Perini, a full-stack web developer, about the importance of practice, building in public, and sending thank you notes when you're interviewing for your first tech job.</p>",
-		"showNotes": "<p>On this episode of the podcast, we talk to Abbey Perini, a full-stack web developer, about the impact building in public has had on her developer journey, what her experience as a recruiting admin taught her as she sent out 160 applications before landing her dev role, and how rehearsing before an interview can make a big impact.</p><h4 class=\"text-left\"><strong>Links mentioned in the episode:</strong></h4><ul><li><p>Github: <a href=\"https://github.com/abbeyperini\" rel=\"noopener noreferrer\" target=\"_blank\">https://github.com/abbeyperini</a></p></li><li><p><a href=\"https://www.indeed.com/career/salaries\" rel=\"noopener noreferrer\" target=\"_blank\">Indeed job rate checker</a></p></li><li><p>Abbey's posts mentioned:</p><ul><li><p><a href=\"https://dev.to/abbeyperini/css-animated-button-with-offset-border-1ibi\" rel=\"noopener noreferrer\" target=\"_blank\">CSS Animated Button with Offset Border</a></p></li><li><p><a href=\"https://javascript.plainenglish.io/react-redux-reload-a-page-when-a-user-makes-a-change-7661a3e1b8ed\" rel=\"noopener noreferrer\" target=\"_blank\">Sheba Counter: How To Reload a Page Whenever a User Makes a Change with React/Redux</a></p></li><li><p><a href=\"https://dev.to/abbeyperini/toggle-dark-mode-in-react-28c9\" rel=\"noopener noreferrer\" target=\"_blank\">Toggle Dark Mode in React</a></p></li><li><p><a href=\"https://dev.to/abbeyperini/knitting-as-programming-3e5\" rel=\"noopener noreferrer\" target=\"_blank\">Knitting as Programming</a></p></li><li><p><a href=\"https://dev.to/abbeyperini/practicing-confidence-for-the-job-search-38nj\" rel=\"noopener noreferrer\" target=\"_blank\">Practicing Confidence for the Job Search</a></p></li></ul></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0302-abbey-episode.jpg",
-		"guests": [
-			{
-				"name": "Abbey Perini",
-				"bio": "<p>Abbey Perini is many things - a metro Atlanta native, a person of many hobbies, and a full-stack web developer. Currently ramping up in her first development role, she loves blogging about stupid Discord bots, animated CSS buttons, and other fun and useful things about programming. You can find her work and ways to connect with her at <a href=\"https://abbeyperini.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">abbeyperini.dev</a>.</p><ul><li><p><a href=\"https://abbeyperini.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">abbeyperini.dev</a></p></li><li><p><a href=\"https://twitter.com/AbbeyPerini\" rel=\"noopener noreferrer\" target=\"_blank\">@AbbeyPerini</a> on Twitter</p></li><li><p><a href=\"https://github.com/abbeyperini\" rel=\"noopener noreferrer\" target=\"_blank\">@abbeyperini</a> on GitHub</p></li><li><p><a href=\"https://dev.to/abbeyperini\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/abbeyperini</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0302-abbey.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Ayu Adiati - Working through burnout as a self-taught developer",
-		"slug": "0303-ayu-adiati",
-		"id": "458",
-		"metaDescription": "Season Three, Episode Three of the Virtual Coffee Podcast",
-		"season": 3,
-		"episode": 3,
-		"buzzsproutId": "8893503",
-		"publishDate": "2021-07-20T04:00:00+00:00",
-		"shortDescription": "<p>In this episode, Dan and Bekah talk to Ayu about the impact of community, being a prolific blogger, and the very real challenge of burnout.</p>",
-		"showNotes": "<p>In this episode, Dan and Bekah talk to Ayu about the impact of community, being a prolific blogger, and the very real challenge of burnout. Ayu's openness about the challenges of being a mom on the self-taught track into tech, isolation, and fears of not being good enough are the stories that we don't share enough of. Because when we share, we can all work through them together. Thank you, Ayu, for reminding us that it's ok to not be ok.</p><h4 class=\"text-left\"><strong>Links mentioned in the episode:</strong></h4><ul><li><p><a href=\"https://community.codenewbie.org/adiatiayu/lesson-learned-massive-burnout-in-learning-web-development-3b5g?signin=true\" rel=\"noopener noreferrer\" target=\"_blank\">Lesson Learned: Massive Burnout In Learning Web Development</a></p></li><li><p><a href=\"https://twitter.com/AdiatiAyu/status/1400833965293019138?s=19\" rel=\"noopener noreferrer\" target=\"_blank\">Ayu's twitter thread about struggling with learning to code</a></p></li><li><p><a href=\"https://www.freecodecamp.org/learn/responsive-web-design/\" rel=\"noopener noreferrer\" target=\"_blank\">Free Code Camp - web responsive design certification</a></p></li><li><p><a href=\"https://community.codenewbie.org/codenewbie/ayu-polyglot-latte-lover-codenewbie-149m\" rel=\"noopener noreferrer\" target=\"_blank\">Ayu's CodeNewbie Community Spotlight</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0303-ayu-episode.jpg",
-		"guests": [
-			{
-				"name": "Ayu Adiati",
-				"bio": "<p>Originally from Indonesia and now based in The Netherlands, Ayu Adiati is a self-taught Frontend Developer & Technical Blogger. She’s on her way to break into tech from being a stay-at-home-mom of now a 4 years old daughter.</p><p class=\"text-left\">When Ayu is not coding, you can find her with the DLSR camera on her hands, cuddling with her daughter, or enjoying her iced macchiato latte.</p><ul><li><p><a href=\"https://virtualcoffee.io/podcast/0303-ayu-adiati/@AdiatiAyu%20(https://twitter.com/AdiatiAyu)\" rel=\"noopener noreferrer\" target=\"_blank\">Twitter</a></p></li><li><p><a href=\"https://adiati.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Blog</a></p></li><li><p><a href=\"https://dev.to/adiatiayu\" rel=\"noopener noreferrer\" target=\"_blank\">DEV</a></p></li><li><p><a href=\"https://community.codenewbie.org/adiatiayu\" rel=\"noopener noreferrer\" target=\"_blank\">CodeNewbie</a></p></li><li><p><a href=\"https://hashnode.com/@ayuadiati\" rel=\"noopener noreferrer\" target=\"_blank\">Hashnode</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0303-ayu.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Joan Marie Verba - Keeping hope through decades of challenges",
-		"slug": "0304-joan-marie-verba",
-		"id": "465",
-		"metaDescription": "Season Three, Episode Four of the Virtual Coffee Podcast",
-		"season": 3,
-		"episode": 4,
-		"buzzsproutId": "8929061",
-		"publishDate": "2021-07-27T04:00:00+00:00",
-		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk to Joan Marie Verba about her early days in tech using Fortran, and how refusal to accommodate her allergies has prevented her from having a lifelong career in tech. She talks about pushing forward and not taking no for an answer as she continues her decades-long journey into tech.</p>",
-		"showNotes": "<p>In this episode of the podcast, Dan and Bekah talk to Joan Marie Verba, a web developer, former astronomy teacher, and prolific science fiction writer, about her early days in tech using Fortran, and how refusal to accommodate her allergies has prevented her from having a lifelong career in tech. She shares the story of her recent job offer that actually turned out to be a scam that's being investigated by the FBI. But she's not done searching for her next place in tech. She's pushing past the challenges until she finds that next job.</p><h5 class=\"text-left\"><strong>Links:</strong></h5><ul><li><p><a href=\"https://www.ada.gov/\" rel=\"noopener noreferrer\" target=\"_blank\">Americans with Disabilities Act</a></p></li><li><p>Website: <a href=\"http://joanmarieverba.com/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.com</a></p></li><li><p>Blog: <a href=\"http://joanmarieverba.info/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.info</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/joanmarieverba\" rel=\"noopener noreferrer\" target=\"_blank\">@joanmarieverba</a></p></li><li><p>Web developer portfolio: <a href=\"http://joanmarieverba.co.technology/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.co.technology</a></p></li><li><p>Projects page: <a href=\"http://joanmarieverba.name/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.name</a></p></li><li><p>UX page: <a href=\"http://joanmarieverba.net/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.net</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0304-joan-episode.jpg",
-		"guests": [
-			{
-				"name": "Joan Marie Verba",
-				"bio": "<p>Joan Marie Verba earned a bachelor of physics degree from the University of Minnesota and attended the graduate school of astronomy at Indiana University, where she was an associate instructor of astronomy for one year. She has worked as a computer programmer and as an editor. She currently works as a writer, a publisher, and a web developer.</p><ul><li><p>Website: <a href=\"http://joanmarieverba.com/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.com</a></p></li><li><p>Blog: <a href=\"http://joanmarieverba.info/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.info</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/joanmarieverba\" rel=\"noopener noreferrer\" target=\"_blank\">@joanmarieverba</a></p></li><li><p>Web developer portfolio: <a href=\"http://joanmarieverba.co.technology/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.co.technology</a></p></li><li><p>Projects page: <a href=\"http://joanmarieverba.name/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.name</a></p></li><li><p>UX page: <a href=\"http://joanmarieverba.net/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.net</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0304-joan.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Kevin Truong - Tech Career Coaching",
-		"slug": "0305-kevin-truong",
-		"id": "472",
-		"metaDescription": "Season Three, Episode Five of the Virtual Coffee Podcast",
-		"season": 3,
-		"episode": 5,
-		"buzzsproutId": "8967149",
-		"publishDate": "2021-08-03T04:00:00+00:00",
-		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk to Kevin, a senior software consultant at Test Double and a coding career coach at his company Tap into Tech, about his approach to interviewing and how to navigate some of the biggest challenges early-career devs face when trying to break into the industry.</p>",
-		"showNotes": "<p>In this episode of the podcast, Dan and Bekah talk to Kevin, a senior software consultant at Test Double and a coding career coach at his company Tap into Tech, about some of the most common challenges early-career developers face getting into tech and offers practical advice for working through those problems. We dive into visualization, personal support, and ways to change the interview process in tech.</p><h5 class=\"text-left\"><strong>Links:</strong></h5><ul><li><p>Kevin's Twitter: <a href=\"https://twitter.com/TheKevinTruong\" rel=\"noopener noreferrer\" target=\"_blank\">@TheKevinTruong</a></p></li><li><p>Kevin's LinkedIn: <a href=\"https://www.linkedin.com/in/thekevintruong/\" rel=\"noopener noreferrer\" target=\"_blank\">thekevintruong</a></p></li><li><p><a href=\"https://tapintotech.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Tap into Tech</a></p></li><li><p><a href=\"https://testdouble.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Test Double</a></p></li><li><p><a href=\"http://thekevintruong.com/\" rel=\"noopener noreferrer\" target=\"_blank\">thekevintruong.com</a></p></li><li><p><a href=\"https://www.loom.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Loom</a></p></li><li><p><a href=\"https://twitter.com/terribledustin/status/1405903173684850695?s=19\" rel=\"noopener noreferrer\" target=\"_blank\">Dustin McCaffree Upwork/Loom Tweet</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0305-kevin-episode.jpg",
-		"guests": [
-			{
-				"name": "Kevin Truong",
-				"bio": "<p>Kevin Truong is a senior software consultant at Test Double and a coding career coach at his company Tap into Tech. Previously a coding boot camp instructor and mentor, Kevin realized that boot camps were missing a lot of information when it came to the final steps of getting hired. With his years of experience, he has developed a program where he has coached dozens of early career devs on how to improve their results on getting a tech job.</p><ul><li><p>Twitter: <a href=\"https://twitter.com/TheKevinTruong\" rel=\"noopener noreferrer\" target=\"_blank\">@TheKevinTruong</a></p></li><li><p>LinkedIn: <a href=\"https://www.linkedin.com/in/thekevintruong/\" rel=\"noopener noreferrer\" target=\"_blank\">thekevintruong</a></p></li><li><p><a href=\"https://tapintotech.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Tap into Tech</a></p></li><li><p><a href=\"http://thekevintruong.com/\" rel=\"noopener noreferrer\" target=\"_blank\">thekevintruong.com</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0305-kevin.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Ray Deck - Rubber-Ducking your Life",
-		"slug": "0306-ray-deck",
-		"id": "479",
-		"metaDescription": "Season Three, Episode Six of the Virtual Coffee Podcast",
-		"season": 3,
-		"episode": 6,
-		"buzzsproutId": "9007249",
-		"publishDate": "2021-08-10T04:00:00+00:00",
-		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk to Ray Deck about rubber ducking your career path, the importance of trust and relationships, and accepting that we're probably wrong more than we're right.</p>",
-		"showNotes": "<p>In this episode, Dan and Bekah talk to Ray Deck, a trained data scientist, occasional angel investor, and software entrepreneur, about finding the right career path through growth, learning, and motivation. We talk about the importance of trust and listening, and Ray drops a bunch of great resources to help everyone find their own path.</p><h5 class=\"text-left\"><strong>Favorite nonfiction books:</strong></h5><ul><li><p>Bekah's pick: <a href=\"https://allisonpataki.com/books/beauty-in-the-broken-places/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Beauty in the Broken Places</em></a><a href=\"https://allisonpataki.com/books/beauty-in-the-broken-places/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Allison Pataki</a></p></li><li><p>Bekah's second pick: <a href=\"https://drgabormate.com/book/scattered-minds/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Scattered Minds</em></a><a href=\"https://drgabormate.com/book/scattered-minds/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Dr. Gabor Maté</a></p></li><li><p>Dan's pick: <a href=\"https://www.hachettebooks.com/titles/lindy-west/shit-actually/9780316449847/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Shit, Actually</em></a><a href=\"https://www.hachettebooks.com/titles/lindy-west/shit-actually/9780316449847/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Lindy West</a></p></li><li><p>Ray's pick: <a href=\"https://www.edwardtufte.com/tufte/books_vdqi\" rel=\"noopener noreferrer\" target=\"_blank\"><em>The Visual Display of Quantitative Information</em></a><a href=\"https://www.edwardtufte.com/tufte/books_vdqi\" rel=\"noopener noreferrer\" target=\"_blank\"> by Edwarde Tufte</a></p></li></ul><h5 class=\"text-left\"><strong>Links to things mentioned in the episode:</strong></h5><ul><li><p><a href=\"https://simonsinek.com/product/start-with-why/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Start With Why</em></a><a href=\"https://simonsinek.com/product/start-with-why/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Simon Sinek</a></p></li><li><p><a href=\"https://www.franklincovey.com/the-7-habits/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>The 7 Habits of Highly Effective People</em></a><a href=\"https://www.franklincovey.com/the-7-habits/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Stephen R. Covey</a></p></li><li><p><a href=\"https://www.amazon.com/8th-Habit-Effectiveness-Greatness-Paperback/dp/B00GOHDKRI/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>The 8th Habit: From Effectiveness to Greatness</em></a><a href=\"https://www.amazon.com/8th-Habit-Effectiveness-Greatness-Paperback/dp/B00GOHDKRI/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Stephen R. Covey</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0306-ray-episode.jpg",
-		"guests": [
-			{
-				"name": "Ray Deck",
-				"bio": "<p>Ray is a trained data scientist, occasional angel investor, and software entrepreneur. His 25-year career spans industries from law to finance. Most recently, Ray is the founder of Sustained Ventures, a software product studio where he also publishes essays on technology and markets.</p><p class=\"text-left\">Ray's thoughts can be followed at <a href=\"https://sustainedventures.com/essays\" rel=\"noopener noreferrer\" target=\"_blank\">sustainedventures.com/essays</a>, and his less-thoughtful self is on Twitter <a href=\"https://twitter.com/ray_deck\" rel=\"noopener noreferrer\" target=\"_blank\">@ray_deck</a>.</p><ul><li><p><a href=\"https://sustainedventures.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Sustained Ventures</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/ray_deck\" rel=\"noopener noreferrer\" target=\"_blank\">@ray_deck</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0306-ray.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Mike Rogers - Tend Your Career like a Garden",
-		"slug": "0307-mike-rogers",
-		"id": "486",
-		"metaDescription": "Season Three, Episode Seven of the Virtual Coffee Podcast",
-		"season": 3,
-		"episode": 7,
-		"buzzsproutId": "9044559",
-		"publishDate": "2021-08-17T04:00:00+00:00",
-		"shortDescription": "<p>In this episode, Dan and Bekah are joined by Mike Rogers, to talk about changing course as a dev, and tending careers like gardens.</p>",
-		"showNotes": "<p>In this episode, Dan and Bekah are joined by Mike Rogers. Mike has had a long and successful career, but at one point he realized he no longer felt good or satisfied with where he was as a developer. He shared with us what he did to change course, and how he has learned to approach tending his career almost like a garden.</p><h5 class=\"text-left\"><strong>Links to things mentioned in the episode:</strong></h5><ul><li><p>Mike's YouTube: <a href=\"https://www.youtube.com/c/MikeRogers0\" rel=\"noopener noreferrer\" target=\"_blank\">MikeRogers0</a></p></li><li><p><a href=\"http://www.slate.com/articles/technology/technology/2012/03/ruby_ruby_on_rails_and__why_the_disappearance_of_one_of_the_world_s_most_beloved_computer_programmers_.html\" rel=\"noopener noreferrer\" target=\"_blank\">Where’s _why?</a> - What happened when one of the world’s most unusual, and beloved, computer programmers disappeared.</p></li><li><p>Meditation Minis podcast: <a href=\"https://www.meditationminis.com/\" rel=\"noopener noreferrer\" target=\"_blank\">meditationminis.com</a></p></li><li><p>Mike's Business Times cover:</p></li><li><p></p><img src=\"https://optimise2.assets-servd.host/virtual-coffee/production/images/0307-mike-bt-cover.jpg?w=378&amp;auto=compress%2Cformat&amp;fit=crop&amp;dm=1648577051&amp;s=3b73d41bc861dfe62cff7d45baac177b\" alt=\"Mike&#039;s cover on the Business Times\" title=\"\"></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0307-mike-episode.jpg",
-		"guests": [
-			{
-				"name": "Mike Rogers",
-				"bio": "<p>Mike Rogers is a Ruby developer from the UK. He made the chat bots for Virtual Coffee, has an awesome Ruby Event Calendar, and loves Docker.</p><ul><li><p><a href=\"https://mikerogers.io/\" rel=\"noopener noreferrer\" target=\"_blank\">mikerogers.io</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/mikerogers0\" rel=\"noopener noreferrer\" target=\"_blank\">mikerogers0</a></p></li><li><p>GitHub: <a href=\"https://github.com/MikeRogers0\" rel=\"noopener noreferrer\" target=\"_blank\">MikeRogers0</a></p></li><li><p>YouTube: <a href=\"https://www.youtube.com/c/MikeRogers0\" rel=\"noopener noreferrer\" target=\"_blank\">MikeRogers0</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0307-mike.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Aurelie Verrot - Learning and Working Remotely",
-		"slug": "0308-aurelie-verrot",
-		"id": "494",
-		"metaDescription": "Season Three, Episode Eight of the Virtual Coffee Podcast",
-		"season": 3,
-		"episode": 8,
-		"buzzsproutId": "9080882",
-		"publishDate": "2021-08-24T04:00:00+00:00",
-		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah are joined by Aurelie Verrot to talk about working through bootcamp during the pandemic, remote work, and how to \"just be cool\" when you're dealing with challenges like the pandemic, virtual school, and remote work.</p>",
-		"showNotes": "<p>In this episode, Dan and Bekah talk to Aurelie Verrot, a Software Engineer from the San Francisco Bay Area, who's originally from France, about the importance of relationships in team-building--whether as part of the learning process or in a work environment--and the benefits of being able to work from home. She talks about the importance of clear communication, creating boundaries, and maintaining flexibility as key habits to build.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Twitter: <a href=\"https://twitter.com/LiliVerrot\" rel=\"noopener noreferrer\" target=\"_blank\">LiliVerrot</a></p></li><li><p>GitHub: <a href=\"https://github.com/aurelieverrot\" rel=\"noopener noreferrer\" target=\"_blank\">aurelieverrot</a></p></li><li><p>LinkedIn: <a href=\"https://www.linkedin.com/in/aurelieverrot/\" rel=\"noopener noreferrer\" target=\"_blank\">aurelieverrot</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0308-aurelie-episode.jpg",
-		"guests": [
-			{
-				"name": "Aurelie Verrot",
-				"bio": "<p>Aurelie Verrot is a software engineer from the San Francisco Bay Area, originally from France. After moving to the US and taking care of her children for 4 years, she decided to make a career change in 2019 to work in tech. She started her first dev job in May as a Software Engineer working mostly with Ruby on Rails.</p><ul><li><p>Twitter: <a href=\"https://twitter.com/LiliVerrot\" rel=\"noopener noreferrer\" target=\"_blank\">LiliVerrot</a></p></li><li><p>GitHub: <a href=\"https://github.com/aurelieverrot\" rel=\"noopener noreferrer\" target=\"_blank\">aurelieverrot</a></p></li><li><p>LinkedIn: <a href=\"https://www.linkedin.com/in/aurelieverrot/\" rel=\"noopener noreferrer\" target=\"_blank\">aurelieverrot</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0308-aurelie.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Season 3 Wrap Up: Hacktoberfest is Coming!",
-		"slug": "0309-season-three-wrap-up",
-		"id": "503",
-		"metaDescription": "Season Three, Episode Nine of the Virtual Coffee Podcast",
-		"season": 3,
-		"episode": 9,
-		"buzzsproutId": "9124000",
-		"publishDate": "2021-09-01T04:00:00+00:00",
-		"shortDescription": "<p>Community Maintainer Kirk joins us (again) for our Season 3 wrap up and Hacktoberfest preview!</p>",
-		"showNotes": "<p>Community Maintainer Kirk joins us (again) for our Season 3 wrap up! We review what Virtual Coffee did last year for Hacktoberfest, and talk about a lot of the exciting things we have coming up this year! We also shared some fun things from the last year at Virtual Coffee, like our Virtual Coffee Co-Working Room!</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p><a href=\"https://apps.apple.com/us/app/classic-sudoku/id1488838275\" rel=\"noopener noreferrer\" target=\"_blank\">Classic Sudoku</a></p></li><li><p><a href=\"https://www.youtube.com/channel/UCC-UOdK8-mIjxBQm_ot1T-Q\" rel=\"noopener noreferrer\" target=\"_blank\">Cracking the Cryptic</a></p></li><li><p><a href=\"https://twitter.com/MarieAntons\" rel=\"noopener noreferrer\" target=\"_blank\">@MarieAntons</a></p></li><li><p>Tatiana Mac - <a href=\"https://github.com/selfdefined\" rel=\"noopener noreferrer\" target=\"_blank\">selfdefined</a></p></li><li><p><a href=\"https://github.com/dominicduffin1/Quarto\" rel=\"noopener noreferrer\" target=\"_blank\">Quarto by Dominic Duffin</a></p></li><li><p><a href=\"https://github.com/BekahHW/postpartum-wellness-app\" rel=\"noopener noreferrer\" target=\"_blank\">Bekah's postpartum wellness app</a></p></li><li><p><a href=\"https://github.com/Virtual-Coffee/virtualcoffee.io\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee's GitHub Org</a></p></li><li><p><a href=\"https://hacktoberfest.digitalocean.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Hacktoberfest on Digital Ocean</a></p></li><li><p>shoutout to our Monthly Challenge team: Adam, Andrew, Aurelie, Chris, Courtney, Dominic, Kevin, Luis, Vanessa, and Yolanda!</p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0309-hacktoberfest.jpg",
-		"guests": [
-			{
-				"name": "Kirk Shillingford",
-				"bio": "<p>Software Developer, and Community Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://twitter.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0108-kirk.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Jessi Shakarian - You aren't your tech stack: sharing your passion",
-		"slug": "0401-jessi-shakarian",
-		"id": "510",
-		"metaDescription": "Season Four, Episode One of the Virtual Coffee Podcast",
-		"season": 4,
-		"episode": 1,
-		"buzzsproutId": "9322612",
-		"publishDate": "2021-10-06T04:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Jessi Shakarian about her journey into UX/UI and how that lead to the big energy she needed to find her place in tech.</p>",
-		"showNotes": "<p>We welcome Jessi Shakarian to the show today to talk about her journey into UX/UI!</p><p class=\"text-left\">Jessi talks about how passion can be your motivation, and how valuable it is to be able to share what you're excited about: you aren't your tech stack. Sometimes finding that passion can lead you to new and interesting places like Jessi's change in focus from web dev to design.</p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0401-jessi-episode.png",
-		"guests": [
-			{
-				"name": "Jessi Shakarian",
-				"bio": "<p>Jessi Shakarian got her start in tech as a developer, but also she loved everything that happened before it was time to build a website. She is currently a UX designer at DIA Design Guild in Los Angeles and a python developer interested in machine learning.</p><ul><li><p><a href=\"https://www.jessishakarian.com/\" rel=\"noopener noreferrer\" target=\"_blank\">jessishakarian.com</a></p></li><li><p><a href=\"https://twitter.com/jessishakarian\" rel=\"noopener noreferrer\" target=\"_blank\">@jessishakarian</a> on Twitter</p></li><li><p><a href=\"https://www.polywork.com/jessishakarian\" rel=\"noopener noreferrer\" target=\"_blank\">jessishakarian</a> on PolyWork</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0401-jessi.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Todd Libby - Making the web equal and accessible",
-		"slug": "0402-todd-libby",
-		"id": "517",
-		"metaDescription": "Season Four, Episode Two of the Virtual Coffee Podcast",
-		"season": 4,
-		"episode": 2,
-		"buzzsproutId": "9355176",
-		"publishDate": "2021-10-12T04:00:00+00:00",
-		"shortDescription": "<p>This week on the podcast, we have Todd Libby talking about his work making the web equal and accessible for everyone. He drops a ton of resources (check the show notes!) tips on how to get started, and talks about how he's continually learning on the job.</p>",
-		"showNotes": "<p>We're welcoming Todd Libby to give us an intro to accessibility and what it means to make the web equal. Todd, a professional web developer, designer, and accessibility advocate for 22 years, provides a plethora of resources that can help everyone to get started and talks about how to advocate for accessibility and equality on projects.</p><h3><strong>Show Notes:</strong></h3><h4 class=\"text-left\"><strong>Things/People mentioned in the episode:</strong></h4><ul><li><p><a href=\"https://www.smashingmagazine.com/2021/07/strong-case-for-accessibility/\" rel=\"noopener noreferrer\" target=\"_blank\">Making A Strong Case for Accessibility</a> by Todd Libby</p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Microsoft_FrontPage\" rel=\"noopener noreferrer\" target=\"_blank\">Front Page Express</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Designing_with_Web_Standards\" rel=\"noopener noreferrer\" target=\"_blank\">Designing with Web Standards</a></p></li><li><p><a href=\"https://www.w3.org/WAI/standards-guidelines/wcag/\" rel=\"noopener noreferrer\" target=\"_blank\">Web Content Accessibility Guidelines (WCAG)</a></p></li><li><p><a href=\"https://twitter.com/cassandrafaris\" rel=\"noopener noreferrer\" target=\"_blank\">Cass Faris</a></p></li><li><p><a href=\"https://twitter.com/saltnburnem\" rel=\"noopener noreferrer\" target=\"_blank\">Chris DeMars</a></p></li></ul><h4 class=\"text-left\"><strong>A11y Learning Resources:</strong></h4><ul><li><p><a href=\"https://www.edx.org/course/web-accessibility-introduction\" rel=\"noopener noreferrer\" target=\"_blank\">Introduction to Web Accessibility</a> on edX</p></li><li><p><a href=\"https://webaim.org/\" rel=\"noopener noreferrer\" target=\"_blank\">WebAIM</a></p></li><li><p><a href=\"https://www.tpgi.com/\" rel=\"noopener noreferrer\" target=\"_blank\">TPGi</a></p></li></ul><h4 class=\"text-left\"><strong>Tools:</strong></h4><ul><li><p><a href=\"https://wave.webaim.org/extension/\" rel=\"noopener noreferrer\" target=\"_blank\">WAVE Web Accessibility Evaluation Tool</a></p></li><li><p><a href=\"https://www.deque.com/axe/\" rel=\"noopener noreferrer\" target=\"_blank\">axe accessibility toolkit</a></p></li><li><p><a href=\"https://pa11y.org/\" rel=\"noopener noreferrer\" target=\"_blank\">pa11y command line</a></p></li><li><p><a href=\"https://pauljadam.com/bookmarklets/tables.html\" rel=\"noopener noreferrer\" target=\"_blank\">Bookmarklets by Ian Loyyd and Paul J Adams</a></p></li><li><p><a href=\"https://github.com/microsoft/accessibility-insights-web\" rel=\"noopener noreferrer\" target=\"_blank\">Microsoft a11y insights</a></p></li><li><p><a href=\"https://developer.mozilla.org/en-US/docs/Tools/Accessibility_inspector\" rel=\"noopener noreferrer\" target=\"_blank\">Firefox a11y devtools</a></p></li><li><p><a href=\"https://developers.google.com/web/tools/lighthouse\" rel=\"noopener noreferrer\" target=\"_blank\">Lighthouse automated testing</a></p></li><li><p><a href=\"https://contrast-ratio.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Contrast Ratio tool by Lea Verou</a></p></li><li><p><a href=\"https://www.tpgi.com/color-contrast-checker/\" rel=\"noopener noreferrer\" target=\"_blank\">Colour Contrast Analyser</a></p></li></ul><h4 class=\"text-left\"><strong>Todd's steps for manual testing:</strong></h4><ol start=\"1\"><li><p>Mouse only</p></li><li><p>Keyboard only</p></li><li><p>Squint test</p></li><li><p><a href=\"https://www.afb.org/blindness-and-low-vision/using-technology/assistive-technology-products/screen-readers\" rel=\"noopener noreferrer\" target=\"_blank\">Screen readers</a></p></li><li><p><a href=\"https://webaim.org/articles/voiceover/\" rel=\"noopener noreferrer\" target=\"_blank\">Voice over in Safari</a></p></li><li><p><a href=\"https://www.nvaccess.org/\" rel=\"noopener noreferrer\" target=\"_blank\">NVDA</a> and <a href=\"https://www.freedomscientific.com/products/software/jaws/\" rel=\"noopener noreferrer\" target=\"_blank\">JAWS</a> on Windows</p></li><li><p><a href=\"https://help.gnome.org/users/orca/stable/introduction.html.en\" rel=\"noopener noreferrer\" target=\"_blank\">Orca</a> on Linux</p></li></ol>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0402-todd-episode.jpg",
-		"guests": [
-			{
-				"name": "Todd Libby",
-				"bio": "<p>Todd is a professional web developer, designer, and accessibility advocate for 22 years under many different technologies starting with HTML/CSS, Perl, and PHP, Todd has been an avid learner of web technologies for over 40 years starting with many flavors of BASIC all the way to React/Vue. Todd is also a member of the W3C working with groups on WCAG Silver (3.0). When not coding or advocating accessibility, you'll usually find Todd tweeting about (or eating) lobster rolls and accessibility.</p><ul><li><p><a href=\"https://toddl.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">toddl.dev</a></p></li><li><p><a href=\"https://twitter.com/toddlibby\" rel=\"noopener noreferrer\" target=\"_blank\">@toddlibby</a> on Twitter</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0402-todd.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Jennifer Konikowski - Hot Takes on Being a Woman in Tech",
-		"slug": "0403-jennifer-konikowski",
-		"id": "524",
-		"metaDescription": "Season Four, Episode Three of the Virtual Coffee Podcast",
-		"season": 4,
-		"episode": 3,
-		"buzzsproutId": "9396120",
-		"publishDate": "2021-10-19T04:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Jennifer Konikowski about building community for women in tech and her own experience as a woman in tech. She gives us some of her hot takes, and we are here for it 🔥</p>",
-		"showNotes": "<p>This week we welcome Jennifer Konikowski to the show to talk about being a woman in tech and building community for women in tech!</p><p class=\"text-left\">Jennifer brings her experience creating communities like <a href=\"http://www.meetup.com/pyladies-boston/\" rel=\"noopener noreferrer\" target=\"_blank\">Py Ladies Boston</a> and <a href=\"https://www.meetup.com/Boston-Ruby-Women/\" rel=\"noopener noreferrer\" target=\"_blank\">Boston Ruby Women</a> to the podcast, and talks about the value of learning to code even if you don't want to be a developer. She also talks about getting through toxic work environments, moving forward, and her hot takes on community and being a woman in tech.</p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0403-jennifer-episode.jpg",
-		"guests": [
-			{
-				"name": "Jennifer Konikowski",
-				"bio": "<p>Jennifer has 10 years of experience as a software engineer, working in Ruby and Rails, Go, Swift, Scala, Rust, PHP, Javascript, Java, Perl, and Python. She was the founder and organizer of PyLadies Boston and a founding member of Boston Ruby Women. She currently resides in Pittsburgh and works remotely at Splice. She also really loves Negronis.</p><ul><li><p><a href=\"https://jenniferkonikowski.com/\" rel=\"noopener noreferrer\" target=\"_blank\">jenniferkonikowski.com</a></p></li><li><p><a href=\"https://twitter.com/jenkoni\" rel=\"noopener noreferrer\" target=\"_blank\">@jenkoni</a> on Twitter</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0403-jennifer.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Mark Noonan - Civic tech, accessibility, holding the door open for other career changers",
-		"slug": "0404-mark-noonan",
-		"id": "531",
-		"metaDescription": "Season Four, Episode Four of the Virtual Coffee Podcast",
-		"season": 4,
-		"episode": 4,
-		"buzzsproutId": "9442638",
-		"publishDate": "2021-10-27T04:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Mark Noonan about how we can make space for career changers through Civic Tech while we make an impact on our communities.</p>",
-		"showNotes": "<p>This week we welcome Mark Noonan to the show to talk about how becoming a part of Civic Tech initiatives can help career changers to grow and help existing developers create opportunities for mentorship, support, and connection for those coming into tech.</p><p class=\"text-left\">Mark talks about his experience with <a href=\"https://www.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">FreeCodeCamp</a> as well as <a href=\"https://www.codeforatlanta.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Code for Atlanta</a>, and the $40,000 Hackathon his group won and donated to charity! He brings his experience as a career transitioner to the conversation and we look at how participating in Civic Tech can help you develop skills to be a better communicator and programmer. And you might hear a little bit about how we prefer our breakfast foods too 🥞</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://www.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">FreeCodeCamp</a></p></li><li><p><a href=\"https://www.codeforatlanta.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Code for Atlanta</a></p></li><li><p><a href=\"https://www.codeforamerica.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Code for America</a></p></li><li><p><a href=\"https://medium.com/paratransit-pal/paratransit-pal-won-40-000-at-at-ts-atlanta-civic-coding-challenge-and-gave-it-all-to-charity-30bba157d92d\" rel=\"noopener noreferrer\" target=\"_blank\">Marta Hackathon</a></p></li><li><p><a href=\"https://brigade.codeforamerica.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Code for America Brigades</a></p></li><li><p><a href=\"http://peoplemakingprogress.org/\" rel=\"noopener noreferrer\" target=\"_blank\">People Making Progress</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0404-mark-episode.jpg",
-		"guests": [
-			{
-				"name": "Mark Noonan",
-				"bio": "<p>Mark is a senior engineer at Cypress.io and is a co-organizer at Code for Atlanta. He also works as a program developer for People Making Progress, an Atlanta-based nonprofit serving adults with developmental disabilities at home, work, and in the community.</p><ul><li><p><a href=\"https://twitter.com/marktnoonan\" rel=\"noopener noreferrer\" target=\"_blank\">@marktnoonan</a> on Twitter</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0404-mark.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Suze Shardlow - Creating welcoming spaces in dev communities",
-		"slug": "0405-suze-shardlow",
-		"id": "540",
-		"metaDescription": "Season Four, Episode Five of the Virtual Coffee Podcast",
-		"season": 4,
-		"episode": 5,
-		"buzzsproutId": "9487228",
-		"publishDate": "2021-11-03T04:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Suze Shardlow about how she approaches creating welcoming spaces in dev communities.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Suze Shardlow. Suze is an award winning community manager, coder, tech writer and tech event MC and she currently leads the developer community at <a href=\"https://redis.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Redis</a>. We had a really interesting conversation with Suze! She's done a million different things throughout her life and her career and she shared with us how her experiences have informed her time as a software developer and a community leader.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://www.goodreads.com/book/show/56638386-30-second-coding?from_search=true&amp;from_srp=true&amp;qid=kCeXU2k1Tx&amp;rank=1\" rel=\"noopener noreferrer\" target=\"_blank\">30-second-coding</a></p></li><li><p><a href=\"https://twitter.com/SuzeShardlow/status/1445413709891973121?s=20\" rel=\"noopener noreferrer\" target=\"_blank\">On being a published author</a></p></li><li><p><a href=\"https://www.twitch.tv/redislabs\" rel=\"noopener noreferrer\" target=\"_blank\">redislabs on Twitch</a></p></li><li><p><a href=\"https://suze.dev/blog/im-a-techwomen100-2020-winner/\" rel=\"noopener noreferrer\" target=\"_blank\">One of the top 100 women in tech in 2020</a></p></li><li><p><a href=\"https://university.redis.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Redis University</a></p></li><li><p><a href=\"https://hacktoberfest.digitalocean.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Hacktoberfest</a></p></li><li><p><a href=\"https://codelandconf.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Codeland</a></p></li><li><p><a href=\"https://t.co/G0RN3vx2Gd?amp=1\" rel=\"noopener noreferrer\" target=\"_blank\">global diversity CFP day</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0405-suze-episode.jpg",
-		"guests": [
-			{
-				"name": "Suze Shardlow",
-				"bio": "<p>Suze Shardlow is a published tech author, developer community manager and event MC. Before retraining as a software engineer, she worked in marketing and management for 20 years in the engineering, technology, law enforcement, education and economic development sectors. Currently the head of developer community at Redis, Suze has won numerous awards including Rising Star In Tech 2021, TechWomen100 2020, Women In Software Power List 2020 and is a finalist in the Women In Tech Excellence Awards 2021.</p><ul><li><p><a href=\"https://suze.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">suze.dev</a></p></li><li><p><a href=\"https://twitter.com/SuzeShardlow\" rel=\"noopener noreferrer\" target=\"_blank\">@SuzeShardlow</a> on Twitter</p></li><li><p><a href=\"https://github.com/SuzeShardlow\" rel=\"noopener noreferrer\" target=\"_blank\">@SuzeShardlow</a> on GitHub</p></li><li><p><a href=\"https://www.linkedin.com/in/SuzeShardlow\" rel=\"noopener noreferrer\" target=\"_blank\">SuzeShardlow</a> on LinkedIn</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0405-suze.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Bryan Healey - The Entrepreneurial Journey of a Startup Founder",
-		"slug": "0406-bryan-healey",
-		"id": "547",
-		"metaDescription": "Season Four, Episode Six of the Virtual Coffee Podcast",
-		"season": 4,
-		"episode": 6,
-		"buzzsproutId": "9522643",
-		"publishDate": "2021-11-10T05:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Bryan Healey about how to kickoff your career as a start-up founder and the lessons he's learned along the way.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Bryan Healey, an entrepreneur, tech leader, data scientist / ML engineer, and biz developer. Bryan talks about gaining experience as an entrepreneur, how to get started in the start-up life, and how the entrepreneurial spirit has always been in his blood.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a></p></li><li><p><a href=\"https://virtualcoffee.io/podcast/0401-jessi-shakarian/\" rel=\"noopener noreferrer\" target=\"_blank\">Jessi's VC Podcast episode</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0406-bryan-episode.jpg",
-		"guests": [
-			{
-				"name": "Bryan Healey",
-				"bio": "<p>Bryan Healey is an entrepreneur, tech leader, data scientist / ML engineer, and biz developer. He's helped create or grow several start-ups, raised money, and built/managed teams of varying sizes, small to large. Currently co-founder and CTO at <a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a>.</p><ul><li><p><a href=\"https://twitter.com/Bryan_Healey\" rel=\"noopener noreferrer\" target=\"_blank\">@Bryan_Healey</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/bryanhealey\" rel=\"noopener noreferrer\" target=\"_blank\">bryanhealey</a> on LinkedIn</p></li><li><p><a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0406-bryan.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Jessica Wilkins - Growing your tech career through writing",
-		"slug": "0407-jessica-wilkins",
-		"id": "554",
-		"metaDescription": "Season Four, Episode Seven of the Virtual Coffee Podcast",
-		"season": 4,
-		"episode": 7,
-		"buzzsproutId": "9566513",
-		"publishDate": "2021-11-17T05:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Jessica Wilkins about how writing can help you to grow your tech career. She gives us tips on getting started and on taking feedback.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Jessica Wilkins, a self-taught developer and a staff author for the freeCodeCamp News publication. Jessica talks about how to get started with tech writing, how to differentiate between constructive criticism and negative feedback, and how to avoid gatekeeping by eliminating assumptions from your writing, avoiding terms and phrases like \"it's so easy!\", and sometimes adding prerequisites to your posts.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://www.esm.rochester.edu/\" rel=\"noopener noreferrer\" target=\"_blank\">Eastman School of Music</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=hD6uRvCtA_0&amp;t=70s\" rel=\"noopener noreferrer\" target=\"_blank\">Jessica's Lunch & Learn: How to grow your tech career through writing</a></p></li><li><p><a href=\"https://www.freecodecamp.org/news/author/jessica-wilkins/\" rel=\"noopener noreferrer\" target=\"_blank\">Freecodecamp news</a></p></li><li><p><a href=\"https://forum.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Freecodecamp forum</a></p></li><li><p><a href=\"https://www.freecodecamp.org/news/author/quincylarson/\" rel=\"noopener noreferrer\" target=\"_blank\">Quincy Larson</a></p></li><li><p><a href=\"https://www.history.com/this-day-in-history/george-floyd-killed-by-police-officer\" rel=\"noopener noreferrer\" target=\"_blank\">George Floyd murder</a></p></li><li><p><a href=\"https://blackexcellencemusicproject.com/\" rel=\"noopener noreferrer\" target=\"_blank\">The Black Excellence Music Project</a></p></li><li><p><a href=\"https://github.com/jdwilkin4/Black_Excellence_Project\" rel=\"noopener noreferrer\" target=\"_blank\">Github for it</a></p></li><li><p><a href=\"https://virtualcoffee.io/monthlychallenges/nov-2021/\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee November Monthly Challenge</a></p></li><li><p><a href=\"https://www.gatsbyjs.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Gatsby</a></p></li><li><p><a href=\"https://www.gatsbyjs.com/blog/gatsby-voices-jessica-wilkins/\" rel=\"noopener noreferrer\" target=\"_blank\">Voices of Gatsby: Fighting Back Against Imposter Syndrome</a></p></li><li><p><a href=\"https://www.freecodecamp.org/news/how-to-use-replit/\" rel=\"noopener noreferrer\" target=\"_blank\">How to Use Repl.it: a beginner's guide</a></p></li><li><p><a href=\"https://www.freecodecamp.org/news/how-to-use-codepen/\" rel=\"noopener noreferrer\" target=\"_blank\">How to Use Codepen: a beginner's guide</a></p></li><li><p><a href=\"https://dev.to/codergirl1991/how-to-create-a-node-bot-that-sends-happy-emails-throughout-the-year-25nj\" rel=\"noopener noreferrer\" target=\"_blank\">NodeMailer</a></p></li></ul><p><br></p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0407-jessica-episode.jpg",
-		"guests": [
-			{
-				"name": "Jessica Wilkins",
-				"bio": "<p>Jessica Wilkins is a self taught developer and technical writer from Los Angeles, California.</p><p class=\"text-left\">In her previous career, she was a professional oboist, educator and owner of JDW Sheet Music.</p><p class=\"text-left\">Jessica's interest in programming came during the pandemic when she wanted to build the Black Excellence Music Project which celebrates black artists from the jazz and classical fields.</p><p class=\"text-left\">She now works part-time as a junior developer for a small tech company and is a staff author for the freeCodeCamp News publication.</p><ul><li><p><a href=\"https://dev.to/codergirl1991\" rel=\"noopener noreferrer\" target=\"_blank\">Dev.to profile</a></p></li><li><p><a href=\"https://twitter.com/codergirl1991\" rel=\"noopener noreferrer\" target=\"_blank\">@codergirl1991 on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/jessica-wilkins-developer\" rel=\"noopener noreferrer\" target=\"_blank\">@jessica-wilkins-developer on LinkedIn</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0407-jessica.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Maeling Murphy - Transitioning to tech, and taking notes along the way",
-		"slug": "0408-maeling-murphy",
-		"id": "561",
-		"metaDescription": "Season Four, Episode Eight of the Virtual Coffee Podcast",
-		"season": 4,
-		"episode": 8,
-		"buzzsproutId": "9600325",
-		"publishDate": "2021-11-23T05:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Maeling Murphy about her journey from Material Science and Engineering to Software Engineering, including her personal documentation of her tech journey, work culture, and the big surprises when starting her job.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Dr. Maeling Murphy, a software engineer who recently transitioned into tech. Maeling shared the importance of connecting with potential employers to see if they would fit her values, how contributing to open source projects can help prepare you for your first job, and the value of developing the connection to community and being able to grow alongside others. Oh, and did we mention we talked a lot about Notion? She takes us through her notetaking journey and answers all our questions about finding the right approach.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://cs50.harvard.edu/\" rel=\"noopener noreferrer\" target=\"_blank\">Harvard's CS50</a></p></li><li><p><a href=\"https://www.100daysofcode.com/\" rel=\"noopener noreferrer\" target=\"_blank\">100 days of code</a></p></li><li><p><a href=\"https://virtualcoffee.io/monthlychallenges/july-2021/\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee Demo Monthly Challenge</a></p></li><li><p><a href=\"https://homeschool-journal.herokuapp.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Homeschool journal</a></p></li><li><p><a href=\"https://github.com/maelingmurphy\" rel=\"noopener noreferrer\" target=\"_blank\">Github</a></p></li><li><p><a href=\"https://github.com/maelingmurphy/My-Learning-Path/blob/main/log.md\" rel=\"noopener noreferrer\" target=\"_blank\">Learning Path log</a></p></li><li><p><a href=\"https://www.notion.so/templates/job-applications\" rel=\"noopener noreferrer\" target=\"_blank\">Karen's Notion for job searches</a></p></li><li><p><a href=\"https://docs.google.com/spreadsheets/d/1ZP0u5MjRiCOaYWuLoRTYr4BvB91M76ZCjkCYPuSePJc/edit?usp=sharing\" rel=\"noopener noreferrer\" target=\"_blank\">Karen's Job Application Details Spreadsheet</a></p></li><li><p><a href=\"https://www.notion.so/Thomas-Frank-s-Note-Taking-System-67924a5a25934f0fbe2f154cffcd8f97\" rel=\"noopener noreferrer\" target=\"_blank\">Frank's Notetaking System</a></p></li><li><p><a href=\"https://www.keyvalues.com/\" rel=\"noopener noreferrer\" target=\"_blank\">KeyValues: Find engineering teams that share your values</a></p></li><li><p><a href=\"https://pinboard.in/u:danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">Dan's Pinboard bookmarks</a></p></li><li><p><a href=\"https://github.com/forem/forem\" rel=\"noopener noreferrer\" target=\"_blank\">Forem</a> - Open source project that Nick Taylor helps maintain</p></li></ul><p><br></p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0408-maeling-episode.jpg",
-		"guests": [
-			{
-				"name": "Maeling Murphy",
-				"bio": "<p>Dr. Maeling Murphy is a software engineer who recently transitioned into tech, coming from an 8+ year entrepreneurial journey as a digital content creator and as a Ph.D. research scientist in Materials Science & Engineering.</p><p class=\"text-left\">Maeling identifies as a multi-passionate creative soul, finding expression through gardening, programming, brush-lettering and other mediums that cross her path.</p><p class=\"text-left\">She lets her love for exploration, learning and sharing with others lead her in all aspects of life and is enjoying this journey with her husband and son.</p><ul><li><p><a href=\"https://github.com/maelingmurphy\" rel=\"noopener noreferrer\" target=\"_blank\">maelingmurphy</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/maelingcodes\" rel=\"noopener noreferrer\" target=\"_blank\">@maelingcodes on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/maeling-murphy\" rel=\"noopener noreferrer\" target=\"_blank\">@maeling-murphy on LinkedIn</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0408-maeling.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Season 4 Wrap Up - Reviewing the year and celebrating our community",
-		"slug": "0409-season-four-wrapup",
-		"id": "568",
-		"metaDescription": "Season 4 Wrap Up - Reviewing the year and celebrating our community",
-		"season": 4,
-		"episode": 9,
-		"buzzsproutId": "9650635",
-		"publishDate": "2021-12-02T05:00:00+00:00",
-		"shortDescription": "<p>In this final episode of season 4 of the podcast, Bekah and Dan bring back special guest and community maintainer, Kirk Shillingford to retro our Virtual Coffee Hacktoberfest Initiative, talk about our monthly challenges and our excitement of going into year 2 of the challenges, and we even throw in some amazing and/or awful jokes at the end.</p>",
-		"showNotes": "<p>Kirk, Dan, and Bekah are back again to wrap up Season 4 of the podcast. We talk about Hacktoberfest and how proud we are of what our community did over the month of Hacktoberfest:</p><ul><li><p>100 members signed up,</p></li><li><p>66 members merged at least 1 pr,</p></li><li><p>336 collectively we merged 336 PRs were merged by these members across 129 repos.</p></li></ul><p class=\"text-left\">On the <a href=\"https://virtualcoffee.io/\" rel=\"noopener noreferrer\" target=\"_blank\">virtualcoffee.io</a> site: 81 PRs merged, 50 were new member profiles, 31 others.</p><p class=\"text-left\">We talk about the monthly challenges, including already surpassing the monthly goal for blogging half way through <a href=\"https://virtualcoffee.io/monthlychallenges/nov-2021/\" rel=\"noopener noreferrer\" target=\"_blank\">November</a>, and what we're looking forward to doing in the next 12 months.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://hacktoberfest.digitalocean.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Digital Ocean Hacktoberfest</a></p></li><li><p><a href=\"https://virtualcoffee.io/podcast/0406-bryan-healey/\" rel=\"noopener noreferrer\" target=\"_blank\">Bryan's Episode</a></p></li><li><p><a href=\"https://github.com/colabottles/\" rel=\"noopener noreferrer\" target=\"_blank\">Todd Libby</a></p></li><li><p><a href=\"https://github.com/abbeyperini\" rel=\"noopener noreferrer\" target=\"_blank\">Abbey Perini</a></p></li><li><p><a href=\"https://github.com/MattyMc\" rel=\"noopener noreferrer\" target=\"_blank\">Matt McInnis</a></p></li><li><p><a href=\"https://prettier.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Prettier</a></p></li><li><p><a href=\"https://virtualcoffee.io/podcast/0407-jessica-wilkins/\" rel=\"noopener noreferrer\" target=\"_blank\">Jessica's Episode</a></p></li><li><p><a href=\"https://chrisbrogan.com/stories/community/audience-or-community/\" rel=\"noopener noreferrer\" target=\"_blank\">Audience or Community by Chris Brogan</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-episode.jpg",
-		"guests": [
-			{
-				"name": "Kirk Shillingford",
-				"bio": "<p>Software Developer, and Community Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://github.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-kirk.jpg"
-			},
-			{
-				"name": "Bekah Hawrot Weigel",
-				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dev.to/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/bekahhw</a></p></li><li><p><a href=\"https://twitter.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">@bekahhw</a> on Twitter</p></li><li><p><a href=\"https://www.instagram.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">bekahhw</a> on Instagram</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0209-bekah.jpg"
-			},
-			{
-				"name": "Dan Ott",
-				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dtott.com/\" rel=\"noopener noreferrer\" target=\"_blank\">dtott.com</a></p></li><li><p><a href=\"https://twitter.com/danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">@danieltott</a> on Twitter</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-dan.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Brian Rinaldi - Developer Advocacy and Fostering Community",
-		"slug": "0501-brian-rinaldi",
-		"id": "180",
-		"metaDescription": "Season Five, Episode One of the Virtual Coffee Podcast",
-		"season": 5,
-		"episode": 1,
-		"buzzsproutId": "10297519",
-		"publishDate": "2022-03-22T04:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Brian Rinaldi about doing DevRel (Developer Relations) right and playing to your team's strengths. We also talk about the importance of connection and why we as developers need to support each other.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Brian Rinaldi, a Developer Experience Engineer at LaunchDarkly with over 20 years of experience as a developer for the web, about how Developer Relationships has changed over the years and why need not just remote community experiences but also in-person opportunities. We talk about the value of different types of communities and how each is necessary to support developers.</p><h3>Links</h3><ul><li><p><a href=\"https://launchdarkly.com/\" rel=\"noopener noreferrer\" target=\"_blank\">LaunchDarkly</a></p></li><li><p><a href=\"https://CFE.dev\" rel=\"noopener noreferrer\" target=\"_blank\">CFE.dev</a></p></li><li><p><a href=\"https://thejam.dev\" rel=\"noopener noreferrer\" target=\"_blank\">TheJam.dev</a></p></li><li><p><a href=\"https://www.manning.com/books/the-jamstack-book\" rel=\"noopener noreferrer\" target=\"_blank\">The Jamstack Book</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0501-brian-episode.jpg",
-		"guests": [
-			{
-				"name": "Brian Rinaldi",
-				"bio": "<p>Brian Rinaldi is a Developer Experience Engineer at LaunchDarkly with over 20 years experience as a developer for the web. Brian is actively involved in the community running developer meetups via CFE.dev and Orlando Devs. He's the editor of the Jamstacked newsletter and co-author of The Jamstack Book from Manning.</p><ul><li><p><a href=\"http://remotesynthesis.com\" rel=\"noopener noreferrer\" target=\"_blank\">remotesynthesis.com</a></p></li><li><p><a href=\"https://github.com/remotesynth\" rel=\"noopener noreferrer\" target=\"_blank\">remotesynth</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/remotesynth\" rel=\"noopener noreferrer\" target=\"_blank\">@remotesynth on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/brianrinaldi\" rel=\"noopener noreferrer\" target=\"_blank\">@brianrinaldi on LinkedIn</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0501-brian.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Amy Shackles - Finding a job you love",
-		"slug": "amy-shackles-finding-a-job-you-love",
-		"id": "767",
-		"metaDescription": "Season Five, Episode Two of the Virtual Coffee Podcast",
-		"season": 5,
-		"episode": 2,
-		"buzzsproutId": "10353204",
-		"publishDate": "2022-03-31T04:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Amy Shackles about the importance of good communication in finding a job you love and defining your career path.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Amy Shackles, a Senior Software Engineer at MURAL, about how she made her way from being a Psychology and Anthropology double major to being a Senior Software Engineer. She shares what’s made her experience at MURAL a great one and the importance of openness in communication.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://amyshackles.com/\" rel=\"noopener noreferrer\" target=\"_blank\">amyshackles.com</a></p></li><li><p><a href=\"https://github.com/AmyShackles/regex_parser\" rel=\"noopener noreferrer\" target=\"_blank\">Amy's regular expression parser</a></p></li><li><p><a href=\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions\" rel=\"noopener noreferrer\" target=\"_blank\">MDN article on regular expressions</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0502-amy-episode.jpg",
-		"guests": [
-			{
-				"name": "Amy Shackles",
-				"bio": "<p>Amy is a Senior Software Engineer currently working at <a href=\"https://mural.co/\" rel=\"noopener noreferrer\" target=\"_blank\">MURAL</a>. She loves information, human interaction, solving problems, helping people, and cats - not in that order. She spends most of her free time lately learning Spanish, practicing calligraphy, singing, writing parody songs, and crocheting.</p><ul><li><p><a href=\"https://amyshackles.com/\" rel=\"noopener noreferrer\" target=\"_blank\">amyshackles.com</a></p></li><li><p><a href=\"https://github.com/AmyShackles\" rel=\"noopener noreferrer\" target=\"_blank\">AmyShackles</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/AmyShackles\" rel=\"noopener noreferrer\" target=\"_blank\">@AmyShackles on Twitter</a></p></li><li><p><a href=\"https://dev.to/amyshackles\" rel=\"noopener noreferrer\" target=\"_blank\">@AmyShackles on DEV.to</a></p></li><li><p><a href=\"https://www.linkedin.com/in/AmyShackles\" rel=\"noopener noreferrer\" target=\"_blank\">@AmyShackles on LinkedIn</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0502-amy.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Helen Griffin - Multi-passionate in tech",
-		"slug": "helen-griffin-multi-passionate-in-tech",
-		"id": "781",
-		"metaDescription": "Season Five, Episode Three of the Virtual Coffee Podcast",
-		"season": 5,
-		"episode": 3,
-		"buzzsproutId": "10397152",
-		"publishDate": "2022-04-07T04:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Helen Griffin about what she’s learned from her journey going from tech to founder and back to tech again.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Helen Griffin, a full-stack developer and founder, about how the tech industry changed during the time she was a founder, how what she’s learned as a founder has helped her to have a broader perspective about the tech industry, and what she’s doing with her companies Jovial and State of Developers to support developers in their career journeys.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://stateofdevs.com/\" rel=\"noopener noreferrer\" target=\"_blank\">The State of Developers</a></p></li><li><p><a href=\"https://jovial.work/\" rel=\"noopener noreferrer\" target=\"_blank\">Jovial</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0503-helen-episode.jpg",
-		"guests": [
-			{
-				"name": "Helen Griffin",
-				"bio": "<p>Helen started her career as a web developer. Now, as a full-stack dev & founder, she enjoys helping developers build products & a life they love. Today, she spends her time building developer tools, like State of Developers & Jovial. Helen is on a campaign to help her peers recover from burnout.</p><ul><li><p><a href=\"https://helenjr.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">HelenJr.dev</a></p></li><li><p><a href=\"https://github.com/helengriffinjr\" rel=\"noopener noreferrer\" target=\"_blank\">helengriffinjr</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/helengriffinjr\" rel=\"noopener noreferrer\" target=\"_blank\">@helengriffinjr</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/hgriffinjr\" rel=\"noopener noreferrer\" target=\"_blank\">@hgriffinjr</a> on LinkedIn</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0503-helen.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Yolanda Haynes - Breaking into Tech: It Takes Time",
-		"slug": "yolanda-haynes-breaking-into-tech-it-takes-time",
-		"id": "790",
-		"metaDescription": "Season Five, Episode Four of the Virtual Coffee Podcast",
-		"season": 5,
-		"episode": 4,
-		"buzzsproutId": "10431216",
-		"publishDate": "2022-04-13T04:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Yolanda Haynes about her journey into tech and how she created her own path and experiences, including joining Virtual Coffee, 100devs, and Collab Lab.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Yolanda Haynes, a career changer who went from working as a certified occupational therapy assistant to a Software Engineer, about the importance of finding community during your learning journey, and remembering that you shouldn’t judge your journey based on anyone else’s; focus on the learning journey, absorbing what you can, and preparing yourself for your future.</p><h3>Links:</h3><ul><li><p><a href=\"https://leonnoel.com/100devs/\" rel=\"noopener noreferrer\" target=\"_blank\">100devs</a></p></li><li><p><a href=\"https://the-collab-lab.codes/\" rel=\"noopener noreferrer\" target=\"_blank\">The Collab Lab</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0504-yolanda.jpg",
-		"guests": [
-			{
-				"name": "Yolanda Haynes",
-				"bio": "<p>A career changer from working in healthcare as a COTA (certified occupational therapy assistant) to a Software Engineer.</p><ul><li><p><a href=\"https://www.yhaynes.com/\" rel=\"noopener noreferrer\" target=\"_blank\">yhaynes.com</a></p></li><li><p><a href=\"https://github.com/YolandaHaynes\" rel=\"noopener noreferrer\" target=\"_blank\">@YolandaHaynes on GitHub</a></p></li><li><p><a href=\"https://twitter.com/_YolandaHaynes\" rel=\"noopener noreferrer\" target=\"_blank\">@_YolandaHaynes on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/yolanda-haynes/\" rel=\"noopener noreferrer\" target=\"_blank\">@yolanda-haynes on LinkedIn</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Profile.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Roger Gentry - Perseverance and  Problem Solving",
-		"slug": "roger-gentry-perseverance-and-problem-solving",
-		"id": "814",
-		"metaDescription": "Season 5, Episode 5 of the Virtual Coffee Podcast",
-		"season": 5,
-		"episode": 5,
-		"buzzsproutId": "10480828",
-		"publishDate": "2022-04-21T04:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Roger Gentry about his love of solving problems and how he's brought that with him into tech.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Roger Gentry, who has spent a lot of his career managing security and compliance for clients across the United States, about his passion for problem-solving and what to do when you get stuck. We're all going to run into frustrations during our tech journeys, but knowing how to navigate through them is one of the key skills you'll need.</p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0505-roger-episode.jpg",
-		"guests": [
-			{
-				"name": "Roger Gentry",
-				"bio": "<p>Roger has managed the security and compliance for clients across the United States. Providing CTO/CSO level consulting to a variety of industries, Roger has worked with customers to achieve successful compliance certifications from PCI, ISO, SOC, and more.</p><p><a href=\"http://r-o-g-e-r.com/\" rel=\"noopener noreferrer\" target=\"_blank\">http://r-o-g-e-r.com/</a></p>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0505-roger.jpeg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Special Kirk Day Bonus Episode (Live)",
-		"slug": "special-kirk-day-bonus-episode",
-		"id": "825",
-		"metaDescription": "Happy Kirk Day!",
-		"season": 5,
-		"episode": 999,
-		"buzzsproutId": "10509803",
-		"publishDate": "2022-04-26T04:00:00+00:00",
-		"shortDescription": "<p>A special live episode of the Virtual Coffee Podcast - Bekah and Dan meet for the first time in real life, and get to hang out with Kirk on Kirk Day!</p>",
-		"showNotes": "<p>A special live episode of the Virtual Coffee Podcast - Bekah and Dan meet for the first time in real life, and get to hang out with Kirk on Kirk Day! Also Dan fires Bekah (for the first time).</p><p><a href=\"https://youtu.be/uh-oA8czBVo\">Watch the stream on YouTube!</a></p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/05-bonus-kirk-day.jpg",
+		"buzzsproutId": "16019031",
+		"publishDate": "2024-10-30T04:00:00+00:00",
+		"shortDescription": "<p><span>Bekah and Dan discuss the considerations and steps involved in open sourcing a private repository, sharing insights from their own experience with the Virtual Coffee community docs.</span></p>",
+		"showNotes": "<p><span>In Episode 8 of Season 10 of the Virtual Coffee Podcast, hosts Bekah and Dan delve into the intricate process of open sourcing a private repository. Drawing from their experience with Virtual Coffee's community docs, they discuss considerations like verifying the safety of repository content, ensuring appropriate permissions, and maintaining the privacy of sensitive discussions. They also touch on the importance of updating READEMEs, licensing, and providing clear guidelines for new contributors.</span></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E08.png",
 		"guests": [],
 		"sponsors": []
 	},
 	{
-		"title": "Andrew Bush - Mobile Development and Giving Back to Community",
-		"slug": "andrew-bush-mobile-development-and-giving-back-to-community",
-		"id": "828",
-		"metaDescription": "Season 5, Episode 6 of the Virtual Coffee Podcast",
-		"season": 5,
-		"episode": 6,
-		"buzzsproutId": "10565670",
-		"publishDate": "2022-05-05T04:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Andrew Bush about his experiences with mobile development, and his thoughts on community and what it means to give back.</p>",
-		"showNotes": "<p>In today's episode, Dan and Bekah talk to Andrew Bush, a Mobile Engineer Specializing in React Native. One of the updates we've made to our site is to have tags on our <a href=\"https://virtualcoffee.io/members\">members page</a> to indicate what volunteer roles they have. Andrew is one of our Monthly Challenge team leads, and he shared with us his experiences helping to facilitate the challenges, keeping our community motivated, and the processes we go through. We also go into what it's like to be a mobile developer, and the learning path he's been on throughout his career.</p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0506-andrew-episode.jpg",
-		"guests": [
-			{
-				"name": "Andrew Bush",
-				"bio": "<p>Andrew is a mobile developer specializing in React Native based out of Wisconsin in the US. He has been developing professionally for 3 years and has really found his passion in mobile apps and accessibility. Being legally blind himself, he recognizes the need for inclusion in software development so that EVERYONE can use the applications we create.</p><p>Outside of his professional life, Andrew is a dedicated amateur runner with a love for the sport that rivals his love of Swedish Fish candy. You can also find him participating as a co-lead of the Virtual Coffee monthly challenges where he strives to create engagement and growth combined with the feeling of an intimate community.</p>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0506-andrew.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Meg Gutshall - Building accountability into Community",
-		"slug": "meg-gutshall-building-accountability-into-community",
-		"id": "840",
-		"metaDescription": "Season 5, Episode 7 of the Virtual Coffee Podcast",
-		"season": 5,
+		"title": "Climbing the Contributor Ladder",
+		"slug": "climbing-the-contributor-ladder",
+		"id": "2175",
+		"metaDescription": "Season 10, Episode 7 of the Virtual Coffee Podcast",
+		"season": 10,
 		"episode": 7,
-		"buzzsproutId": "10613498",
-		"publishDate": "2022-05-13T04:00:00+00:00",
-		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk with Meg Gutshall about accountability and how to bring that to your community. She shares some of her memorable experiences with community and she does it all with Philly flair.</p>",
-		"showNotes": "<p>In today's episode, Bekah and Dan talk to Meg Gutshall, a Ruby on Rails Developer, and community volunteer at Virtual Coffee. She shared all things Philly and some memorable stories of how she's supported others--including Bekah--in their journeys into tech. Meg talks about her Accountabilibuddies group at Virtual Coffee and how she chose Ruby after graduating from a full stack bootcamp.</p><p></p><img src=\"http://storage.googleapis.com/virtualcoffeeio-assets/images/_podcastShowNotesImage/gritty.jpg\" alt=\"Gritty, the Fliers Mascot\" title=\"Gritty, the Fliers Mascot\"><p></p><h3>Links</h3><ul><li><p><a href=\"https://en.wikipedia.org/wiki/Gritty\" rel=\"noopener noreferrer\" target=\"_blank\">Gritty</a></p></li><li><p><a href=\"https://freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">freeCodeCamp</a></p></li><li><p><a href=\"https://www.pennmedicine.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Penn medicine</a></p></li><li><p><a href=\"https://www.urbandictionary.com/define.php?term=Jawn\" rel=\"noopener noreferrer\" target=\"_blank\">jawn</a></p></li><li><p>Meg's blog post on code and Spanish: <a href=\"https://meghangutshall.com/2018/07/21/the_little_things_matter/\" rel=\"noopener noreferrer\" target=\"_blank\">The Little Things Matter</a></p></li><li><p><a href=\"https://rubyforgood.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Ruby for Good</a></p></li><li><p><a href=\"https://humanessentials.app/\" rel=\"noopener noreferrer\" target=\"_blank\">HumanEssentials.app</a></p></li><li><p><a href=\"https://nationalcasagal.org/\" rel=\"noopener noreferrer\" target=\"_blank\">CASA</a></p></li><li><p><a href=\"https://2022.phillytechweek.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Philly Tech Week</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0507-meg-episode.jpg",
-		"guests": [
-			{
-				"name": "Meg Gutshall",
-				"bio": "<p>Meg is a Ruby on Rails developer with a passion for open source and tech for good. She's always smiling, continuously learning, and quick to strike up a conversation. She takes her advice with a grain of salt & a shot of tequila.</p>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0507-meg.png"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Matt McInnis - Go Make Stuff!",
-		"slug": "matt-mcinnis-go-make-stuff",
-		"id": "860",
-		"metaDescription": "Season 5, Episode 8 of the Virtual Coffee Podcast",
-		"season": 5,
-		"episode": 8,
-		"buzzsproutId": "10680520",
-		"publishDate": "2022-05-25T04:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Matt McInnis about his incredible journey through tech from math professor, to self-taught data-scientist working with IBM and Microsoft, to founder.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Matt McInnis a former Math Professor, and current data scientist, full-stack engineer, and founder, about his journey through tech as a self-taught engineer. He shares his insight into building personal projects and creating value in the projects you work on, even if those projects are just for you.</p><h3>Links</h3><ul><li><p><a href=\"https://typistapp.ca/\">Typist</a></p></li><li><p><a href=\"https://www.littlebrown.com/titles/malcolm-gladwell/the-tipping-point/9780759574731/\">Malcolm Gladwell's Tipping Point</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Kidstreet\" rel=\"noopener noreferrer\" target=\"_blank\">Kidstreet</a></p></li><li><p><a href=\"https://www.hackerparadise.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Hacker Paradise</a></p></li><li><p><a href=\"https://ologicinc.com/portfolio/star-wars-science-force-trainer/\" rel=\"noopener noreferrer\" target=\"_blank\">Star Wars Force Trainer</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0508-matt-episode.jpg",
-		"guests": [
-			{
-				"name": "Matt McInnis",
-				"bio": "<p>Matt is a full-stack developer (Rails+React) at <a href=\"https://typistapp.ca/\">Typist</a> based in Toronto, Canada. Former artificial intelligence lead at IBM and Microsoft, mathematics professor at Centennial College and Saskatchewan Polytechnic. Matt really loves brunch.</p><ul><li><p><a href=\"https://github.com/MattyMc\">MattyMc on GitHub</a></p></li><li><p><a href=\"https://twitter.com/MattLovesMath\">MattLovesMath on Twitter</a></p></li><li><p><a href=\"http://linkedin.com/in/mattmcinnis\">mattmcinnis on LinkedIn</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0508-matt.jpeg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Season 5 Wrap-Up: Working to Empower the Virtual Coffee Community",
-		"slug": "season-5-wrap-up-working-to-empower-the-virtual-coffee-community",
-		"id": "876",
-		"metaDescription": "Season 5 Finale of the Virtual Coffee Podcast",
-		"season": 5,
-		"episode": 9,
-		"buzzsproutId": "10720878",
-		"publishDate": "2022-06-01T04:00:00+00:00",
-		"shortDescription": "<p>In this season finale of the podcast, Dan, Kirk, and Bekah come together to talk about making hard decisions to ensure community support and stability. They also share how they're navigating technical and community challenges as the community grows.</p>",
-		"showNotes": "<p>In this episode of the podcast, Bekah, Kirk, and Dan discuss the decision to pause new membership and what the maintainers are doing to progress towards opening the community up again. We share what we think makes our community special, how we're working to preserve that, and some of the challenges we're figuring out as we take steps towards reopening membership. What goes into the long-term strategy of making Virtual Coffee <em>an intimate group of devs, optimized for you</em>? You'll find out in this episode.</p><h3>Links:</h3><ul><li><p><a href=\"https://gamesnostalgia.com/game/dx-ball\" rel=\"noopener noreferrer\" target=\"_blank\">DX Ball</a></p></li><li><p><a href=\"https://boardgamegeek.com/boardgame/3086/omega-virus\" rel=\"noopener noreferrer\" target=\"_blank\">Omega Virus</a></p></li><li><p><a href=\"https://www.ultraboardgames.com/othello/game-rules.php\" rel=\"noopener noreferrer\" target=\"_blank\">Othello</a></p></li><li><p><a href=\"http://virtualcoffee.io/members\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee Members</a></p></li><li><p><a href=\"https://virtualcoffee.io/resources/virtual-coffee/get-involved/paths-to-leadership\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee Paths to Leadership</a></p></li><li><p><a href=\"https://twitter.com/SuzeShardlow\" rel=\"noopener noreferrer\" target=\"_blank\">Suze Shardlow</a></p></li><li><p><a href=\"https://www.bbc.com/future/article/20191001-dunbars-number-why-we-can-only-maintain-150-relationships\" rel=\"noopener noreferrer\" target=\"_blank\">Dunbar's Number</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0509-finale-episode.jpg",
-		"guests": [
-			{
-				"name": "Kirk Shillingford",
-				"bio": "<p>Software Developer, and Community Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://github.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-kirk.jpg"
-			},
-			{
-				"name": "Bekah Hawrot Weigel",
-				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dev.to/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/bekahhw</a></p></li><li><p><a href=\"https://twitter.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">@bekahhw</a> on Twitter</p></li><li><p><a href=\"https://www.instagram.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">bekahhw</a> on Instagram</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/T014AAKN3KP-U014HT3RNCU-f7cccf369940-512.png"
-			},
-			{
-				"name": "Dan Ott",
-				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dtott.com/\" rel=\"noopener noreferrer\" target=\"_blank\">dtott.com</a></p></li><li><p><a href=\"https://twitter.com/danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">@danieltott</a> on Twitter</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-dan.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "David Alpert - On pairing and providing support",
-		"slug": "david-alpert-on-pairing-and-providing-support",
-		"id": "913",
-		"metaDescription": "Season 6, Episode 1 of the Virtual Coffee Podcast",
-		"season": 6,
-		"episode": 1,
-		"buzzsproutId": "10964411",
-		"publishDate": "2022-07-15T04:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to David Alpert about supporting others in their tech journey, asking the right questions, and leading with empathy.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with David Alpert, Director of Engineering at Northfield IT, about taking a personalized approach to helping others as they ask coding questions and navigate career paths. David shares the importance of bringing empathy to every situation and gives tips on how to handle challenging situations.</p><h3>Links:</h3><ul><li><p><a href=\"https://en.wikipedia.org/wiki/Logo_(programming_language)\">Logo (the programming turtle)</a></p></li><li><p><a href=\"https://dev.to/virtualcoffee/how-the-virtual-coffee-coworking-room-works-2a89\">Virtual Coffee Co-Working Room</a></p></li><li><p><a href=\"https://agilemanifesto.org/\">The Agile Manifesto</a></p></li><li><p><a href=\"https://www.twitch.tv/virtualcoffeeio\">Typescript Tuesdays</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0601-david-episode.jpg",
-		"guests": [
-			{
-				"name": "David Alpert",
-				"bio": "<p>David Alpert is a collaborative leader and agile coach striving to reduce friction between people and software. Based in Winnipeg, Manitoba, David has over 20 years of professional IT experience in software development, system design, and project and people management spanning the finance, manufacturing, and sports entertainment industries. David is passionate about test-driven development, refactoring, pair programming, and helping people become better developers.</p><ul><li><p>Website: <a href=\"https://blog.spinthemoose.com\">Spin the Moose</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/davidalpert\">@davidalpert</a></p></li><li><p>GitHub: <a href=\"https://github.com/davidalpert\">davidalpert</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0601-david.jpeg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Bogdan Covrig - Navigating Tech Career Paths",
-		"slug": "bogdan-covrig-navigating-tech-career-paths",
-		"id": "933",
-		"metaDescription": "Season Six, Episode Two of the Virtual Coffee Podcast",
-		"season": 6,
-		"episode": 2,
-		"buzzsproutId": "11044164",
-		"publishDate": "2022-07-28T04:00:00+00:00",
-		"shortDescription": "<p>In this episode, Dan and Bekah talk to Bogdan Covrig about finding the right career path within tech and searching for what gets you excited.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Bogdan Covrig, a Software Engineer in the Netherlands who's into Typescript, React and Node, about navigating different learning and career paths in tech before landing a job that fulfills his interests to see the changes he's making and provides a dynamic work environment. He also drops his tips on the most important things you can do if you're starting your journey into tech.</p><h3>Links</h3><ul><li><p><a href=\"https://p5js.org/\">p5.js</a></p></li><li><p><a href=\"https://www.arduino.cc/\">Arduino</a></p></li><li><p><a href=\"https://www.twitch.tv/virtualcoffeeio/schedule\">Twitch TypeScript Tuesdays</a></p></li><li><p>Nick and Bekah's Lunch & Learn <a href=\"https://youtu.be/DVqtr3iwkwQ\">Coding questions: Problem-solving and working through challenges</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0602-bogdan-episode.png",
-		"guests": [
-			{
-				"name": "Bogdan Covrig",
-				"bio": "<p>Bogdan is a Software Engineer in the Netherlands. He’s passionate about privacy, automation and infrastructure. He’s into Typescript, React and Node, currently building and working with CMS. He’s usually busy with movies, concerts or sitting in the park for no reason.</p><ul><li><p><a href=\"https://github.com/BogDAAAMN\">@BogDAAAMN</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/BogdanCovrig\">@BogdanCovrig</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/BogdanCovrig\">@BogdanCovrig</a> on LinkedIn</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0602-bogdan.jpeg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Seth Hall - From Film Production to Technical Product Owner: A Career Changer's Story",
-		"slug": "seth-hall-from-film-production-to-technical-product-owner-a-career-changers-story",
-		"id": "954",
-		"metaDescription": "Season 6, Episode 3 of the Virtual Coffee Podcast",
-		"season": 6,
-		"episode": 3,
-		"buzzsproutId": "11103329",
-		"publishDate": "2022-08-09T04:00:00+00:00",
-		"shortDescription": "<p>Bekah and Dan talk to Seth Hall, a Technical Product Owner at Uniform. He talks about the importance of fostering authentic company culture, as well as how his search to find a challenging, fun, and flexible job led him from Film Production, to Frontend Developer, to his current role.</p>",
-		"showNotes": "<p>In today's episode, Dan and Bekah talk with Seth Hall about the importance of intimate collaboration, advocating for yourself, and transferable skills as part of his job as a Technical Product Owner at <a href=\"https://uniform.dev/\">Uniform</a>. He shares how his background as a creative producer informs how he guides demo initiatives, creates roadmaps, and collaborates with other departments.</p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0603-seth-hall-episode.jpg",
-		"guests": [
-			{
-				"name": "Seth Hall",
-				"bio": "<p>Seth is a Technical Product Owner at <a href=\"https://uniform.dev/\">Uniform</a></p><ul><li><p>Website: <a href=\"https://sethhall.dev/\">sethhall.dev</a></p></li><li><p>Dev.to: <a href=\"https://dev.to/sethburtonhall\"><u>dev.to/sethburtonhall</u></a></p></li><li><p>Polywork: <a href=\"https://www.polywork.com/sethhall\"><u>polywork.com/sethhall</u></a></p></li><li><p>Twitter: <a href=\"https://twitter.com/sethburtonhall\">@sethburtonhall</a></p></li><li><p>GitHub: <a href=\"https://github.com/sethburtonhall\">@sethburtonhall</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0603-seth-hall.png"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "50th Episode Special - Live at KCDC 2022",
-		"slug": "50th-episode-special-live-at-kcdc-2022",
-		"id": "987",
-		"metaDescription": "Season Six Special Edition",
-		"season": 6,
-		"episode": 999,
-		"buzzsproutId": "11127313",
-		"publishDate": "2022-08-12T04:00:00+00:00",
-		"shortDescription": "<p>For the 50th episode of the podcast, Dan and Bekah are live at KCDC 2022 answering listener questions and practicing their accents.</p>",
-		"showNotes": "<p>For the 50th episode of the podcast, Dan and Bekah are live at the Kansas City Developer Conference 2022 answering listener questions and practicing their accents.</p><p><a href=\"https://www.youtube.com/watch?v=_fqFv1joZ3A\"><strong>Check out the video version on YouTube!</strong></a></p><h4>Listener questions:</h4><ul><li><p>What time do you go to sleep? (2:19)</p></li><li><p>How does a computer get drunk? (12:42)</p></li><li><p>What's the hardest part of community? (22:20)</p></li><li><p>Ayu would like to hear the history of how Virtual Coffee was founded. (31:57)</p></li><li><p>What does community mean to you? (38:01)</p></li><li><p>At in-person events, what are some techniques or tactics you used for starting a conversation with a stranger? (41:00)</p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/06-special.png",
+		"buzzsproutId": "15975962",
+		"publishDate": "2024-10-23T04:00:00+00:00",
+		"shortDescription": "<p><span>Dan and Bekah discuss strategies for advancing from contributor to maintainer in open source projects by engaging with the community, understanding contribution guidelines, handling issues effectively, and collaborating respectfully.</span></p>",
+		"showNotes": "<p><span>In this episode of the Virtual Coffee Podcast, hosts Bekah Hawrot Weigel and Dan Ott delve into the journey of climbing the contributor ladder in open-source projects. They explore the progression from contributor to maintainer, focusing on the importance of trust-building, consistent contributions, and respectful interactions within the community. Key strategies discussed include engaging with project documentation, reproducing bugs, and effective communication. The episode also highlights how projects like Astro and Nuxt guide contributors and the role of events like Hacktoberfest in encouraging new participation. Real-life examples illustrate how proactive engagement can lead to managing more complex tasks and even job opportunities. Sponsored by Level Up Financial Planning, this insightful episode is a must-listen for anyone looking to make significant strides in the open-source community.</span><br><br><span>Visit <a href=\"https://virtualcoffee.io/resources/developer-resources/open-source\">https://virtualcoffee.io/resources/developer-resources/open-source</a> for additional resources.</span></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E07.png",
 		"guests": [],
-		"sponsors": []
-	},
-	{
-		"title": "Sadie Jay - Technical Interviews for Bootcamp Grads",
-		"slug": "sadie-jay-technical-interview-for-bootcamp-grads",
-		"id": "990",
-		"metaDescription": "Season 6, Episode 4 of the Virtual Coffee Podcast",
-		"season": 6,
-		"episode": 4,
-		"buzzsproutId": "11204579",
-		"publishDate": "2022-08-30T04:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Sadie about technical interviewing after bootcamp. She shares her tips for landing interviews, prepping, and interviewing your interviewers.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Sadie a frontend developer for a federal agency, to chat about her experience navigating the interview process and how she found success after giving tech a second shot. She shares tips on how to avoid burnout both during the interview process and while you're working in tech.</p><h3>Links:</h3><ul><li><p><a href=\"https://18f.gsa.gov/\">18f</a></p></li><li><p><a href=\"https://skillcrush.com/\">Skill Crush</a></p></li><li><p><a href=\"https://leetcode.com/explore/challenge/\">Leet Code Challenge</a></p></li><li><p><a href=\"https://github.com/jmkoni/interview-questions\"><u>Jennifer's List of Interview Questions</u></a></p></li><li><p><a href=\"https://skillcrush.com/blog/technical-test-preparation-advice/\">Technical Test Preparation Advice</a> post by Sadie</p></li><li><p><a href=\"https://www.wordsofmouth.org/\">Words of Mouth job email</a></p></li><li><p><a href=\"https://designsystem.digital.gov/\">US Web Design Standards</a></p></li><li><p><a href=\"https://jekyllrb.com/\">Jekyll</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0604-sadie-episode.png",
-		"guests": [
-			{
-				"name": "Sadie Jay",
-				"bio": "<p>Sadie is a Front-end Developer and bootcamp alum. In 2016, Sadie started her journey into tech with web design courses. Along the way, she graduated with a Masters specializing in Web Design and Online Communication, taught yoga, searched for cheap flights at a travel startup, volunteered as a writer and proofreader for various non-profits, and contributed to a number of open source projects. Outside of coding and writing, Sadie can be found petting her cat Maxie, hanging out with her mom, or looking up the next vegan restaurant to check out.</p><ul><li><p><a href=\"https://sadiejay.github.io/portfolio/\">Sadie's Portfolio Site</a></p></li><li><p><a href=\"https://github.com/sadiejay\">@sadiejay on GitHub</a></p></li><li><p><a href=\"https://www.linkedin.com/in/sadiej/\">@sadiej on LinkedIn</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0604-sadie.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Chad Stewart - OSS and #TechisHiring",
-		"slug": "chad-stewart-oss-and-techishiring",
-		"id": "1026",
-		"metaDescription": "Season 6, Episode 5 of the Virtual Coffee Podcast",
-		"season": 6,
-		"episode": 5,
-		"buzzsproutId": "11269316",
-		"publishDate": "2022-09-06T04:00:00+00:00",
-		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk with Chad Stewart about getting started in open source, finding a project with a supportive community, and his project #TechIsHiring.</p>",
-		"showNotes": "<p>In today's episode, Bekah and Dan talk to Chad Stewart, a Software Engineer from Kingston, Jamaica, about his journey into contributing to Open Source projects like Open Sauced and how to find your way to your first contribution. He shares the inspiration behind his <a href=\"https://www.getrevue.co/profile/techishiring\">#TechIsHiring project</a>, which helps to identify tech jobs and resources, but more importantly, to connect people in the wider tech community.</p><h3>Links</h3><ul><li><p><a href=\"https://www.amazon.com/Side-Mountain-Jean-Craighead-George/dp/0141312424\">My Side of the Mountain</a></p></li><li><p><a href=\"https://twitter.com/bdougieYO\">Brian Douglas, aka Bdougie</a></p></li><li><p><a href=\"https://opensauced.pizza/\">Open Sauced</a></p></li><li><p><a href=\"https://github.com/yangshun/tech-interview-handbook\">Tech Interview Handbook</a></p></li><li><p><a href=\"https://github.com/TheAlgorithms\">The Algorithms</a></p></li><li><p><a href=\"https://twitter.com/AdiatiAyu\">Ayu</a></p></li><li><p><a href=\"https://twitter.com/TechIsHiring\">Tech is Hiring</a></p></li><li><p><a href=\"https://github.com/Virtual-Coffee/virtualcoffee.io/blob/main/CONTRIBUTING.md\">Virtual Coffee Contributors Guide</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0605-chad-episode.jpg",
-		"guests": [
-			{
-				"name": "Chad Stewart",
-				"bio": "<p>Software Engineer from Kingston, Jamaica. Founder of <a href=\"https://www.getrevue.co/profile/techishiring\">TechIsHiring</a>.</p><ul><li><p><a href=\"https://twitter.com/Chad_R_Stewart\">@Chad_R_Stewart on Twitter</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0605-chad.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Julia Seidman - Embracing the Careen Over the Career",
-		"slug": "julia-seidman-embracing-the-careen-over-the-career",
-		"id": "1049",
-		"metaDescription": "Season Six, Episode Six, of the Virtual Coffee Podcast",
-		"season": 6,
-		"episode": 6,
-		"buzzsproutId": "11351419",
-		"publishDate": "2022-09-20T04:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Julia about learning how to learn as a Technical Writer, the importance of teaching as a tool for learning, and her approach to writing about new technologies.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Julia Seidman, a technical marketing consultant and developer in the Seattle area, and talked about her work writing about different technologies, learning by teaching, and embracing the careen over the career. She talks about her career journey from studying anthropology to financial analysis to teaching high school English, ESL and Debate, before landing her current role as a technical writer.</p><h3>Links</h3><ul><li><p><a href=\"https://en.wikipedia.org/wiki/Krugerrand\">Krugerrand</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Doubloon\">Gold Doubloons</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Rhodium\">Rhodium</a></p></li><li><p><a href=\"https://flutter.dev/\">Flutter</a></p></li><li><p><a href=\"https://www.amazon.com/Developer-Marketing-Does-Not-Exist-ebook/dp/B091NK954H\">Developer Marketing Does Not Exist</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0606-julia-episode.jpg",
-		"guests": [
-			{
-				"name": "Julia Seidman",
-				"bio": "<p>Julia Seidman is a technical marketing consultant and developer in the Seattle area. She has 2 terrific kids and a wonderful partner, and her family cos-plays as a “normal” family.</p><p class=\"text-left\">Julia is a believer in the careen, rather than the career.</p><p class=\"text-left\">After studying anthropology and writing a senior thesis on the ethics of museum collections of human skeletal remains, she took the job she could get, which was fundraising for a hospital.</p><p class=\"text-left\">From there, she became a financial analyst and employee educator for 401(k) and pension plans. After that, she got a Master’s in Teaching, and taught high school English, ESL and Debate for most of a decade.</p><p class=\"text-left\">Now, she works as a freelance technical writer and software developer, specializing in technical content marketing.</p><p class=\"text-left\">Along the way, she has learned a lot about a lot of things, including the Python ecosystem.</p>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0606-juila.JPG"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Ryan Kahn - Building Better Teams",
-		"slug": "ryan-kahn-building-better-teams",
-		"id": "1091",
-		"metaDescription": "Season 6, Episode 7 of the Virtual Coffee Podcast",
-		"season": 6,
-		"episode": 7,
-		"buzzsproutId": "11407929",
-		"publishDate": "2022-09-29T04:00:00+00:00",
-		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk with Ryan Kahn about building better teams to deliver quality software by practicing empathy and knowledge sharing.</p>",
-		"showNotes": "<p>In today's episode, Bekah and Dan talk to Ryan Kahn, a developer experience and productivity consultant from New York City, about his work as a consultant helping companies to build better software teams. He emphasizes the importance of recognizing that teams are made up of individuals who have different needs and approaches. He also breaks down the difference between quality, technical, knowledge, and innovation debt and the need to identify which most impacts teams as they seek better communication to build a stronger team.</p><h3>Links:</h3><ul><li><p><a href=\"http://adr.github.io\">ADR GitHub organization</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Oblique_Strategies\">Oblique Strategies</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0607-ryan-episode.jpg",
-		"guests": [
-			{
-				"name": "Ryan Kahn",
-				"bio": "<p>Ryan loves solving the human and technical problems of software development, and works on both as a developer experience and productivity consultant. He lives in New York City with his partner, daughter, and dog. Outside of his work he loves Astronomy and Amateur Radio.</p>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0607-ryan.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Shelley McHardy: Junior Dev life",
-		"slug": "shelley-mchardy-junior-dev-life",
-		"id": "1101",
-		"metaDescription": "Season Six, Episode Eight of the Virtual Coffee Podcast",
-		"season": 6,
-		"episode": 8,
-		"buzzsproutId": "11445606",
-		"publishDate": "2022-10-05T04:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Shelley McHardy about navigating a career transition and the challenges of interviewing for your first developer role.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Shelley McHardy, a former chemistry teacher turned front end developer at <a href=\"https://www.rightpoint.com/\">Rightpoint</a>, and talked about the early career developer's journey. She gave insight into what her seven-month interview process looked like, forcing interviewers to interview you, the importance of finding \"your people\", and being picky in your job search.</p><h3>Links:</h3><ul><li><p><a href=\"https://www.edx.org/\">edX</a></p></li><li><p><a href=\"https://the-collab-lab.codes/\">Collab Lab</a></p></li><li><p><a href=\"https://www.studentachievementsolutions.com/what-are-professional-learning-communities-plcs/\">PLCs- Professional learning communities</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0608-shelley-episode.jpg",
-		"guests": [
-			{
-				"name": "Shelley McHardy",
-				"bio": "<p>Shelley is a former chemistry teacher turned front end developer at Rightpoint. A native San Franciscan, she is currently doing her best to stay cool in Atlanta, Georgia. When not crocheting, she and her wife love hiking the Georgia State Parks, geocaching, cooking, baking, and video games.</p><ul><li><p>GitHub: <a href=\"https://github.com/shelleymcq\">@shelleymcq</a></p></li><li><p>Twitter <a href=\"https://twitter.com/shelleymcqDev\">@shelleymcqDev</a></p></li><li><p>LinkedIn <a href=\"https://www.linkedin.com/in/shelleymchardy/\">shelleymchardy</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0608-shelley.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Season Six Finale - Talking Hacktoberfest with Bekah, Dan, and Kirk",
-		"slug": "season-six-finale-talking-hacktoberfest-with-bekah-dan-and-kirk",
-		"id": "1132",
-		"metaDescription": "Season Six, Episode Nine of the Virtual Coffee Podcast",
-		"season": 6,
-		"episode": 9,
-		"buzzsproutId": "11496083",
-		"publishDate": "2022-10-13T04:00:00+00:00",
-		"shortDescription": "<p>It’s the final episode of season six of the podcast and we’re bringing it to you live with Bekah, Dan, and Kirk!</p>",
-		"showNotes": "<p>It’s the final episode of season six of the podcast and we’re bringing it to you live with Bekah, Dan, and Kirk! We talked a lot about Hacktoberfest with many side-tracks and segues in between.</p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0609-finale.jpg",
-		"guests": [],
-		"sponsors": []
-	},
-	{
-		"title": "Jörn Bernhardt - Becoming a Founder",
-		"slug": "jörn-bernhardt-becoming-a-founder",
-		"id": "1626",
-		"metaDescription": "Season Seven, Episode One of the Virtual Coffee Podcast",
-		"season": 7,
-		"episode": 1,
-		"buzzsproutId": "12164997",
-		"publishDate": "2023-02-02T05:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Jörn Bernhardt about his journey as a 2x founder and his lifelong interest in technology.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Jörn Bernhardt, a 2x founder in Germany, about his career path, the challenges of being a founder, and the key traits that have led to his success.</p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Jörn.png",
-		"guests": [
-			{
-				"name": "Jörn Bernhardt",
-				"bio": "<p>Jörn started developing web-based software in the last century when he was still in school. In 2018, he founded his second company <a href=\"http://compose.us\">compose.us</a> where they implement digital solutions and share their knowledge with public administrations. In his spare time Jörn organizes local meetups in Germany and creates at least one open source commit per day to push his side projects.</p><ul><li><p><a href=\"https://compose.us/\">compose.us</a></p></li><li><p><a href=\"https://github.com/Narigo\">Jörn on GitHub</a></p></li><li><p><a href=\"NarigoDF\">Jörn on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/j%C3%B6rn-bernhardt-a04225104/\">Jörn on LinkedIn</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/joern.png"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Joe Karow - Career Transitions and the ADHD Experience",
-		"slug": "joe-karow-career-transitions-and-the-adhd-experience",
-		"id": "1655",
-		"metaDescription": "Season Seven, Episode Two of the Virtual Coffee Podcast",
-		"season": 7,
-		"episode": 2,
-		"buzzsproutId": "12213630",
-		"publishDate": "2023-02-09T05:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Joe Karow about his journey as into tech with 100devs and about his ADHD journey.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Joe Karow, the Lead Engineer at a nonprofit, about his career change from the hospitality industry, his experience with the online bootcamp, 100devs, and about the ADHD experience.</p><h3>Links</h3><ul><li><p><a href=\"https://jobs.all-hands.us/jobs\">All Hands Job Board</a></p></li><li><p><a href=\"https://leonnoel.com/100devs/\">100devs</a></p></li><li><p><a href=\"https://www.resilientcoders.org/\">Resilient Coders</a></p></li><li><p><a href=\"https://twitter.com/leonnoel\">Leon Noel</a></p></li><li><p><a href=\"https://www.cedarpoint.com/\">Cedar Point</a></p></li><li><p><a href=\"https://buschgardens.com/\">Busch Gardens</a></p></li><li><p><a href=\"https://www.kennywood.com/\">Kennywood</a></p></li><li><p><a href=\"https://cssbattle.dev/\">cssbattle.dev</a></p></li><li><p><a href=\"https://remo.co/\">remo</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0702-joe-episode.jpg",
-		"guests": [
-			{
-				"name": "Joe Karow",
-				"bio": "<p>Joe is the Lead Engineer at InReach, a 501(c)3 registered non-profit building world’s first tech platform matching LGBTQ+ people facing discrimination and persecution with safe, verified resources. Formerly a Director of Finance for a large hotel chain, he made the leap in to tech in 2022. Tech was always a part of Joe's life, it just took a global pandemic for him to decide to start getting paid for it.</p><ul><li><p><a href=\"https://joekarow.dev\"><u>joekarow.dev</u></a></p></li><li><p><a href=\"https://github.com/JoeKarow\">@JoeKarow</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/JoeKarow\">@JoeKarow</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/jkarow/\">@jkarow</a> on LinkedIn</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0702-joe.jpeg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Kai Katschthaler - Technical Writing &  Neurodiverse Learning",
-		"slug": "kai-katschthaler-technical-writing-neurodiverse-learning",
-		"id": "1680",
-		"metaDescription": "Season Seven, Episode Three of the Virtual Coffee Podcast",
-		"season": 7,
-		"episode": 3,
-		"buzzsproutId": "12263721",
-		"publishDate": "2023-02-16T05:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Kai Katschthaler about their experience growing their technical writing career and creating content.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Kai Katschthaler, a technical writer and content creator, about their creation process, finding learning approaches that work for them, and mentoring others.</p><h3>Links:</h3><ul><li><p><a href=\"https://www.spreaker.com/user/15541131/kai-ep-final\">Kai's appearance on the Coming Out Pod</a></p></li><li><p><a href=\"https://bau.edu/blog/kinesthetic-learner/\">Kinesthetic Learning</a></p></li><li><p><a href=\"https://www.freecodecamp.org/\">Freecodecamp</a></p></li><li><p><a href=\"https://www.codecademy.com/\">Codecademy</a></p></li><li><p><a href=\"https://learn.co/\">Flatironschool</a></p></li><li><p><a href=\"https://exercism.org/\">Exercism</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0703-kai-episode.jpg",
-		"guests": [
-			{
-				"name": "Kai Katschthaler",
-				"bio": "<p>Kai is a tech content specialist and mental health advocate. They run Taboola Rasa, a mental health awareness project that seeks to erase the stigma connected to mental health.</p><ul><li><p><a href=\"https://linktr.ee/thegrumpyenby\">linktr.ee/thegrumpyenby</a></p></li><li><p><a href=\"https://github.com/thegrumpyenby\">@thegrumpyenby</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/thegrumpyenby\">@thegrumpyenby</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/kaikatschthaler/\">@kaikatschthaler</a> on LinkedIn</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0703-kai.jpeg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Aishwarya Mali - A Journey into Open Source",
-		"slug": "aishwarya-mali-a-journey-into-open-source",
-		"id": "1695",
-		"metaDescription": "Season Seven, Episode Four of the Virtual Coffee Podcast",
-		"season": 7,
-		"episode": 4,
-		"buzzsproutId": "12315603",
-		"publishDate": "2023-02-23T05:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Aishwarya about her journey as a first time contributer during the 2022 Hacktoberfest.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Aishwarya, front-end developer from India, about her first open source contributions and how her perspective on open source changed after her fourth (of ten!) Pull Request during Hacktoberfest.</p><ul><li><p>One word to describe you - <strong>Dedicated</strong></p></li><li><p>One word to describe your developer journey - <strong>Evolving</strong></p></li><li><p><a href=\"https://www.amazon.com/Me-Before-You-Novel-Tie/dp/0143130153\"><em><u>Me Before You</u></em><u> by Jojo Moyes</u></a></p></li><li><p>Open-Source YouTube Videos:</p><ul><li><p><a href=\"https://www.youtube.com/watch?v=yfopPq4354o\">How to Find Beginner-Friendly Open Source Projects</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=_uetV0wZyXM\">4 Beginner Friendly Open Source Projects to Contribute before 2023</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=lnLiD0GfCRE\">5 Beginner friendly Open Source Organisations to start your Open source journey</a></p></li></ul></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0704-aishwara-episode.jpg",
-		"guests": [
-			{
-				"name": "Aishwarya Mali",
-				"bio": "<p>Aishwarya Mali is a front-end developer (React+XState+Redux) based in Pune, India. She loves to read!</p><ul><li><p><a href=\"https://github.com/aishwarya-mali\">@aishwarya-mali</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/aishwaryamali24\">@aishwaryamali24</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/aishwaryamali24/\">@aishwaryamali24</a> on LinkedIn</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0704-aishwara.jpeg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Rebecca Key - From PhD to Frontend",
-		"slug": "rebecca-key-from-phd-to-frontend",
-		"id": "1711",
-		"metaDescription": "Season Seven, Episode Five of the Virtual Coffee Podcast",
-		"season": 7,
-		"episode": 5,
-		"buzzsproutId": "12363084",
-		"publishDate": "2023-03-02T05:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Rebecca Key about her journey from a career in chemistry to Software Engineer and the hobbies that she finds exciting.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Rebecca Key, a PhD in Organic Chemistry and now Software Engineer, and chatted about her career journey, Ham radios, being left-handed, taking notes, and the importance of consistency.</p><h3>Links:</h3><ul><li><p><a href=\"https://en.wikipedia.org/wiki/Brassica_oleracea\">Brassica oleracea</a> (the plant Dan was talking about)</p></li><li><p><a href=\"https://www.sota-at.com/\">SOTA-AT</a>: An interactive map that displays and provides information for peaks along the GA section of the Appalachian Trail that count toward activations for “Summits on the Air”, a ham radio contest.</p></li><li><p><a href=\"https://github.com/rek990/crochet-counter\">Row Counter</a>: A tool to help fiber artists (crocheters, knitters, rug makers, basket weavers, etc.) keep track of the row they are on with a given project. <a href=\"https://dev.to/rek990/virtual-coffees-july-monthly-challenge-live-demo-of-the-progress-toward-my-row-counter-app-3jd7\">Live Demo of the Progress Toward my Row Counter App</a></p></li><li><p>Rebecca's RF Quests: <a href=\"https://www.rfquests.com/\">Blog</a> and <a href=\"https://www.youtube.com/channel/UC5Rtn09KIdwsySkf7B-DPsw\">YouTube Channel</a></p></li><li><p><a href=\"https://parksontheair.com/\">Parks on the Air (POTA)</a></p></li><li><p><a href=\"https://www.sota.org.uk/\">Summits on the Air (SOTA)</a></p></li><li><p><a href=\"https://www.sota.org.uk/Joining-In/Awards\">SOTA Mountain goat award</a></p></li><li><p><a href=\"https://orgmode.org/\">Emacs Org Mode</a></p></li></ul><h4>Left-handed Deep Dive</h4><ul><li><p><a href=\"https://kids.frontiersin.org/articles/10.3389/frym.2014.00013\">Your Left-Handed Brain</a></p></li><li><p><a href=\"https://www.bbc.com/news/health-49579810\">Left-handed DNA found - and it changes brain structure</a></p></li><li><p><a href=\"https://pubmed.ncbi.nlm.nih.gov/1839378/#:~:text=Left%2Dhandedness%20occurs%20in%20about,monozygotic%20twins%20show%20substantial%20discordance\">The inheritance of left-handedness</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0705-rebecca-episode.png",
-		"guests": [
-			{
-				"name": "Rebecca Key",
-				"bio": "<p>Rebecca Key is a Software Engineer based out of Atlanta, GA. She is a first-generation college graduate that went on to obtain a PhD in Organic Chemistry from Georgia Tech. After many years in research (roles ranging from Laboratory Technician to Research Director), she made a career change into the tech field, where she currently works as an Independent Front-End Engineer. When not coding, she enjoys mountain biking, running, weightlifting, crocheting, and knitting!</p><ul><li><p><a href=\"http://rebeccakeyphd.com/\">rebeccakeyphd.com</a></p></li><li><p><a href=\"https://github.com/rek990\">@rek990</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/rebeccakeyphd\">@rebeccakeyphd</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/rebecca-key/\">@rebecca-key</a> on LinkedIn</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0705-rebecca.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Arthur Doler - The Human Side of Tech",
-		"slug": "arthur-doler-the-human-side-of-tech",
-		"id": "1727",
-		"metaDescription": "Season Seven, Episode Six of the Virtual Coffee Podcast",
-		"season": 7,
-		"episode": 6,
-		"buzzsproutId": "12407750",
-		"publishDate": "2023-03-09T05:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Arthur Doler about team dynamics, motivation, and how to identify problematic situations.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Arthur Doler, a Software Engineer and Community and Culture Steward, and chatted about the human side of tech, the importance of recognizing our emotions, communication styles, and the dynamics of the environments we're working in.</p><h3>Links:</h3><ul><li><p><a href=\"https://www.danpink.com/books/drive/\">Daniel Pink's Drive</a></p></li><li><p><a href=\"https://youtu.be/-XYK8ulQId0\">Arthur's talk: You're Not Just Tired: The Psychology of Burnout</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Aikido\">Aikido</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/List_of_disc_golf_players\">Pro Disc Golfers</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0706-arthur-episode.jpg",
-		"guests": [
-			{
-				"name": "Arthur Doler",
-				"bio": "<p>Arthur (or Art, take your pick) has been a software engineer for 19 years and has worked on things as exciting as analysis software for casinos and things as boring as banking websites. He is an advocate for talking openly about mental health and psychology in the technical world, and he spends a lot of time thinking about <em>how</em> we program and <em>why</em> we program, and about the tools, structures, cultures, and mental processes that help and hinder us from our ultimate goal of writing amazing things. His hair is brown and his thorax is a shiny blue color.</p><ul><li><p><a href=\"https://arthurdoler.com\">arthurdoler.com</a></p></li><li><p><a href=\"https://github.com/doleraj\">@doleraj</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/arthurdoler\">@arthurdoler</a> on Twitter</p></li><li><p><a href=\"https://mastodon.sandwich.net/@arthurdoler\">@arthurdoler</a> on Mastodon</p></li><li><p><a href=\"https://www.linkedin.com/in/arthurdoler/\">@arthurdoler</a> on LinkedIn</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0706-arthur.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Dominic Duffin - Finding value in challenging ourselves",
-		"slug": "dominic-duffin-finding-value-in-challenging-ourselves",
-		"id": "1740",
-		"metaDescription": "Season Seven, Episode Seven of the Virtual Coffee Podcast",
-		"season": 7,
-		"episode": 7,
-		"buzzsproutId": "12453805",
-		"publishDate": "2023-03-16T04:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Dominic Duffin about the impact of non-traditional learning experiences and the importance of community collaboration.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Dominic Duffin, a Full-Stack Developer, Co-founder of ArtTechChat Twitter chat, Salon Host at The Interintellect, and Open Source contributor, and chatted about the the value gained in creating a learning environment wherever you go and the importance of participating in community experiences.</p><ul><li><p>Pass the Pen: <a href=\"https://codepen.io/collection/nZrZLy\">https://codepen.io/collection/nZrZLy</a></p></li><li><p><a href=\"@ArtTechChat on Twitter\"><u>https://twitter.com/arttechchat</u></a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0707-dominic-episode.jpg",
-		"guests": [
-			{
-				"name": "Dominic Duffin",
-				"bio": "<p>Full Stack Developer, community builder, remote worker and aspiring polymath. Passionate about open source everything, decentralization, peer-to-peer tech and cryptocurrency. Also to be found playing board games, studying paper maps and riding public transport.</p><ul><li><p><a href=\"https://dominicduffin.uk\">dominicduffin.uk</a></p></li><li><p><a href=\"https://github.com/dominicduffin1\">@dominicduffin1</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/DominicDuffin1\">@DominicDuffin1</a> on Twitter</p></li><li><p><a href=\"https://toot.cafe/@dominicduffin1\">@dominicduffin1</a> on Mastadon</p></li><li><p><a href=\"https://www.linkedin.com/in/dominic-duffin-a992b0225\">@dominic-duffin</a> on LinkedIn</p></li><li><p><a href=\"https://www.polywork.com/dominic\">@dominic</a> on Polywork</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0707-dominic.png"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Ramón Huidobro - Thoughtful Learning",
-		"slug": "ramón-huidobro-thoughtful-learning",
-		"id": "1756",
-		"metaDescription": "Season Seven, Episode Eight of the Virtual Coffee Podcast",
-		"season": 7,
-		"episode": 8,
-		"buzzsproutId": "12503114",
-		"publishDate": "2023-03-23T04:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Ramón Huidobro about asking good questions about your code and how to ask for help.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Ramón Huidobro, a developer advocate and DevEd enthusiast, and chatted about the process of learning and growing and how asking questions and knowing what questions to ask is an important part of the tech experience.</p><p>Check out Ramón's article <a href=\"https://ramonh.dev/2022/11/13/asking-for-help/\">about reaching out for help</a>!</p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0708-ramon-episode.jpg",
-		"guests": [
-			{
-				"name": "Ramón Huidobro",
-				"bio": "<p>Ramón Huidobro is a developer advocate and DevEd enthusiast. He thrives on lifting others up in their tech careers and loves a good CSS challenge. Always excited to talk about teaching tech, especialmente en Español, oder auf Deutsch.</p><ul><li><p><a href=\"https://https://ramonh.dev\">ramonh.dev</a></p></li><li><p><a href=\"https://github.com/hola-soy-milk\">@hola-soy-milk</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/hola_soy_milk\">@hola_soy_milk</a> on Twitter</p></li><li><p><a href=\"https://hachyderm.io/@hola_soy_milk\">@hola_soy_milk</a> on Mastadon</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0708-ramon.jpg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Season Seven Finale - Live with Nick Taylor",
-		"slug": "season-seven-finale-live-with-nick-taylor",
-		"id": "1772",
-		"metaDescription": "Season Seven, Episode Nine of the Virtual Coffee Podcast",
-		"season": 7,
-		"episode": 9,
-		"buzzsproutId": "12558497",
-		"publishDate": "2023-03-31T04:00:00+00:00",
-		"shortDescription": "<p>Join Bekah, Dan, and Special Guest Nick Taylor for a live-streamed episode of the Season Seven Finale!</p>",
-		"showNotes": "<p>Join Bekah, Dan, and Special Guest Nick Taylor for a live-streamed episode of the Season Seven Finale!</p><p>Watch the video replay here: <a href=\"https://www.youtube.com/watch?v=0Wj-zlORvm8\">https://www.youtube.com/watch?v=0Wj-zlORvm8</a></p><p>Watch our 2023 Spring Lightning Talks here: <a href=\"https://www.youtube.com/watch?v=O2CsTN-WEZ0\">https://www.youtube.com/watch?v=O2CsTN-WEZ0</a></p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0709-finale.png",
-		"guests": [],
-		"sponsors": []
-	},
-	{
-		"title": "VC Maintainers - Importance of Culture Citizenship",
-		"slug": "vc-maintainers-importance-of-culture-citizenship",
-		"id": "1796",
-		"metaDescription": "Season Eight, Episode One of the Virtual Coffee Podcast",
-		"season": 8,
-		"episode": 1,
-		"buzzsproutId": "12988617",
-		"publishDate": "2023-06-07T04:00:00+00:00",
-		"shortDescription": "<p><span>We're starting the new season with a conversation with our maintainers, including our new maintainer, Julia Seidman! We share our thought process for adding a maintainer and walk through our culture citizenship statement to share how we intend to create a positive community.</span></p>",
-		"showNotes": "<p><span>Starting off this new season, we're bringing in all of our maintainers, Bekah Hawrot Weigel, Dan Ott, Kirk Shillingford, and Julia Seidman. We walk through the importance of understanding communities, members, and how to create a positive community experience.</span></p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0801-Cover.jpeg",
-		"guests": [
-			{
-				"name": "Julia Seidman",
-				"bio": "<p><span>Julia Seidman is a developer education consultant based in the Seattle area. Julia is a believer in embracing the 'careen' over the career. </span></p>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Julia-Headshot.jpeg"
-			},
-			{
-				"name": "Kirk Shillingford",
-				"bio": "<p><span>A full stack developer in the Caribbean interested in Functional Programming, Domain Driven Development, and Security.</span></p>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Kirk-Headshot.jpeg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Alex Curtis-Slep - Enriching Your Life as a Developer",
-		"slug": "alex-curtis-slep-enriching-your-life-as-a-developer",
-		"id": "1827",
-		"metaDescription": "Season Eight, Episode Two of the Virtual Coffee Podcast",
-		"season": 8,
-		"episode": 2,
-		"buzzsproutId": "13038514",
-		"publishDate": "2023-06-15T04:00:00+00:00",
-		"shortDescription": "<p><span>In today's episode, Dan and Bekah talk to Alex about his gratifying journey as a self-taught developer and tools you can use to maintain a positive attitude, create balance, decrease stress, and form good habits to enrich your life.</span></p>",
-		"showNotes": "<p><span>This week Bekah and Dan sat down with Alex Curtis-Slep, long time member and volunteer and self-taught developer, about documenting the small wins, falling in love with the process, and aligning your goals to maintain a healthy life while job searching and during your tech career.</span></p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe.png",
-		"guests": [
-			{
-				"name": "Alex Curtis-Slep",
-				"bio": "<p>Alex Curtis-Slep is a self taught software developer. After getting his initial tastes of HTML and CSS in the early 2000’s on his basketball blog, Alex jumped into coding in early 2019. He heard about a course Madison Kanna created on roadmapping to become a developer and took the plunge. Following a few years of learning, creating, contributing to open source, and much more, Alex landed his first job in tech at Paypixl. When he’s not coding and hyping up his developer friends, he loves everything basketball, tropical fruit, vegan, travel, family, friend, and foreign language related!</p><ul><li><p><a href=\"http://alexcurtisslep.com\">alexcurtisslep.com</a></p></li><li><p><a href=\"https://github.com/AlexVCS\" rel=\"noopener noreferrer\" target=\"_blank\">@AlexVCS</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/AlexCurtisSlep\" rel=\"noopener noreferrer\" target=\"_blank\">@AlexCurtisSlep</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/alexcurtisslep/\" rel=\"noopener noreferrer\" target=\"_blank\">@alexcurtisslep</a> on LinkedIn</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Alex-Curtis.jpeg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Carmen - Tech Industry Friendships: Leveraging Connections for Growth, Challenges, and Opportunities and DevOps!",
-		"slug": "carmen-tech-industry-friendships-leveraging-connections-for-growth-challenges-and-opportunities-and-devops",
-		"id": "1841",
-		"metaDescription": "Season Eight, Episode Three of the Virtual Coffee Podcast",
-		"season": 8,
-		"episode": 3,
-		"buzzsproutId": "13047459",
-		"publishDate": "2023-06-21T04:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Carmen about the impactful role of friendships in the tech industry. We talked about how these connections positively influenced her professional journeys, helped her overcome challenges, and contributed to career growth in DevOps.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Carmen Kohole, a DevOps Engineer based in Portland, Oregon, to chat about the benefits of collaboration and the valuable opportunities you can gain just by asking for help. We also discussed the benefits of fostering strong relationships in the tech industry, and what it means to be a DevOps engineer.</p><h3>Links:</h3><ul><li><p><a href=\"https://twitter.com/thejonanshow\">Jonan Scheffler</a></p></li><li><p><a href=\"https://twitter.com/nickytonline\">Nick Taylor</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0803-Carmen.png",
-		"guests": [
-			{
-				"name": "Carmen",
-				"bio": "<p>DevOps Engineer based in Portland, Oregon. Big fan of house plants, hiking, hats and cats. Here to help build stuff, break stuff, learn stuff and make friends.</p><ul><li><p><a href=\"https://github.com/carmenkolohe\" rel=\"noopener noreferrer\" target=\"_blank\">@carmenkolohe</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/carmenkolohe\" rel=\"noopener noreferrer\" target=\"_blank\">@carmenkolohe</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/carmenkolohe/\" rel=\"noopener noreferrer\" target=\"_blank\">@carmenkolohe</a> on LinkedIn</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Carmen.jpeg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Caitlin Floyd - Mentorship",
-		"slug": "caitlin-floyd",
-		"id": "1855",
-		"metaDescription": "Season Eight, Episode Four of the Virtual Coffee Podcast",
-		"season": 8,
-		"episode": 4,
-		"buzzsproutId": "13121425",
-		"publishDate": "2023-06-28T04:00:00+00:00",
-		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Caitlin about expanding the definition of tech mentorship. We challenge the traditional one-on-one approach and delve into group and community mentorship, where learning, growth, and curiosity thrive collectively. We discuss how active and empathetic listening fosters understanding and knowledge exchange.</p>",
-		"showNotes": "<p>This week Bekah and Dan sat down with Caitlin Floyd, a front-end developer, to chat about the concept of collective learning and explore new possibilities in the evolving landscape of tech mentorship. Discover firsthand how Caitlin's experiences highlight the power of collaboration, breaking down silos, and leveraging collective knowledge to drive innovation and success.</p><h3>Links:</h3><ul><li><p><a href=\"https://the-collab-lab.codes/\">Collab Lab</a></p></li><li><p><a href=\"https://dev.to/the-collab-lab/tcl-22-recap-211m/\">Recap of a Collab Lab cohort that Caitlin participated in</a></p></li><li><p><a href=\"https://leaddev.com/mentoring-coaching-feedback/mentor-coach-sponsor-guide-developing-engineers\">Mentor, coach, sponsor: a guide to developing engineers</a> by Neha Batra</p></li><li><p><a href=\"https://kwugirl.blogspot.com/2020/10/secrets-of-stealth-mentee.html?m=1\">Secrets of a Stealth Mentee</a> by KWu</p></li><li><p><a href=\"https://larahogan.me/sponsors/\">Mentorship and Sponsorship</a> by Lara Hogan</p></li><li><p><a href=\"https://cate.blog/2017/03/21/sponsorship-can-start-small/\">Sponsorship Can Start Small</a> by Cate</p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe_2023-06-28-031129_uyfo.png",
-		"guests": [
-			{
-				"name": "Caitlin Floyd",
-				"bio": "<p>Caitlin is a front-end developer driven by the power of technology as a force for good. Before entering tech, she worked in linguistics, education, and nonprofit management. When not coding, she loves reading, studying languages, traveling, and most of all doting on her puppy.</p><ul><li><p><a href=\"https://caitlinfoyd.com\">caitlinfoyd.com</a></p></li><li><p><a href=\"https://github.com/cafloyd\" rel=\"noopener noreferrer\" target=\"_blank\">@cafloyd</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/caitlinfloyd\" rel=\"noopener noreferrer\" target=\"_blank\">@caitlinfloyd</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/caitlinfloyd/\" rel=\"noopener noreferrer\" target=\"_blank\">@caitlinfloyd</a> on LinkedIn</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Caitlin.jpeg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Reda - From Maritime Engineer to Self-Taught Front-End Developer",
-		"slug": "reda-from-maritime-engineer-to-self-taught-front-end-developer",
-		"id": "1880",
-		"metaDescription": "Season Eight, Episode Five of the Virtual Coffee Podcast",
-		"season": 8,
-		"episode": 5,
-		"buzzsproutId": "13204285",
-		"publishDate": "2023-07-12T04:00:00+00:00",
-		"shortDescription": "<p>Join hosts Bekah and Dan in this inspiring episode as they talk through the captivating journey of Reda, a self-taught developer. Discover the challenges and triumphs of the world of programming solo, and gain valuable insights on the optimal timing for job applications—because as Reda shares the advice he was given, \"When should you start applying for jobs? Yesterday.\"</p>",
-		"showNotes": "<p><span>Join Bekah and Dan in this week's episode, where they dive into the transformative journey of Reda, a self-taught developer. Hear about the unique challenges and victories Reda faced as he navigated the journey to becoming a front-end developer. Gain valuable advice on the ideal timing for job applications, as Reda shares advice he heard along his journey: \"When should you start applying for jobs? Yesterday.\" Tune in for an enriching conversation that will inspire aspiring self-taught developers and offer practical insights for your career paths.</span></p><h3>Links: </h3><ul><li><p><a href=\"https://www.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Free Code Camp</a></p></li><li><p><a href=\"https://the-collab-lab.codes/\" rel=\"noopener noreferrer\" target=\"_blank\">Collab Lab</a></p></li><li><p><a href=\"https://www.coursera.org/specializations/python\" rel=\"noopener noreferrer\" target=\"_blank\">Python Course</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe_2023-07-11-193524_yhob.png",
-		"guests": [
-			{
-				"name": "Reda",
-				"bio": "<p>I'm a self-taught front-end developer based in Morocco, with a background in Marine Mechanics.</p><ul><li><p><a href=\"https://github.com/redapy\" rel=\"noopener noreferrer\" target=\"_blank\">redapy</a> on GitHub</p></li><li><p><a href=\"https://www.google.com/url?sa=t&amp;rct=j&amp;q=&amp;esrc=s&amp;source=web&amp;cd=&amp;cad=rja&amp;uact=8&amp;ved=2ahUKEwjSsLzRsYeAAxVBmGoFHUEQDNUQFnoECBAQAQ&amp;url=https%3A%2F%2Ftwitter.com%2Fredabaha12&amp;usg=AOvVaw2LtVxW6oDxwQ_Aq1KKL3ik&amp;opi=89978449\" rel=\"noopener noreferrer\" target=\"_blank\">redabaha12</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/redabaha/\" rel=\"noopener noreferrer\" target=\"_blank\">redabaha</a> on LinkedIn</p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Reda.jpeg"
-			}
-		],
-		"sponsors": []
-	},
-	{
-		"title": "Josh - The Life of a Full Time Open Source Developer",
-		"slug": "josh-the-life-of-a-full-time-open-source-developer",
-		"id": "1895",
-		"metaDescription": "Season Eight, Episode Six of the Virtual Coffee Podcast",
-		"season": 8,
-		"episode": 6,
-		"buzzsproutId": "13247190",
-		"publishDate": "2023-07-19T04:00:00+00:00",
-		"shortDescription": "<p>In this episode, Dan and Bekah explore the fascinating journey of being a full-time open source contributor with Josh Goldberg. We discuss the challenges and rewards of dedicating yourself to the open source ecosystem, TypeScript's growing popularity, and how Josh supports the tech community.</p>",
-		"showNotes": "<p>Join Bekah and Dan in this week's episode, where they talk with Josh Goldberg, an independent full time open source developer working on projects in the TypeScript ecosystem, where he shares valuable tips and insights on how you can get started with contributing to open source, whether you're a seasoned developer or just dipping your toes into OSS. Josh also shares the story of his prolific speaking journey over the last couple of years and how staying involved in the tech community has been a rewarding experience.</p><p><strong>Links:</strong></p><ul><li><p><a href=\"https://typescript-eslint.io/\" rel=\"noopener noreferrer\" target=\"_blank\">typescript-eslint</a></p></li><li><p><a href=\"https://github.com/typescript-eslint/typescript-eslint\" rel=\"noopener noreferrer\" target=\"_blank\">typescript-eslint GitHub</a></p></li><li><p><a href=\"https://www.codecademy.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Code Academy</a></p></li><li><p><a href=\"https://sway.office.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Microsoft Sway</a> </p></li><li><p>Josh's Blog posts about applying to conferences:</p><ul><li><p><a href=\"https://blog.joshuakgoldberg.com/how-i-apply-to-conferences/\" rel=\"noopener noreferrer\" target=\"_blank\">How I Apply to Conferences</a></p></li><li><p><a href=\"https://blog.joshuakgoldberg.com/how-i-apply-to-conferences-faqs/\" rel=\"noopener noreferrer\" target=\"_blank\">How I Apply to Conferences: FAQs</a></p></li></ul></li><li><p>Josh's Book: <a href=\"https://www.learningtypescript.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Learning Typescript</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe_2023-07-19-033240_jrwt.png",
-		"guests": [
-			{
-				"name": "Josh Golberg",
-				"bio": "<p>Hi, I’m Josh! I’m an independent full time open source developer. I work on projects in the TypeScript ecosystem, most notably typescript-eslint: the tooling that enables ESLint and Prettier to run on TypeScript code. I’m also the author of the O’Reilly Learning TypeScript book, a Microsoft MVP for developer technologies, and an active conference speaker.</p>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Josh.jpeg"
-			}
-		],
 		"sponsors": [
 			{
 				"title": "LevelUP Financial planning",
@@ -1537,24 +39,18 @@
 		]
 	},
 	{
-		"title": "Taiwo Yusuf - The Importance of Having a Learning Mindset",
-		"slug": "taiwo-yusuf-the-importance-of-having-a-learning-mindset",
-		"id": "1910",
-		"metaDescription": "Season Eight, Episode Seven of the Virtual Coffee Podcast",
-		"season": 8,
-		"episode": 7,
-		"buzzsproutId": "13295814",
-		"publishDate": "2023-07-26T04:00:00+00:00",
-		"shortDescription": "<p>In this episode, Dan and Bekah chat with Taiwo, a backend developer from Nigeria. He shares his journey from Electrical Engineering Major to backend development, and the importance of staying motivated and always being hungry to learn and grow.</p>",
-		"showNotes": "<p>Join Bekah and Dan in this week's episode,  where they talk with Taiwo Yusuf, a back-end engineer with a passion for developing innovative solutions.  Despite being the top of his class in Electrical Engineering, he found his passion in backend development. He shares the importance of always learning, growing, and surrounding yourself with people who are more skilled than you are to find inspiration, support, and motivation.</p><p><strong>Links:</strong></p><ul><li><p><a href=\"https://www.grace.health/\" rel=\"noopener noreferrer\" target=\"_blank\">Grace Health</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe-1.png",
-		"guests": [
-			{
-				"name": "Taiwo Yusuf",
-				"bio": "<p>I'm Taiwo Yusuf, a back-end engineer with a passion for developing innovative solutions. I've been fortunate enough to work with amazing companies like Grace Health, LogicShift, and JufoPay. When I'm not busy coding, I'm an avid fan of generative art, and I adore cats. So, whether you want to talk about tech, art, or felines, let's connect and have a chat!</p>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/3bmcquEcQTRCESX5KIOTJO-AvdRCqPIKvQDtqprXWGY.png"
-			}
-		],
+		"title": "Building Relationships in Open Source",
+		"slug": "building-relationships-in-open-source",
+		"id": "2172",
+		"metaDescription": "Season 10, Episode 6 of the Virtual Coffee Podcast",
+		"season": 10,
+		"episode": 6,
+		"buzzsproutId": "15931952",
+		"publishDate": "2024-10-15T04:00:00+00:00",
+		"shortDescription": "<p>The Virtual Coffee Podcast explores the significance of relationship-building and mentorship in open-source communities during Hacktoberfest, underlining practical advice, effective communication, and providing support to foster a welcoming environment for contributors.</p>",
+		"showNotes": "<p><span>In Season 10, Episode 6 of the Virtual Coffee Podcast, hosts Bekah and Dan explore the multifaceted aspects of building and nurturing relationships within the open source community, particularly during Hacktoberfest. The episode highlights the significance of effective networking, making meaningful connections, and becoming a valued repeat contributor. The hosts provide practical advice for newcomers, stressing the importance of understanding projects, submitting quality pull requests, and contributing beyond code through community management and content creation. Emphasizing mentorship, they discuss how maintainers can aid first-time contributors via comprehensive readme files, contributing guides, and constructive feedback. The importance of communication, relationship-building, and the impact of small gestures like a simple thank you are also covered to foster a supportive and efficient open source community.</span></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E06.png",
+		"guests": [],
 		"sponsors": [
 			{
 				"title": "LevelUP Financial planning",
@@ -1567,24 +63,18 @@
 		]
 	},
 	{
-		"title": "Rafi - Exploring Side Projects and AI",
-		"slug": "rafi-exploring-side-projects-and-ai",
-		"id": "1919",
-		"metaDescription": "Season Eight, Episode Eight of the Virtual Coffee Podcast",
-		"season": 8,
-		"episode": 8,
-		"buzzsproutId": "13331830",
-		"publishDate": "2023-08-02T04:00:00+00:00",
-		"shortDescription": "<p>Join Bekah and Dan in this week's episode,  where they talk with Rafi, a full-stack engineer who develops his passion and motivation with side projects.  Rafi highlights the importance of focusing on developing side projects using a time limit and completing tasks. Learn Rafi's approach to using AI as a tool in his toolbox to accelerate the development process.</p>",
-		"showNotes": "<p>Join hosts Bekah and Dan in this episode featuring Rafi, a talented full-stack developer from Bangalore. In this episode, you'll discover how building new things  and making progress helps him find calmness and focus. Learn Rafi's approach to side projects, including his exploration of Blender, mobile development, Chrome extensions, and Ionic framework. Rafi also shares valuable tips on leveraging AI to enhance learning during project work</p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe.png",
-		"guests": [
-			{
-				"name": "Rafi",
-				"bio": "<p>I am a developer, hobbyist who loves JavaScript, Star trek and Cats. I build things, talk tech and write things.</p>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Rafi.png"
-			}
-		],
+		"title": "Open Source Maintainer Challenges and Benefits",
+		"slug": "open-source-maintainer-challenges-and-benefits",
+		"id": "2167",
+		"metaDescription": "Season 10, Episode 5 of the Virtual Coffee Podcast",
+		"season": 10,
+		"episode": 5,
+		"buzzsproutId": "15891752",
+		"publishDate": "2024-10-08T04:00:00+00:00",
+		"shortDescription": "<p><span>Bekah and Dan share personal experiences of maintaining open source projects, highlight the benefits of creating a community of contributors, and offer insights into tools and strategies for effective project management and collaboration.</span></p>",
+		"showNotes": "<p>In this episode of the Virtual Coffee Podcast, hosts Bekah and Dan delve into the benefits and challenges of being a maintainer in open source projects, particularly during Hacktoberfest. They discuss the excitement and responsibility of maintaining projects, the joy of welcoming new contributors, and the importance of community building. The hosts also highlight the preparation involved in enhancing project onboarding and documentation, and the growth opportunities for maintainers. The episode also emphasizes strategies to attract contributors and the impact of efficiently managing open source projects.</p><h3>Links:</h3><ul><li><p><a href=\"https://opensauced.pizza/learn\">https://opensauced.pizza/learn</a></p></li><li><p>Becoming an Open Source Maintainer</p></li></ul><p></p><p>00:00 Welcome to Virtual Coffee Podcast</p><p>00:26 Hacktoberfest Excitement and Open Source</p><p>00:43 Sponsorship Shoutout</p><p>01:06 Grab Your Drink and Settle In</p><p>01:34 Maintainer Experiences and Challenges</p><p>03:44 The Joy of Hacktoberfest</p><p>05:08 Maintaining Beyond Hacktoberfest</p><p>08:13 The Importance of Onboarding</p><p>09:29 PrepTember and Readiness</p><p>11:01 Building Trust and Community</p><p>12:18 The Benefits of Being a Maintainer</p><p>17:32 Growing as a Maintainer</p><p>18:40 Marketing Your Open Source Project</p><p>21:06 Community Support and Resources</p><p>23:44 Wrapping Up and Final Thoughts</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E05.png",
+		"guests": [],
 		"sponsors": [
 			{
 				"title": "LevelUP Financial planning",
@@ -1597,62 +87,118 @@
 		]
 	},
 	{
-		"title": "Ayu & Dominic - Hacktoberfest is Coming, Preptember is Here!",
-		"slug": "ayu-dominic-hacktoberfest-is-coming-preptember-is-here",
-		"id": "1940",
-		"metaDescription": "Season 9, Episode 1 of the Virtual Coffee Podcast",
+		"title": "How to Make a Positive Impact during Hacktoberfest",
+		"slug": "how-to-make-a-positive-impact-during-hacktoberfest",
+		"id": "2161",
+		"metaDescription": "Season 10, Episode 4 of the Virtual Coffee Podcast",
+		"season": 10,
+		"episode": 4,
+		"buzzsproutId": "15841150",
+		"publishDate": "2024-09-30T04:00:00+00:00",
+		"shortDescription": "<p>Welcome to Hacktoberfest!</p>",
+		"showNotes": "<p>Bekah and Dan explore the community's engagement with Hacktoberfest, a month-long event encouraging open source contributions. They discuss what Hacktoberfest is and what it means to be a positive contributor in the open source community. They highlight the importance of meaningful contributions, respecting maintainers' time, and provides tips for navigating and contributing to open source projects, and touches on ways to be a good open source citizen and the benefits of contributing consistently to a single project or organization. The episode emphasizes understanding project documentation and being patient with maintainers, while exploring various ways to support open source initiatives beyond writing code.</p><ul><li><p><code>00:00</code> Welcome to the Virtual Coffee Podcast</p></li><li><p><code>00:25</code> Introduction to Hacktoberfest</p></li><li><p><code>00:45</code> Sponsorship Shoutout</p></li><li><p><code>01:08</code> Getting Started with Hacktoberfest</p></li><li><p><code>02:01</code> The Origins of Virtual Coffee and Hacktoberfest</p></li><li><p><code>05:01</code> How to Contribute Positively</p></li><li><p><code>13:02</code> The Importance of Documentation</p></li><li><p><code>18:04</code> Non-Code Contributions</p></li><li><p><code>24:02</code> Building Relationships in Open Source</p></li><li><p><code>26:25</code> Closing Remarks and Contact Information</p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E04.png",
+		"guests": [],
+		"sponsors": [
+			{
+				"title": "LevelUP Financial planning",
+				"url": "https://www.levelupfinancialplanning.com/?vc",
+				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+				"logoWidth": 679,
+				"logoHeight": 525,
+				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+			}
+		]
+	},
+	{
+		"title": "'Big M' versus 'Little m' Mentorship",
+		"slug": "big-m-versus-little-m-mentorship",
+		"id": "2154",
+		"metaDescription": "Season 10, Episode 3 of the Virtual Coffee Podcast",
+		"season": 10,
+		"episode": 3,
+		"buzzsproutId": "15809647",
+		"publishDate": "2024-09-24T04:00:00+00:00",
+		"shortDescription": "<p><span>Bekah and Dan discuss the differences between formal and informal mentorship, sharing insights on how community and personal connections play a role in effective mentorship.</span></p>",
+		"showNotes": "<p><span>In Season 10, Episode 3 of the Virtual Coffee Podcast, hosts Bekah and Dan explore the topic of 'Big M' versus 'Little m' Mentorship. They distinguish between formal, one-on-one mentorship ('Big M') and more informal, community-based mentorship ('Little M'). They discuss the advantages and potential pitfalls of each approach, emphasizing the importance of finding the right mentorship fit. They also touch on the role of coaches, the value of community support in events like Hacktoberfest, and the concept of a personal 'board of mentors.' </span></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E03.png",
+		"guests": [],
+		"sponsors": [
+			{
+				"title": "LevelUP Financial planning",
+				"url": "https://www.levelupfinancialplanning.com/?vc",
+				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+				"logoWidth": 679,
+				"logoHeight": 525,
+				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+			}
+		]
+	},
+	{
+		"title": "How to Build Trust Capital",
+		"slug": "how-to-build-trust-capital",
+		"id": "2146",
+		"metaDescription": "Season 10, Episode 2 of the Virtual Coffee Podcast",
+		"season": 10,
+		"episode": 1,
+		"buzzsproutId": "15762421",
+		"publishDate": "2024-09-16T04:00:00+00:00",
+		"shortDescription": "<p>Bekah and Dan discuss the concept of 'trust capital' and its importance in tech communities.</p>",
+		"showNotes": "<p><span>In Episode 2 of Season 10 of the Virtual Coffee podcast, hosts Bekah and Dan discuss the concept of 'trust capital' and its importance in tech communities. They define trust capital as the value and trustworthiness one has with others. The hosts explore how to build trust through consistent actions, showing up, transparency, and effective communication. They highlight the difference between networking and building genuine relationships, emphasizing practical ways to accumulate trust capital, such as writing blog posts, mentoring, and being an active, dependable community member. The episode underscores the benefits of trust capital in fostering credibility, enhancing professional relationships, and reducing barriers to collaborative progress.</span></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E02.png",
+		"guests": [],
+		"sponsors": [
+			{
+				"title": "LevelUP Financial planning",
+				"url": "https://www.levelupfinancialplanning.com/?vc",
+				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+				"logoWidth": 679,
+				"logoHeight": 525,
+				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+			}
+		]
+	},
+	{
+		"title": "Remote Collaboration Tools and Techniques",
+		"slug": "remote-collaboration-tools-and-techniques",
+		"id": "2142",
+		"metaDescription": "Season 10, Episode 1 of the Virtual Coffee Podcast",
+		"season": 10,
+		"episode": 1,
+		"buzzsproutId": "15727596",
+		"publishDate": "2024-09-10T04:00:00+00:00",
+		"shortDescription": "<p><span>In the first episode of Season 10 of the Virtual Coffee Podcast, hosts Bekah and Dan introduce the new format focusing on </span>\"back pocket topics\" from Virtual Coffee <span>community discussions, beginning with a discussion on tools and techniques for remote collaboration.</span></p>",
+		"showNotes": "<p><span>In the first episode of Season 10 of the Virtual Coffee podcast, hosts Bekah and Dan introduce the new format focusing on \"back pocket topics\" from Virtual Coffee community discussions. They delve into common remote collaboration tools and techniques, sharing insights from their experiences in tech. Topics include effective communication, the importance of documentation, and how different company cultures influence remote work. The episode also touches on the role of community members in improving knowledge sharing, both in work settings and open-source projects.</span></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E01.png",
+		"guests": [],
+		"sponsors": [
+			{
+				"title": "LevelUP Financial planning",
+				"url": "https://www.levelupfinancialplanning.com/?vc",
+				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+				"logoWidth": 679,
+				"logoHeight": 525,
+				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+			}
+		]
+	},
+	{
+		"title": "Jessica Wilkins - Using Open Source to Create Connections",
+		"slug": "jessica-wilkins-using-open-source-to-create-connections",
+		"id": "2105",
+		"metaDescription": "Season 9, Episode 4 of the Virtual Coffee Podcast",
 		"season": 9,
-		"episode": 1,
-		"buzzsproutId": "13611744",
-		"publishDate": "2023-09-18T04:00:00+00:00",
-		"shortDescription": "<p><span>Join hosts Bekah and Dan in this episode featuring Dominic and Ayu as we explore Preptember—the month where we prepare for Hacktoberfest—and the importance of taking the month to prepare, learn more about open source projects, and evaluate open source repositories to recommend to contributors.</span></p>",
-		"showNotes": "<p>Join hosts Bekah and Dan in this episode with monthly challenge Preptember leads, Dominic and Ayu. We talk about the importance of preparing both as a contributor and a maintainer,  some of the challenges you might face as someone new to those roles during Hacktoberfest, and some of the benefits you'll receive by participating in open source.</p><h3>Links</h3><ul><li><p><a href=\"https://virtualcoffee.io/podcast/0303-ayu-adiati\">Ayu's Episode: Working through burnout as a self-taught developer</a></p></li><li><p><a class=\"postlist-title\" href=\"https://virtualcoffee.io/podcast/dominic-duffin-finding-value-in-challenging-ourselves\">Dominic's Episode: Finding value in challenging ourselves</a></p></li><li><p><a href=\"https://github.com/issues\">Your GitHub Issues</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0901-ayu-dominic.png",
-		"guests": [
-			{
-				"name": "Dominic Duffin",
-				"bio": "<p>Dominic is a Full Stack Developer, community builder, remote worker and aspiring polymath. He's passionate about open source everything, decentralization, peer-to-peer tech and cryptocurrency. He's also to be found playing board games, studying paper maps and riding public transport.</p>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0707-dominic.png"
-			},
-			{
-				"name": "Ayu Adiati",
-				"bio": "<p>Ayu is a self-taught front-end developer and technical blogger based in The Netherlands.</p><p class=\"text-left\">She has a strong interest in building projects that are accessible to everyone.</p><p class=\"text-left\">Her passion for life-long learning is what motivates her open-source contributions, project collaboration, and community engagement.</p><p class=\"text-left\">Learning new things is something that fills her with excitement and she's eager to share her learning in public and pass on her knowledge through her blog and Twitter.</p>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0303-ayu.jpg"
-			}
-		],
-		"sponsors": [
-			{
-				"title": "LevelUP Financial planning",
-				"url": "https://www.levelupfinancialplanning.com/?vc",
-				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
-				"logoWidth": 679,
-				"logoHeight": 525,
-				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
-			}
-		]
-	},
-	{
-		"title": "OSS Book Review: Nadia Eghbal's Working in Public - The Making and Maintenance of Open Source Software",
-		"slug": "working-in-public-the-making-and-maintenance-of-open-source-software-book-review",
-		"id": "1967",
-		"metaDescription": "Season Nine, Episode Two of the Virtual Coffee Podcast",
-		"season": 9,
-		"episode": 2,
-		"buzzsproutId": "13668999",
-		"publishDate": "2023-09-26T04:00:00+00:00",
-		"shortDescription": "<p><span>Join hosts Bekah and Dan in this episode featuring Jessica Wilkins and Brian Meeker as we delve into the insights from </span>Nadia Eghbal's book \"Working in Public.\" Discover the intricacies of open source collaboration, the evolving dynamics of digital communities, and the profound impact of individual contributions.</p>",
-		"showNotes": "<p>Join hosts Bekah and Dan in this episode with Nadia Eghbal's \"Working in Public\" enthusiasts Jessica Wilkins and Brian Meeker. We discuss the nuances of open source collaboration highlighted in the book, the challenges and rewards of being both a contributor and a maintainer, and the profound impact of individual contributions in the open source community. Dive into the transformative journey of participating in open source and redefining its true meaning with OpenSauced.</p><h3>Links</h3><ul><li><p><a href=\"https://press.stripe.com/working-in-public\">Working in Public: The Making and Maintenance of Open Source Software by Nadia Eghbal</a></p></li><li><p><a href=\"https://github.com/orgs/Virtual-Coffee/discussions/932\">Virtual Coffee Book Club Discussion</a></p></li><li><p><a href=\"https://qz.com/646467/how-one-programmer-broke-the-internet-by-deleting-a-tiny-piece-of-code\">The left-pad story</a></p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0902.png",
+		"episode": 4,
+		"buzzsproutId": "13897541",
+		"publishDate": "2023-11-02T04:00:00+00:00",
+		"shortDescription": "<p>Join hosts Bekah and Dan in this enlightening episode with Jessica Wilkins. Dive deep into the art of nurturing relationships in the open source community. Learn the intricacies of collaborating with maintainers, the value of non-traditional skillsets, and the journey of personal growth as a contributor. </p>",
+		"showNotes": "<p>Join hosts Bekah and Dan as they engage in a captivating conversation with Jessica Wilkins, a prominent figure from freeCodeCamp. In this episode, Jessica shares her invaluable insights on nurturing and developing relationships within the open source community. Delve into the nuances of effective collaboration with maintainers, understand the significance of embracing non-traditional skillsets, and discover the pathways to flourish as a contributor. Jessica's experiences with freeCodeCamp provide a unique perspective on the human dynamics and interpersonal relationships that form the backbone of successful open source projects.</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0904-jessica.png",
 		"guests": [
 			{
 				"name": "Jessica Wilkins",
 				"bio": "<p>Jessica Wilkins is a self taught developer and technical writer from Los Angeles, California.</p><p class=\"text-left\">In her previous career, she was a professional oboist, educator and owner of JDW Sheet Music.</p><p class=\"text-left\">Jessica's interest in programming came during the pandemic when she wanted to build the Black Excellence Music Project which celebrates black artists from the jazz and classical fields.</p><p class=\"text-left\">She now works for freeCodeCamp on the curriculum team.</p><ul><li><p class=\"text-left\"><a href=\"https://github.com/jdwilkin4\"><u>@jdwilkin4 on GitHub</u></a></p></li><li><p class=\"text-left\"><a href=\"https://twitter.com/codergirl1991?lang=en\"><u>@codergirl1991 on Twitter</u></a></p></li><li><p class=\"text-left\"><a href=\"https://www.linkedin.com/in/jessica-wilkins-developer\"><u>@jessica-wilkins-developer on LinkedIn</u></a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0407-jessica.jpg"
-			},
-			{
-				"name": "Brian Meeker",
-				"bio": "<p>Brian Meeker is a full stack engineer who occasionally leaves his basement in Indiana. Currently, he works as a Senior Engineer at Online Rewards. He works mostly in Elixir these days, but has a past littered with a wide variety of technologies and platforms. Outside of work, Brian is a devoted father, avid nerd, and lover of metal.</p><ul><li><p><a href=\"https://brianmeeker.me/\"><u>brianmeeker.me</u></a></p></li><li><p><a href=\"https://github.com/CuriousCurmudgeon\"><span>@CuriousCurmudgeon on GitHub</span></a></p></li><li><p><a href=\"https://twitter.com/CuriousCurmudge\">@CuriousCurmudge on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/brianmeeker\">@brianmeeker on LinkedIn</a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/headshot_cropped.png"
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0904-jessica.png"
 			}
 		],
 		"sponsors": [
@@ -1707,22 +253,27 @@
 		]
 	},
 	{
-		"title": "Jessica Wilkins - Using Open Source to Create Connections",
-		"slug": "jessica-wilkins-using-open-source-to-create-connections",
-		"id": "2105",
-		"metaDescription": "Season 9, Episode 4 of the Virtual Coffee Podcast",
+		"title": "OSS Book Review: Nadia Eghbal's Working in Public - The Making and Maintenance of Open Source Software",
+		"slug": "working-in-public-the-making-and-maintenance-of-open-source-software-book-review",
+		"id": "1967",
+		"metaDescription": "Season Nine, Episode Two of the Virtual Coffee Podcast",
 		"season": 9,
-		"episode": 4,
-		"buzzsproutId": "13897541",
-		"publishDate": "2023-11-02T04:00:00+00:00",
-		"shortDescription": "<p>Join hosts Bekah and Dan in this enlightening episode with Jessica Wilkins. Dive deep into the art of nurturing relationships in the open source community. Learn the intricacies of collaborating with maintainers, the value of non-traditional skillsets, and the journey of personal growth as a contributor. </p>",
-		"showNotes": "<p>Join hosts Bekah and Dan as they engage in a captivating conversation with Jessica Wilkins, a prominent figure from freeCodeCamp. In this episode, Jessica shares her invaluable insights on nurturing and developing relationships within the open source community. Delve into the nuances of effective collaboration with maintainers, understand the significance of embracing non-traditional skillsets, and discover the pathways to flourish as a contributor. Jessica's experiences with freeCodeCamp provide a unique perspective on the human dynamics and interpersonal relationships that form the backbone of successful open source projects.</p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0904-jessica.png",
+		"episode": 2,
+		"buzzsproutId": "13668999",
+		"publishDate": "2023-09-26T04:00:00+00:00",
+		"shortDescription": "<p><span>Join hosts Bekah and Dan in this episode featuring Jessica Wilkins and Brian Meeker as we delve into the insights from </span>Nadia Eghbal's book \"Working in Public.\" Discover the intricacies of open source collaboration, the evolving dynamics of digital communities, and the profound impact of individual contributions.</p>",
+		"showNotes": "<p>Join hosts Bekah and Dan in this episode with Nadia Eghbal's \"Working in Public\" enthusiasts Jessica Wilkins and Brian Meeker. We discuss the nuances of open source collaboration highlighted in the book, the challenges and rewards of being both a contributor and a maintainer, and the profound impact of individual contributions in the open source community. Dive into the transformative journey of participating in open source and redefining its true meaning with OpenSauced.</p><h3>Links</h3><ul><li><p><a href=\"https://press.stripe.com/working-in-public\">Working in Public: The Making and Maintenance of Open Source Software by Nadia Eghbal</a></p></li><li><p><a href=\"https://github.com/orgs/Virtual-Coffee/discussions/932\">Virtual Coffee Book Club Discussion</a></p></li><li><p><a href=\"https://qz.com/646467/how-one-programmer-broke-the-internet-by-deleting-a-tiny-piece-of-code\">The left-pad story</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0902.png",
 		"guests": [
 			{
 				"name": "Jessica Wilkins",
 				"bio": "<p>Jessica Wilkins is a self taught developer and technical writer from Los Angeles, California.</p><p class=\"text-left\">In her previous career, she was a professional oboist, educator and owner of JDW Sheet Music.</p><p class=\"text-left\">Jessica's interest in programming came during the pandemic when she wanted to build the Black Excellence Music Project which celebrates black artists from the jazz and classical fields.</p><p class=\"text-left\">She now works for freeCodeCamp on the curriculum team.</p><ul><li><p class=\"text-left\"><a href=\"https://github.com/jdwilkin4\"><u>@jdwilkin4 on GitHub</u></a></p></li><li><p class=\"text-left\"><a href=\"https://twitter.com/codergirl1991?lang=en\"><u>@codergirl1991 on Twitter</u></a></p></li><li><p class=\"text-left\"><a href=\"https://www.linkedin.com/in/jessica-wilkins-developer\"><u>@jessica-wilkins-developer on LinkedIn</u></a></p></li></ul>",
-				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0904-jessica.png"
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0407-jessica.jpg"
+			},
+			{
+				"name": "Brian Meeker",
+				"bio": "<p>Brian Meeker is a full stack engineer who occasionally leaves his basement in Indiana. Currently, he works as a Senior Engineer at Online Rewards. He works mostly in Elixir these days, but has a past littered with a wide variety of technologies and platforms. Outside of work, Brian is a devoted father, avid nerd, and lover of metal.</p><ul><li><p><a href=\"https://brianmeeker.me/\"><u>brianmeeker.me</u></a></p></li><li><p><a href=\"https://github.com/CuriousCurmudgeon\"><span>@CuriousCurmudgeon on GitHub</span></a></p></li><li><p><a href=\"https://twitter.com/CuriousCurmudge\">@CuriousCurmudge on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/brianmeeker\">@brianmeeker on LinkedIn</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/headshot_cropped.png"
 			}
 		],
 		"sponsors": [
@@ -1737,18 +288,29 @@
 		]
 	},
 	{
-		"title": "Remote Collaboration Tools and Techniques",
-		"slug": "remote-collaboration-tools-and-techniques",
-		"id": "2142",
-		"metaDescription": "Season 10, Episode 1 of the Virtual Coffee Podcast",
-		"season": 10,
+		"title": "Ayu & Dominic - Hacktoberfest is Coming, Preptember is Here!",
+		"slug": "ayu-dominic-hacktoberfest-is-coming-preptember-is-here",
+		"id": "1940",
+		"metaDescription": "Season 9, Episode 1 of the Virtual Coffee Podcast",
+		"season": 9,
 		"episode": 1,
-		"buzzsproutId": "15727596",
-		"publishDate": "2024-09-10T04:00:00+00:00",
-		"shortDescription": "<p><span>In the first episode of Season 10 of the Virtual Coffee Podcast, hosts Bekah and Dan introduce the new format focusing on </span>\"back pocket topics\" from Virtual Coffee <span>community discussions, beginning with a discussion on tools and techniques for remote collaboration.</span></p>",
-		"showNotes": "<p><span>In the first episode of Season 10 of the Virtual Coffee podcast, hosts Bekah and Dan introduce the new format focusing on \"back pocket topics\" from Virtual Coffee community discussions. They delve into common remote collaboration tools and techniques, sharing insights from their experiences in tech. Topics include effective communication, the importance of documentation, and how different company cultures influence remote work. The episode also touches on the role of community members in improving knowledge sharing, both in work settings and open-source projects.</span></p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E01.png",
-		"guests": [],
+		"buzzsproutId": "13611744",
+		"publishDate": "2023-09-18T04:00:00+00:00",
+		"shortDescription": "<p><span>Join hosts Bekah and Dan in this episode featuring Dominic and Ayu as we explore Preptember—the month where we prepare for Hacktoberfest—and the importance of taking the month to prepare, learn more about open source projects, and evaluate open source repositories to recommend to contributors.</span></p>",
+		"showNotes": "<p>Join hosts Bekah and Dan in this episode with monthly challenge Preptember leads, Dominic and Ayu. We talk about the importance of preparing both as a contributor and a maintainer,  some of the challenges you might face as someone new to those roles during Hacktoberfest, and some of the benefits you'll receive by participating in open source.</p><h3>Links</h3><ul><li><p><a href=\"https://virtualcoffee.io/podcast/0303-ayu-adiati\">Ayu's Episode: Working through burnout as a self-taught developer</a></p></li><li><p><a class=\"postlist-title\" href=\"https://virtualcoffee.io/podcast/dominic-duffin-finding-value-in-challenging-ourselves\">Dominic's Episode: Finding value in challenging ourselves</a></p></li><li><p><a href=\"https://github.com/issues\">Your GitHub Issues</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0901-ayu-dominic.png",
+		"guests": [
+			{
+				"name": "Dominic Duffin",
+				"bio": "<p>Dominic is a Full Stack Developer, community builder, remote worker and aspiring polymath. He's passionate about open source everything, decentralization, peer-to-peer tech and cryptocurrency. He's also to be found playing board games, studying paper maps and riding public transport.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0707-dominic.png"
+			},
+			{
+				"name": "Ayu Adiati",
+				"bio": "<p>Ayu is a self-taught front-end developer and technical blogger based in The Netherlands.</p><p class=\"text-left\">She has a strong interest in building projects that are accessible to everyone.</p><p class=\"text-left\">Her passion for life-long learning is what motivates her open-source contributions, project collaboration, and community engagement.</p><p class=\"text-left\">Learning new things is something that fills her with excitement and she's eager to share her learning in public and pass on her knowledge through her blog and Twitter.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0303-ayu.jpg"
+			}
+		],
 		"sponsors": [
 			{
 				"title": "LevelUP Financial planning",
@@ -1761,162 +323,1600 @@
 		]
 	},
 	{
-		"title": "How to Build Trust Capital",
-		"slug": "how-to-build-trust-capital",
-		"id": "2146",
-		"metaDescription": "Season 10, Episode 2 of the Virtual Coffee Podcast",
-		"season": 10,
-		"episode": 1,
-		"buzzsproutId": "15762421",
-		"publishDate": "2024-09-16T04:00:00+00:00",
-		"shortDescription": "<p>Bekah and Dan discuss the concept of 'trust capital' and its importance in tech communities.</p>",
-		"showNotes": "<p><span>In Episode 2 of Season 10 of the Virtual Coffee podcast, hosts Bekah and Dan discuss the concept of 'trust capital' and its importance in tech communities. They define trust capital as the value and trustworthiness one has with others. The hosts explore how to build trust through consistent actions, showing up, transparency, and effective communication. They highlight the difference between networking and building genuine relationships, emphasizing practical ways to accumulate trust capital, such as writing blog posts, mentoring, and being an active, dependable community member. The episode underscores the benefits of trust capital in fostering credibility, enhancing professional relationships, and reducing barriers to collaborative progress.</span></p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E02.png",
-		"guests": [],
-		"sponsors": [
-			{
-				"title": "LevelUP Financial planning",
-				"url": "https://www.levelupfinancialplanning.com/?vc",
-				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
-				"logoWidth": 679,
-				"logoHeight": 525,
-				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
-			}
-		]
-	},
-	{
-		"title": "'Big M' versus 'Little m' Mentorship",
-		"slug": "big-m-versus-little-m-mentorship",
-		"id": "2154",
-		"metaDescription": "Season 10, Episode 3 of the Virtual Coffee Podcast",
-		"season": 10,
-		"episode": 3,
-		"buzzsproutId": "15809647",
-		"publishDate": "2024-09-24T04:00:00+00:00",
-		"shortDescription": "<p><span>Bekah and Dan discuss the differences between formal and informal mentorship, sharing insights on how community and personal connections play a role in effective mentorship.</span></p>",
-		"showNotes": "<p><span>In Season 10, Episode 3 of the Virtual Coffee Podcast, hosts Bekah and Dan explore the topic of 'Big M' versus 'Little m' Mentorship. They distinguish between formal, one-on-one mentorship ('Big M') and more informal, community-based mentorship ('Little M'). They discuss the advantages and potential pitfalls of each approach, emphasizing the importance of finding the right mentorship fit. They also touch on the role of coaches, the value of community support in events like Hacktoberfest, and the concept of a personal 'board of mentors.' </span></p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E03.png",
-		"guests": [],
-		"sponsors": [
-			{
-				"title": "LevelUP Financial planning",
-				"url": "https://www.levelupfinancialplanning.com/?vc",
-				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
-				"logoWidth": 679,
-				"logoHeight": 525,
-				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
-			}
-		]
-	},
-	{
-		"title": "How to Make a Positive Impact during Hacktoberfest",
-		"slug": "how-to-make-a-positive-impact-during-hacktoberfest",
-		"id": "2161",
-		"metaDescription": "Season 10, Episode 4 of the Virtual Coffee Podcast",
-		"season": 10,
-		"episode": 4,
-		"buzzsproutId": "15841150",
-		"publishDate": "2024-09-30T04:00:00+00:00",
-		"shortDescription": "<p>Welcome to Hacktoberfest!</p>",
-		"showNotes": "<p>Bekah and Dan explore the community's engagement with Hacktoberfest, a month-long event encouraging open source contributions. They discuss what Hacktoberfest is and what it means to be a positive contributor in the open source community. They highlight the importance of meaningful contributions, respecting maintainers' time, and provides tips for navigating and contributing to open source projects, and touches on ways to be a good open source citizen and the benefits of contributing consistently to a single project or organization. The episode emphasizes understanding project documentation and being patient with maintainers, while exploring various ways to support open source initiatives beyond writing code.</p><ul><li><p><code>00:00</code> Welcome to the Virtual Coffee Podcast</p></li><li><p><code>00:25</code> Introduction to Hacktoberfest</p></li><li><p><code>00:45</code> Sponsorship Shoutout</p></li><li><p><code>01:08</code> Getting Started with Hacktoberfest</p></li><li><p><code>02:01</code> The Origins of Virtual Coffee and Hacktoberfest</p></li><li><p><code>05:01</code> How to Contribute Positively</p></li><li><p><code>13:02</code> The Importance of Documentation</p></li><li><p><code>18:04</code> Non-Code Contributions</p></li><li><p><code>24:02</code> Building Relationships in Open Source</p></li><li><p><code>26:25</code> Closing Remarks and Contact Information</p></li></ul>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E04.png",
-		"guests": [],
-		"sponsors": [
-			{
-				"title": "LevelUP Financial planning",
-				"url": "https://www.levelupfinancialplanning.com/?vc",
-				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
-				"logoWidth": 679,
-				"logoHeight": 525,
-				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
-			}
-		]
-	},
-	{
-		"title": "Open Source Maintainer Challenges and Benefits",
-		"slug": "open-source-maintainer-challenges-and-benefits",
-		"id": "2167",
-		"metaDescription": "Season 10, Episode 5 of the Virtual Coffee Podcast",
-		"season": 10,
-		"episode": 5,
-		"buzzsproutId": "15891752",
-		"publishDate": "2024-10-08T04:00:00+00:00",
-		"shortDescription": "<p><span>Bekah and Dan share personal experiences of maintaining open source projects, highlight the benefits of creating a community of contributors, and offer insights into tools and strategies for effective project management and collaboration.</span></p>",
-		"showNotes": "<p>In this episode of the Virtual Coffee Podcast, hosts Bekah and Dan delve into the benefits and challenges of being a maintainer in open source projects, particularly during Hacktoberfest. They discuss the excitement and responsibility of maintaining projects, the joy of welcoming new contributors, and the importance of community building. The hosts also highlight the preparation involved in enhancing project onboarding and documentation, and the growth opportunities for maintainers. The episode also emphasizes strategies to attract contributors and the impact of efficiently managing open source projects.</p><h3>Links:</h3><ul><li><p><a href=\"https://opensauced.pizza/learn\">https://opensauced.pizza/learn</a></p></li><li><p>Becoming an Open Source Maintainer</p></li></ul><p></p><p>00:00 Welcome to Virtual Coffee Podcast</p><p>00:26 Hacktoberfest Excitement and Open Source</p><p>00:43 Sponsorship Shoutout</p><p>01:06 Grab Your Drink and Settle In</p><p>01:34 Maintainer Experiences and Challenges</p><p>03:44 The Joy of Hacktoberfest</p><p>05:08 Maintaining Beyond Hacktoberfest</p><p>08:13 The Importance of Onboarding</p><p>09:29 PrepTember and Readiness</p><p>11:01 Building Trust and Community</p><p>12:18 The Benefits of Being a Maintainer</p><p>17:32 Growing as a Maintainer</p><p>18:40 Marketing Your Open Source Project</p><p>21:06 Community Support and Resources</p><p>23:44 Wrapping Up and Final Thoughts</p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E05.png",
-		"guests": [],
-		"sponsors": [
-			{
-				"title": "LevelUP Financial planning",
-				"url": "https://www.levelupfinancialplanning.com/?vc",
-				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
-				"logoWidth": 679,
-				"logoHeight": 525,
-				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
-			}
-		]
-	},
-	{
-		"title": "Building Relationships in Open Source",
-		"slug": "building-relationships-in-open-source",
-		"id": "2172",
-		"metaDescription": "Season 10, Episode 6 of the Virtual Coffee Podcast",
-		"season": 10,
-		"episode": 6,
-		"buzzsproutId": "15931952",
-		"publishDate": "2024-10-15T04:00:00+00:00",
-		"shortDescription": "<p>The Virtual Coffee Podcast explores the significance of relationship-building and mentorship in open-source communities during Hacktoberfest, underlining practical advice, effective communication, and providing support to foster a welcoming environment for contributors.</p>",
-		"showNotes": "<p><span>In Season 10, Episode 6 of the Virtual Coffee Podcast, hosts Bekah and Dan explore the multifaceted aspects of building and nurturing relationships within the open source community, particularly during Hacktoberfest. The episode highlights the significance of effective networking, making meaningful connections, and becoming a valued repeat contributor. The hosts provide practical advice for newcomers, stressing the importance of understanding projects, submitting quality pull requests, and contributing beyond code through community management and content creation. Emphasizing mentorship, they discuss how maintainers can aid first-time contributors via comprehensive readme files, contributing guides, and constructive feedback. The importance of communication, relationship-building, and the impact of small gestures like a simple thank you are also covered to foster a supportive and efficient open source community.</span></p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E06.png",
-		"guests": [],
-		"sponsors": [
-			{
-				"title": "LevelUP Financial planning",
-				"url": "https://www.levelupfinancialplanning.com/?vc",
-				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
-				"logoWidth": 679,
-				"logoHeight": 525,
-				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
-			}
-		]
-	},
-	{
-		"title": "Climbing the Contributor Ladder",
-		"slug": "climbing-the-contributor-ladder",
-		"id": "2175",
-		"metaDescription": "Season 10, Episode 7 of the Virtual Coffee Podcast",
-		"season": 10,
-		"episode": 7,
-		"buzzsproutId": "15975962",
-		"publishDate": "2024-10-23T04:00:00+00:00",
-		"shortDescription": "<p><span>Dan and Bekah discuss strategies for advancing from contributor to maintainer in open source projects by engaging with the community, understanding contribution guidelines, handling issues effectively, and collaborating respectfully.</span></p>",
-		"showNotes": "<p><span>In this episode of the Virtual Coffee Podcast, hosts Bekah Hawrot Weigel and Dan Ott delve into the journey of climbing the contributor ladder in open-source projects. They explore the progression from contributor to maintainer, focusing on the importance of trust-building, consistent contributions, and respectful interactions within the community. Key strategies discussed include engaging with project documentation, reproducing bugs, and effective communication. The episode also highlights how projects like Astro and Nuxt guide contributors and the role of events like Hacktoberfest in encouraging new participation. Real-life examples illustrate how proactive engagement can lead to managing more complex tasks and even job opportunities. Sponsored by Level Up Financial Planning, this insightful episode is a must-listen for anyone looking to make significant strides in the open-source community.</span><br><br><span>Visit <a href=\"https://virtualcoffee.io/resources/developer-resources/open-source\">https://virtualcoffee.io/resources/developer-resources/open-source</a> for additional resources.</span></p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E07.png",
-		"guests": [],
-		"sponsors": [
-			{
-				"title": "LevelUP Financial planning",
-				"url": "https://www.levelupfinancialplanning.com/?vc",
-				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
-				"logoWidth": 679,
-				"logoHeight": 525,
-				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
-			}
-		]
-	},
-	{
-		"title": "Open Sourcing a Private Repo",
-		"slug": "open-sourcing-a-private-repo",
-		"id": "2178",
-		"metaDescription": "Season 10, Episode 8 of the Virtual Coffee Podcast",
-		"season": 10,
+		"title": "Rafi - Exploring Side Projects and AI",
+		"slug": "rafi-exploring-side-projects-and-ai",
+		"id": "1919",
+		"metaDescription": "Season Eight, Episode Eight of the Virtual Coffee Podcast",
+		"season": 8,
 		"episode": 8,
-		"buzzsproutId": "16019031",
-		"publishDate": "2024-10-30T04:00:00+00:00",
-		"shortDescription": "<p><span>Bekah and Dan discuss the considerations and steps involved in open sourcing a private repository, sharing insights from their own experience with the Virtual Coffee community docs.</span></p>",
-		"showNotes": "<p><span>In Episode 8 of Season 10 of the Virtual Coffee Podcast, hosts Bekah and Dan delve into the intricate process of open sourcing a private repository. Drawing from their experience with Virtual Coffee's community docs, they discuss considerations like verifying the safety of repository content, ensuring appropriate permissions, and maintaining the privacy of sensitive discussions. They also touch on the importance of updating READEMEs, licensing, and providing clear guidelines for new contributors.</span></p>",
-		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Podcast-S10E08.png",
+		"buzzsproutId": "13331830",
+		"publishDate": "2023-08-02T04:00:00+00:00",
+		"shortDescription": "<p>Join Bekah and Dan in this week's episode,  where they talk with Rafi, a full-stack engineer who develops his passion and motivation with side projects.  Rafi highlights the importance of focusing on developing side projects using a time limit and completing tasks. Learn Rafi's approach to using AI as a tool in his toolbox to accelerate the development process.</p>",
+		"showNotes": "<p>Join hosts Bekah and Dan in this episode featuring Rafi, a talented full-stack developer from Bangalore. In this episode, you'll discover how building new things  and making progress helps him find calmness and focus. Learn Rafi's approach to side projects, including his exploration of Blender, mobile development, Chrome extensions, and Ionic framework. Rafi also shares valuable tips on leveraging AI to enhance learning during project work</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe.png",
+		"guests": [
+			{
+				"name": "Rafi",
+				"bio": "<p>I am a developer, hobbyist who loves JavaScript, Star trek and Cats. I build things, talk tech and write things.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Rafi.png"
+			}
+		],
+		"sponsors": [
+			{
+				"title": "LevelUP Financial planning",
+				"url": "https://www.levelupfinancialplanning.com/?vc",
+				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+				"logoWidth": 679,
+				"logoHeight": 525,
+				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+			}
+		]
+	},
+	{
+		"title": "Taiwo Yusuf - The Importance of Having a Learning Mindset",
+		"slug": "taiwo-yusuf-the-importance-of-having-a-learning-mindset",
+		"id": "1910",
+		"metaDescription": "Season Eight, Episode Seven of the Virtual Coffee Podcast",
+		"season": 8,
+		"episode": 7,
+		"buzzsproutId": "13295814",
+		"publishDate": "2023-07-26T04:00:00+00:00",
+		"shortDescription": "<p>In this episode, Dan and Bekah chat with Taiwo, a backend developer from Nigeria. He shares his journey from Electrical Engineering Major to backend development, and the importance of staying motivated and always being hungry to learn and grow.</p>",
+		"showNotes": "<p>Join Bekah and Dan in this week's episode,  where they talk with Taiwo Yusuf, a back-end engineer with a passion for developing innovative solutions.  Despite being the top of his class in Electrical Engineering, he found his passion in backend development. He shares the importance of always learning, growing, and surrounding yourself with people who are more skilled than you are to find inspiration, support, and motivation.</p><p><strong>Links:</strong></p><ul><li><p><a href=\"https://www.grace.health/\" rel=\"noopener noreferrer\" target=\"_blank\">Grace Health</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe-1.png",
+		"guests": [
+			{
+				"name": "Taiwo Yusuf",
+				"bio": "<p>I'm Taiwo Yusuf, a back-end engineer with a passion for developing innovative solutions. I've been fortunate enough to work with amazing companies like Grace Health, LogicShift, and JufoPay. When I'm not busy coding, I'm an avid fan of generative art, and I adore cats. So, whether you want to talk about tech, art, or felines, let's connect and have a chat!</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/3bmcquEcQTRCESX5KIOTJO-AvdRCqPIKvQDtqprXWGY.png"
+			}
+		],
+		"sponsors": [
+			{
+				"title": "LevelUP Financial planning",
+				"url": "https://www.levelupfinancialplanning.com/?vc",
+				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+				"logoWidth": 679,
+				"logoHeight": 525,
+				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+			}
+		]
+	},
+	{
+		"title": "Josh - The Life of a Full Time Open Source Developer",
+		"slug": "josh-the-life-of-a-full-time-open-source-developer",
+		"id": "1895",
+		"metaDescription": "Season Eight, Episode Six of the Virtual Coffee Podcast",
+		"season": 8,
+		"episode": 6,
+		"buzzsproutId": "13247190",
+		"publishDate": "2023-07-19T04:00:00+00:00",
+		"shortDescription": "<p>In this episode, Dan and Bekah explore the fascinating journey of being a full-time open source contributor with Josh Goldberg. We discuss the challenges and rewards of dedicating yourself to the open source ecosystem, TypeScript's growing popularity, and how Josh supports the tech community.</p>",
+		"showNotes": "<p>Join Bekah and Dan in this week's episode, where they talk with Josh Goldberg, an independent full time open source developer working on projects in the TypeScript ecosystem, where he shares valuable tips and insights on how you can get started with contributing to open source, whether you're a seasoned developer or just dipping your toes into OSS. Josh also shares the story of his prolific speaking journey over the last couple of years and how staying involved in the tech community has been a rewarding experience.</p><p><strong>Links:</strong></p><ul><li><p><a href=\"https://typescript-eslint.io/\" rel=\"noopener noreferrer\" target=\"_blank\">typescript-eslint</a></p></li><li><p><a href=\"https://github.com/typescript-eslint/typescript-eslint\" rel=\"noopener noreferrer\" target=\"_blank\">typescript-eslint GitHub</a></p></li><li><p><a href=\"https://www.codecademy.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Code Academy</a></p></li><li><p><a href=\"https://sway.office.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Microsoft Sway</a> </p></li><li><p>Josh's Blog posts about applying to conferences:</p><ul><li><p><a href=\"https://blog.joshuakgoldberg.com/how-i-apply-to-conferences/\" rel=\"noopener noreferrer\" target=\"_blank\">How I Apply to Conferences</a></p></li><li><p><a href=\"https://blog.joshuakgoldberg.com/how-i-apply-to-conferences-faqs/\" rel=\"noopener noreferrer\" target=\"_blank\">How I Apply to Conferences: FAQs</a></p></li></ul></li><li><p>Josh's Book: <a href=\"https://www.learningtypescript.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Learning Typescript</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe_2023-07-19-033240_jrwt.png",
+		"guests": [
+			{
+				"name": "Josh Golberg",
+				"bio": "<p>Hi, I’m Josh! I’m an independent full time open source developer. I work on projects in the TypeScript ecosystem, most notably typescript-eslint: the tooling that enables ESLint and Prettier to run on TypeScript code. I’m also the author of the O’Reilly Learning TypeScript book, a Microsoft MVP for developer technologies, and an active conference speaker.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Josh.jpeg"
+			}
+		],
+		"sponsors": [
+			{
+				"title": "LevelUP Financial planning",
+				"url": "https://www.levelupfinancialplanning.com/?vc",
+				"logo": "https://virtualcoffeeio-cms.imgix.net/podcast/levelUP.png",
+				"logoWidth": 679,
+				"logoHeight": 525,
+				"description": "<p>We're grateful to be sponorsored by LevelUP Financial planning, who understands the importance of finding balance between having an awesome life today, and being confident and excited about your future possibilities. If you want to take your financial confidence to the next level, check out <a href=\"https://www.levelupfinancialplanning.com/?vc\">levelupfinancialplanning.com</a>.</p>"
+			}
+		]
+	},
+	{
+		"title": "Reda - From Maritime Engineer to Self-Taught Front-End Developer",
+		"slug": "reda-from-maritime-engineer-to-self-taught-front-end-developer",
+		"id": "1880",
+		"metaDescription": "Season Eight, Episode Five of the Virtual Coffee Podcast",
+		"season": 8,
+		"episode": 5,
+		"buzzsproutId": "13204285",
+		"publishDate": "2023-07-12T04:00:00+00:00",
+		"shortDescription": "<p>Join hosts Bekah and Dan in this inspiring episode as they talk through the captivating journey of Reda, a self-taught developer. Discover the challenges and triumphs of the world of programming solo, and gain valuable insights on the optimal timing for job applications—because as Reda shares the advice he was given, \"When should you start applying for jobs? Yesterday.\"</p>",
+		"showNotes": "<p><span>Join Bekah and Dan in this week's episode, where they dive into the transformative journey of Reda, a self-taught developer. Hear about the unique challenges and victories Reda faced as he navigated the journey to becoming a front-end developer. Gain valuable advice on the ideal timing for job applications, as Reda shares advice he heard along his journey: \"When should you start applying for jobs? Yesterday.\" Tune in for an enriching conversation that will inspire aspiring self-taught developers and offer practical insights for your career paths.</span></p><h3>Links: </h3><ul><li><p><a href=\"https://www.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Free Code Camp</a></p></li><li><p><a href=\"https://the-collab-lab.codes/\" rel=\"noopener noreferrer\" target=\"_blank\">Collab Lab</a></p></li><li><p><a href=\"https://www.coursera.org/specializations/python\" rel=\"noopener noreferrer\" target=\"_blank\">Python Course</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe_2023-07-11-193524_yhob.png",
+		"guests": [
+			{
+				"name": "Reda",
+				"bio": "<p>I'm a self-taught front-end developer based in Morocco, with a background in Marine Mechanics.</p><ul><li><p><a href=\"https://github.com/redapy\" rel=\"noopener noreferrer\" target=\"_blank\">redapy</a> on GitHub</p></li><li><p><a href=\"https://www.google.com/url?sa=t&amp;rct=j&amp;q=&amp;esrc=s&amp;source=web&amp;cd=&amp;cad=rja&amp;uact=8&amp;ved=2ahUKEwjSsLzRsYeAAxVBmGoFHUEQDNUQFnoECBAQAQ&amp;url=https%3A%2F%2Ftwitter.com%2Fredabaha12&amp;usg=AOvVaw2LtVxW6oDxwQ_Aq1KKL3ik&amp;opi=89978449\" rel=\"noopener noreferrer\" target=\"_blank\">redabaha12</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/redabaha/\" rel=\"noopener noreferrer\" target=\"_blank\">redabaha</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Reda.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Caitlin Floyd - Mentorship",
+		"slug": "caitlin-floyd",
+		"id": "1855",
+		"metaDescription": "Season Eight, Episode Four of the Virtual Coffee Podcast",
+		"season": 8,
+		"episode": 4,
+		"buzzsproutId": "13121425",
+		"publishDate": "2023-06-28T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Caitlin about expanding the definition of tech mentorship. We challenge the traditional one-on-one approach and delve into group and community mentorship, where learning, growth, and curiosity thrive collectively. We discuss how active and empathetic listening fosters understanding and knowledge exchange.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Caitlin Floyd, a front-end developer, to chat about the concept of collective learning and explore new possibilities in the evolving landscape of tech mentorship. Discover firsthand how Caitlin's experiences highlight the power of collaboration, breaking down silos, and leveraging collective knowledge to drive innovation and success.</p><h3>Links:</h3><ul><li><p><a href=\"https://the-collab-lab.codes/\">Collab Lab</a></p></li><li><p><a href=\"https://dev.to/the-collab-lab/tcl-22-recap-211m/\">Recap of a Collab Lab cohort that Caitlin participated in</a></p></li><li><p><a href=\"https://leaddev.com/mentoring-coaching-feedback/mentor-coach-sponsor-guide-developing-engineers\">Mentor, coach, sponsor: a guide to developing engineers</a> by Neha Batra</p></li><li><p><a href=\"https://kwugirl.blogspot.com/2020/10/secrets-of-stealth-mentee.html?m=1\">Secrets of a Stealth Mentee</a> by KWu</p></li><li><p><a href=\"https://larahogan.me/sponsors/\">Mentorship and Sponsorship</a> by Lara Hogan</p></li><li><p><a href=\"https://cate.blog/2017/03/21/sponsorship-can-start-small/\">Sponsorship Can Start Small</a> by Cate</p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe_2023-06-28-031129_uyfo.png",
+		"guests": [
+			{
+				"name": "Caitlin Floyd",
+				"bio": "<p>Caitlin is a front-end developer driven by the power of technology as a force for good. Before entering tech, she worked in linguistics, education, and nonprofit management. When not coding, she loves reading, studying languages, traveling, and most of all doting on her puppy.</p><ul><li><p><a href=\"https://caitlinfoyd.com\">caitlinfoyd.com</a></p></li><li><p><a href=\"https://github.com/cafloyd\" rel=\"noopener noreferrer\" target=\"_blank\">@cafloyd</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/caitlinfloyd\" rel=\"noopener noreferrer\" target=\"_blank\">@caitlinfloyd</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/caitlinfloyd/\" rel=\"noopener noreferrer\" target=\"_blank\">@caitlinfloyd</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Caitlin.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Carmen - Tech Industry Friendships: Leveraging Connections for Growth, Challenges, and Opportunities and DevOps!",
+		"slug": "carmen-tech-industry-friendships-leveraging-connections-for-growth-challenges-and-opportunities-and-devops",
+		"id": "1841",
+		"metaDescription": "Season Eight, Episode Three of the Virtual Coffee Podcast",
+		"season": 8,
+		"episode": 3,
+		"buzzsproutId": "13047459",
+		"publishDate": "2023-06-21T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Carmen about the impactful role of friendships in the tech industry. We talked about how these connections positively influenced her professional journeys, helped her overcome challenges, and contributed to career growth in DevOps.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Carmen Kohole, a DevOps Engineer based in Portland, Oregon, to chat about the benefits of collaboration and the valuable opportunities you can gain just by asking for help. We also discussed the benefits of fostering strong relationships in the tech industry, and what it means to be a DevOps engineer.</p><h3>Links:</h3><ul><li><p><a href=\"https://twitter.com/thejonanshow\">Jonan Scheffler</a></p></li><li><p><a href=\"https://twitter.com/nickytonline\">Nick Taylor</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0803-Carmen.png",
+		"guests": [
+			{
+				"name": "Carmen",
+				"bio": "<p>DevOps Engineer based in Portland, Oregon. Big fan of house plants, hiking, hats and cats. Here to help build stuff, break stuff, learn stuff and make friends.</p><ul><li><p><a href=\"https://github.com/carmenkolohe\" rel=\"noopener noreferrer\" target=\"_blank\">@carmenkolohe</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/carmenkolohe\" rel=\"noopener noreferrer\" target=\"_blank\">@carmenkolohe</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/carmenkolohe/\" rel=\"noopener noreferrer\" target=\"_blank\">@carmenkolohe</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Carmen.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Alex Curtis-Slep - Enriching Your Life as a Developer",
+		"slug": "alex-curtis-slep-enriching-your-life-as-a-developer",
+		"id": "1827",
+		"metaDescription": "Season Eight, Episode Two of the Virtual Coffee Podcast",
+		"season": 8,
+		"episode": 2,
+		"buzzsproutId": "13038514",
+		"publishDate": "2023-06-15T04:00:00+00:00",
+		"shortDescription": "<p><span>In today's episode, Dan and Bekah talk to Alex about his gratifying journey as a self-taught developer and tools you can use to maintain a positive attitude, create balance, decrease stress, and form good habits to enrich your life.</span></p>",
+		"showNotes": "<p><span>This week Bekah and Dan sat down with Alex Curtis-Slep, long time member and volunteer and self-taught developer, about documenting the small wins, falling in love with the process, and aligning your goals to maintain a healthy life while job searching and during your tech career.</span></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Copy-of-0702-joe.png",
+		"guests": [
+			{
+				"name": "Alex Curtis-Slep",
+				"bio": "<p>Alex Curtis-Slep is a self taught software developer. After getting his initial tastes of HTML and CSS in the early 2000’s on his basketball blog, Alex jumped into coding in early 2019. He heard about a course Madison Kanna created on roadmapping to become a developer and took the plunge. Following a few years of learning, creating, contributing to open source, and much more, Alex landed his first job in tech at Paypixl. When he’s not coding and hyping up his developer friends, he loves everything basketball, tropical fruit, vegan, travel, family, friend, and foreign language related!</p><ul><li><p><a href=\"http://alexcurtisslep.com\">alexcurtisslep.com</a></p></li><li><p><a href=\"https://github.com/AlexVCS\" rel=\"noopener noreferrer\" target=\"_blank\">@AlexVCS</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/AlexCurtisSlep\" rel=\"noopener noreferrer\" target=\"_blank\">@AlexCurtisSlep</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/alexcurtisslep/\" rel=\"noopener noreferrer\" target=\"_blank\">@alexcurtisslep</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Alex-Curtis.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "VC Maintainers - Importance of Culture Citizenship",
+		"slug": "vc-maintainers-importance-of-culture-citizenship",
+		"id": "1796",
+		"metaDescription": "Season Eight, Episode One of the Virtual Coffee Podcast",
+		"season": 8,
+		"episode": 1,
+		"buzzsproutId": "12988617",
+		"publishDate": "2023-06-07T04:00:00+00:00",
+		"shortDescription": "<p><span>We're starting the new season with a conversation with our maintainers, including our new maintainer, Julia Seidman! We share our thought process for adding a maintainer and walk through our culture citizenship statement to share how we intend to create a positive community.</span></p>",
+		"showNotes": "<p><span>Starting off this new season, we're bringing in all of our maintainers, Bekah Hawrot Weigel, Dan Ott, Kirk Shillingford, and Julia Seidman. We walk through the importance of understanding communities, members, and how to create a positive community experience.</span></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0801-Cover.jpeg",
+		"guests": [
+			{
+				"name": "Julia Seidman",
+				"bio": "<p><span>Julia Seidman is a developer education consultant based in the Seattle area. Julia is a believer in embracing the 'careen' over the career. </span></p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Julia-Headshot.jpeg"
+			},
+			{
+				"name": "Kirk Shillingford",
+				"bio": "<p><span>A full stack developer in the Caribbean interested in Functional Programming, Domain Driven Development, and Security.</span></p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Kirk-Headshot.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Season Seven Finale - Live with Nick Taylor",
+		"slug": "season-seven-finale-live-with-nick-taylor",
+		"id": "1772",
+		"metaDescription": "Season Seven, Episode Nine of the Virtual Coffee Podcast",
+		"season": 7,
+		"episode": 9,
+		"buzzsproutId": "12558497",
+		"publishDate": "2023-03-31T04:00:00+00:00",
+		"shortDescription": "<p>Join Bekah, Dan, and Special Guest Nick Taylor for a live-streamed episode of the Season Seven Finale!</p>",
+		"showNotes": "<p>Join Bekah, Dan, and Special Guest Nick Taylor for a live-streamed episode of the Season Seven Finale!</p><p>Watch the video replay here: <a href=\"https://www.youtube.com/watch?v=0Wj-zlORvm8\">https://www.youtube.com/watch?v=0Wj-zlORvm8</a></p><p>Watch our 2023 Spring Lightning Talks here: <a href=\"https://www.youtube.com/watch?v=O2CsTN-WEZ0\">https://www.youtube.com/watch?v=O2CsTN-WEZ0</a></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0709-finale.png",
 		"guests": [],
+		"sponsors": []
+	},
+	{
+		"title": "Ramón Huidobro - Thoughtful Learning",
+		"slug": "ramón-huidobro-thoughtful-learning",
+		"id": "1756",
+		"metaDescription": "Season Seven, Episode Eight of the Virtual Coffee Podcast",
+		"season": 7,
+		"episode": 8,
+		"buzzsproutId": "12503114",
+		"publishDate": "2023-03-23T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Ramón Huidobro about asking good questions about your code and how to ask for help.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Ramón Huidobro, a developer advocate and DevEd enthusiast, and chatted about the process of learning and growing and how asking questions and knowing what questions to ask is an important part of the tech experience.</p><p>Check out Ramón's article <a href=\"https://ramonh.dev/2022/11/13/asking-for-help/\">about reaching out for help</a>!</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0708-ramon-episode.jpg",
+		"guests": [
+			{
+				"name": "Ramón Huidobro",
+				"bio": "<p>Ramón Huidobro is a developer advocate and DevEd enthusiast. He thrives on lifting others up in their tech careers and loves a good CSS challenge. Always excited to talk about teaching tech, especialmente en Español, oder auf Deutsch.</p><ul><li><p><a href=\"https://https://ramonh.dev\">ramonh.dev</a></p></li><li><p><a href=\"https://github.com/hola-soy-milk\">@hola-soy-milk</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/hola_soy_milk\">@hola_soy_milk</a> on Twitter</p></li><li><p><a href=\"https://hachyderm.io/@hola_soy_milk\">@hola_soy_milk</a> on Mastadon</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0708-ramon.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Dominic Duffin - Finding value in challenging ourselves",
+		"slug": "dominic-duffin-finding-value-in-challenging-ourselves",
+		"id": "1740",
+		"metaDescription": "Season Seven, Episode Seven of the Virtual Coffee Podcast",
+		"season": 7,
+		"episode": 7,
+		"buzzsproutId": "12453805",
+		"publishDate": "2023-03-16T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Dominic Duffin about the impact of non-traditional learning experiences and the importance of community collaboration.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Dominic Duffin, a Full-Stack Developer, Co-founder of ArtTechChat Twitter chat, Salon Host at The Interintellect, and Open Source contributor, and chatted about the the value gained in creating a learning environment wherever you go and the importance of participating in community experiences.</p><ul><li><p>Pass the Pen: <a href=\"https://codepen.io/collection/nZrZLy\">https://codepen.io/collection/nZrZLy</a></p></li><li><p><a href=\"@ArtTechChat on Twitter\"><u>https://twitter.com/arttechchat</u></a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0707-dominic-episode.jpg",
+		"guests": [
+			{
+				"name": "Dominic Duffin",
+				"bio": "<p>Full Stack Developer, community builder, remote worker and aspiring polymath. Passionate about open source everything, decentralization, peer-to-peer tech and cryptocurrency. Also to be found playing board games, studying paper maps and riding public transport.</p><ul><li><p><a href=\"https://dominicduffin.uk\">dominicduffin.uk</a></p></li><li><p><a href=\"https://github.com/dominicduffin1\">@dominicduffin1</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/DominicDuffin1\">@DominicDuffin1</a> on Twitter</p></li><li><p><a href=\"https://toot.cafe/@dominicduffin1\">@dominicduffin1</a> on Mastadon</p></li><li><p><a href=\"https://www.linkedin.com/in/dominic-duffin-a992b0225\">@dominic-duffin</a> on LinkedIn</p></li><li><p><a href=\"https://www.polywork.com/dominic\">@dominic</a> on Polywork</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0707-dominic.png"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Arthur Doler - The Human Side of Tech",
+		"slug": "arthur-doler-the-human-side-of-tech",
+		"id": "1727",
+		"metaDescription": "Season Seven, Episode Six of the Virtual Coffee Podcast",
+		"season": 7,
+		"episode": 6,
+		"buzzsproutId": "12407750",
+		"publishDate": "2023-03-09T05:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Arthur Doler about team dynamics, motivation, and how to identify problematic situations.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Arthur Doler, a Software Engineer and Community and Culture Steward, and chatted about the human side of tech, the importance of recognizing our emotions, communication styles, and the dynamics of the environments we're working in.</p><h3>Links:</h3><ul><li><p><a href=\"https://www.danpink.com/books/drive/\">Daniel Pink's Drive</a></p></li><li><p><a href=\"https://youtu.be/-XYK8ulQId0\">Arthur's talk: You're Not Just Tired: The Psychology of Burnout</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Aikido\">Aikido</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/List_of_disc_golf_players\">Pro Disc Golfers</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0706-arthur-episode.jpg",
+		"guests": [
+			{
+				"name": "Arthur Doler",
+				"bio": "<p>Arthur (or Art, take your pick) has been a software engineer for 19 years and has worked on things as exciting as analysis software for casinos and things as boring as banking websites. He is an advocate for talking openly about mental health and psychology in the technical world, and he spends a lot of time thinking about <em>how</em> we program and <em>why</em> we program, and about the tools, structures, cultures, and mental processes that help and hinder us from our ultimate goal of writing amazing things. His hair is brown and his thorax is a shiny blue color.</p><ul><li><p><a href=\"https://arthurdoler.com\">arthurdoler.com</a></p></li><li><p><a href=\"https://github.com/doleraj\">@doleraj</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/arthurdoler\">@arthurdoler</a> on Twitter</p></li><li><p><a href=\"https://mastodon.sandwich.net/@arthurdoler\">@arthurdoler</a> on Mastodon</p></li><li><p><a href=\"https://www.linkedin.com/in/arthurdoler/\">@arthurdoler</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0706-arthur.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Rebecca Key - From PhD to Frontend",
+		"slug": "rebecca-key-from-phd-to-frontend",
+		"id": "1711",
+		"metaDescription": "Season Seven, Episode Five of the Virtual Coffee Podcast",
+		"season": 7,
+		"episode": 5,
+		"buzzsproutId": "12363084",
+		"publishDate": "2023-03-02T05:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Rebecca Key about her journey from a career in chemistry to Software Engineer and the hobbies that she finds exciting.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Rebecca Key, a PhD in Organic Chemistry and now Software Engineer, and chatted about her career journey, Ham radios, being left-handed, taking notes, and the importance of consistency.</p><h3>Links:</h3><ul><li><p><a href=\"https://en.wikipedia.org/wiki/Brassica_oleracea\">Brassica oleracea</a> (the plant Dan was talking about)</p></li><li><p><a href=\"https://www.sota-at.com/\">SOTA-AT</a>: An interactive map that displays and provides information for peaks along the GA section of the Appalachian Trail that count toward activations for “Summits on the Air”, a ham radio contest.</p></li><li><p><a href=\"https://github.com/rek990/crochet-counter\">Row Counter</a>: A tool to help fiber artists (crocheters, knitters, rug makers, basket weavers, etc.) keep track of the row they are on with a given project. <a href=\"https://dev.to/rek990/virtual-coffees-july-monthly-challenge-live-demo-of-the-progress-toward-my-row-counter-app-3jd7\">Live Demo of the Progress Toward my Row Counter App</a></p></li><li><p>Rebecca's RF Quests: <a href=\"https://www.rfquests.com/\">Blog</a> and <a href=\"https://www.youtube.com/channel/UC5Rtn09KIdwsySkf7B-DPsw\">YouTube Channel</a></p></li><li><p><a href=\"https://parksontheair.com/\">Parks on the Air (POTA)</a></p></li><li><p><a href=\"https://www.sota.org.uk/\">Summits on the Air (SOTA)</a></p></li><li><p><a href=\"https://www.sota.org.uk/Joining-In/Awards\">SOTA Mountain goat award</a></p></li><li><p><a href=\"https://orgmode.org/\">Emacs Org Mode</a></p></li></ul><h4>Left-handed Deep Dive</h4><ul><li><p><a href=\"https://kids.frontiersin.org/articles/10.3389/frym.2014.00013\">Your Left-Handed Brain</a></p></li><li><p><a href=\"https://www.bbc.com/news/health-49579810\">Left-handed DNA found - and it changes brain structure</a></p></li><li><p><a href=\"https://pubmed.ncbi.nlm.nih.gov/1839378/#:~:text=Left%2Dhandedness%20occurs%20in%20about,monozygotic%20twins%20show%20substantial%20discordance\">The inheritance of left-handedness</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0705-rebecca-episode.png",
+		"guests": [
+			{
+				"name": "Rebecca Key",
+				"bio": "<p>Rebecca Key is a Software Engineer based out of Atlanta, GA. She is a first-generation college graduate that went on to obtain a PhD in Organic Chemistry from Georgia Tech. After many years in research (roles ranging from Laboratory Technician to Research Director), she made a career change into the tech field, where she currently works as an Independent Front-End Engineer. When not coding, she enjoys mountain biking, running, weightlifting, crocheting, and knitting!</p><ul><li><p><a href=\"http://rebeccakeyphd.com/\">rebeccakeyphd.com</a></p></li><li><p><a href=\"https://github.com/rek990\">@rek990</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/rebeccakeyphd\">@rebeccakeyphd</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/rebecca-key/\">@rebecca-key</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0705-rebecca.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Aishwarya Mali - A Journey into Open Source",
+		"slug": "aishwarya-mali-a-journey-into-open-source",
+		"id": "1695",
+		"metaDescription": "Season Seven, Episode Four of the Virtual Coffee Podcast",
+		"season": 7,
+		"episode": 4,
+		"buzzsproutId": "12315603",
+		"publishDate": "2023-02-23T05:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Aishwarya about her journey as a first time contributer during the 2022 Hacktoberfest.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Aishwarya, front-end developer from India, about her first open source contributions and how her perspective on open source changed after her fourth (of ten!) Pull Request during Hacktoberfest.</p><ul><li><p>One word to describe you - <strong>Dedicated</strong></p></li><li><p>One word to describe your developer journey - <strong>Evolving</strong></p></li><li><p><a href=\"https://www.amazon.com/Me-Before-You-Novel-Tie/dp/0143130153\"><em><u>Me Before You</u></em><u> by Jojo Moyes</u></a></p></li><li><p>Open-Source YouTube Videos:</p><ul><li><p><a href=\"https://www.youtube.com/watch?v=yfopPq4354o\">How to Find Beginner-Friendly Open Source Projects</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=_uetV0wZyXM\">4 Beginner Friendly Open Source Projects to Contribute before 2023</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=lnLiD0GfCRE\">5 Beginner friendly Open Source Organisations to start your Open source journey</a></p></li></ul></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0704-aishwara-episode.jpg",
+		"guests": [
+			{
+				"name": "Aishwarya Mali",
+				"bio": "<p>Aishwarya Mali is a front-end developer (React+XState+Redux) based in Pune, India. She loves to read!</p><ul><li><p><a href=\"https://github.com/aishwarya-mali\">@aishwarya-mali</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/aishwaryamali24\">@aishwaryamali24</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/aishwaryamali24/\">@aishwaryamali24</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0704-aishwara.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Kai Katschthaler - Technical Writing &  Neurodiverse Learning",
+		"slug": "kai-katschthaler-technical-writing-neurodiverse-learning",
+		"id": "1680",
+		"metaDescription": "Season Seven, Episode Three of the Virtual Coffee Podcast",
+		"season": 7,
+		"episode": 3,
+		"buzzsproutId": "12263721",
+		"publishDate": "2023-02-16T05:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Kai Katschthaler about their experience growing their technical writing career and creating content.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Kai Katschthaler, a technical writer and content creator, about their creation process, finding learning approaches that work for them, and mentoring others.</p><h3>Links:</h3><ul><li><p><a href=\"https://www.spreaker.com/user/15541131/kai-ep-final\">Kai's appearance on the Coming Out Pod</a></p></li><li><p><a href=\"https://bau.edu/blog/kinesthetic-learner/\">Kinesthetic Learning</a></p></li><li><p><a href=\"https://www.freecodecamp.org/\">Freecodecamp</a></p></li><li><p><a href=\"https://www.codecademy.com/\">Codecademy</a></p></li><li><p><a href=\"https://learn.co/\">Flatironschool</a></p></li><li><p><a href=\"https://exercism.org/\">Exercism</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0703-kai-episode.jpg",
+		"guests": [
+			{
+				"name": "Kai Katschthaler",
+				"bio": "<p>Kai is a tech content specialist and mental health advocate. They run Taboola Rasa, a mental health awareness project that seeks to erase the stigma connected to mental health.</p><ul><li><p><a href=\"https://linktr.ee/thegrumpyenby\">linktr.ee/thegrumpyenby</a></p></li><li><p><a href=\"https://github.com/thegrumpyenby\">@thegrumpyenby</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/thegrumpyenby\">@thegrumpyenby</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/kaikatschthaler/\">@kaikatschthaler</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0703-kai.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Joe Karow - Career Transitions and the ADHD Experience",
+		"slug": "joe-karow-career-transitions-and-the-adhd-experience",
+		"id": "1655",
+		"metaDescription": "Season Seven, Episode Two of the Virtual Coffee Podcast",
+		"season": 7,
+		"episode": 2,
+		"buzzsproutId": "12213630",
+		"publishDate": "2023-02-09T05:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Joe Karow about his journey as into tech with 100devs and about his ADHD journey.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Joe Karow, the Lead Engineer at a nonprofit, about his career change from the hospitality industry, his experience with the online bootcamp, 100devs, and about the ADHD experience.</p><h3>Links</h3><ul><li><p><a href=\"https://jobs.all-hands.us/jobs\">All Hands Job Board</a></p></li><li><p><a href=\"https://leonnoel.com/100devs/\">100devs</a></p></li><li><p><a href=\"https://www.resilientcoders.org/\">Resilient Coders</a></p></li><li><p><a href=\"https://twitter.com/leonnoel\">Leon Noel</a></p></li><li><p><a href=\"https://www.cedarpoint.com/\">Cedar Point</a></p></li><li><p><a href=\"https://buschgardens.com/\">Busch Gardens</a></p></li><li><p><a href=\"https://www.kennywood.com/\">Kennywood</a></p></li><li><p><a href=\"https://cssbattle.dev/\">cssbattle.dev</a></p></li><li><p><a href=\"https://remo.co/\">remo</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0702-joe-episode.jpg",
+		"guests": [
+			{
+				"name": "Joe Karow",
+				"bio": "<p>Joe is the Lead Engineer at InReach, a 501(c)3 registered non-profit building world’s first tech platform matching LGBTQ+ people facing discrimination and persecution with safe, verified resources. Formerly a Director of Finance for a large hotel chain, he made the leap in to tech in 2022. Tech was always a part of Joe's life, it just took a global pandemic for him to decide to start getting paid for it.</p><ul><li><p><a href=\"https://joekarow.dev\"><u>joekarow.dev</u></a></p></li><li><p><a href=\"https://github.com/JoeKarow\">@JoeKarow</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/JoeKarow\">@JoeKarow</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/jkarow/\">@jkarow</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0702-joe.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Jörn Bernhardt - Becoming a Founder",
+		"slug": "jörn-bernhardt-becoming-a-founder",
+		"id": "1626",
+		"metaDescription": "Season Seven, Episode One of the Virtual Coffee Podcast",
+		"season": 7,
+		"episode": 1,
+		"buzzsproutId": "12164997",
+		"publishDate": "2023-02-02T05:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Jörn Bernhardt about his journey as a 2x founder and his lifelong interest in technology.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Jörn Bernhardt, a 2x founder in Germany, about his career path, the challenges of being a founder, and the key traits that have led to his success.</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/Jörn.png",
+		"guests": [
+			{
+				"name": "Jörn Bernhardt",
+				"bio": "<p>Jörn started developing web-based software in the last century when he was still in school. In 2018, he founded his second company <a href=\"http://compose.us\">compose.us</a> where they implement digital solutions and share their knowledge with public administrations. In his spare time Jörn organizes local meetups in Germany and creates at least one open source commit per day to push his side projects.</p><ul><li><p><a href=\"https://compose.us/\">compose.us</a></p></li><li><p><a href=\"https://github.com/Narigo\">Jörn on GitHub</a></p></li><li><p><a href=\"NarigoDF\">Jörn on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/j%C3%B6rn-bernhardt-a04225104/\">Jörn on LinkedIn</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/joern.png"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Season Six Finale - Talking Hacktoberfest with Bekah, Dan, and Kirk",
+		"slug": "season-six-finale-talking-hacktoberfest-with-bekah-dan-and-kirk",
+		"id": "1132",
+		"metaDescription": "Season Six, Episode Nine of the Virtual Coffee Podcast",
+		"season": 6,
+		"episode": 9,
+		"buzzsproutId": "11496083",
+		"publishDate": "2022-10-13T04:00:00+00:00",
+		"shortDescription": "<p>It’s the final episode of season six of the podcast and we’re bringing it to you live with Bekah, Dan, and Kirk!</p>",
+		"showNotes": "<p>It’s the final episode of season six of the podcast and we’re bringing it to you live with Bekah, Dan, and Kirk! We talked a lot about Hacktoberfest with many side-tracks and segues in between.</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0609-finale.jpg",
+		"guests": [],
+		"sponsors": []
+	},
+	{
+		"title": "Shelley McHardy: Junior Dev life",
+		"slug": "shelley-mchardy-junior-dev-life",
+		"id": "1101",
+		"metaDescription": "Season Six, Episode Eight of the Virtual Coffee Podcast",
+		"season": 6,
+		"episode": 8,
+		"buzzsproutId": "11445606",
+		"publishDate": "2022-10-05T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Shelley McHardy about navigating a career transition and the challenges of interviewing for your first developer role.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Shelley McHardy, a former chemistry teacher turned front end developer at <a href=\"https://www.rightpoint.com/\">Rightpoint</a>, and talked about the early career developer's journey. She gave insight into what her seven-month interview process looked like, forcing interviewers to interview you, the importance of finding \"your people\", and being picky in your job search.</p><h3>Links:</h3><ul><li><p><a href=\"https://www.edx.org/\">edX</a></p></li><li><p><a href=\"https://the-collab-lab.codes/\">Collab Lab</a></p></li><li><p><a href=\"https://www.studentachievementsolutions.com/what-are-professional-learning-communities-plcs/\">PLCs- Professional learning communities</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0608-shelley-episode.jpg",
+		"guests": [
+			{
+				"name": "Shelley McHardy",
+				"bio": "<p>Shelley is a former chemistry teacher turned front end developer at Rightpoint. A native San Franciscan, she is currently doing her best to stay cool in Atlanta, Georgia. When not crocheting, she and her wife love hiking the Georgia State Parks, geocaching, cooking, baking, and video games.</p><ul><li><p>GitHub: <a href=\"https://github.com/shelleymcq\">@shelleymcq</a></p></li><li><p>Twitter <a href=\"https://twitter.com/shelleymcqDev\">@shelleymcqDev</a></p></li><li><p>LinkedIn <a href=\"https://www.linkedin.com/in/shelleymchardy/\">shelleymchardy</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0608-shelley.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Ryan Kahn - Building Better Teams",
+		"slug": "ryan-kahn-building-better-teams",
+		"id": "1091",
+		"metaDescription": "Season 6, Episode 7 of the Virtual Coffee Podcast",
+		"season": 6,
+		"episode": 7,
+		"buzzsproutId": "11407929",
+		"publishDate": "2022-09-29T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk with Ryan Kahn about building better teams to deliver quality software by practicing empathy and knowledge sharing.</p>",
+		"showNotes": "<p>In today's episode, Bekah and Dan talk to Ryan Kahn, a developer experience and productivity consultant from New York City, about his work as a consultant helping companies to build better software teams. He emphasizes the importance of recognizing that teams are made up of individuals who have different needs and approaches. He also breaks down the difference between quality, technical, knowledge, and innovation debt and the need to identify which most impacts teams as they seek better communication to build a stronger team.</p><h3>Links:</h3><ul><li><p><a href=\"http://adr.github.io\">ADR GitHub organization</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Oblique_Strategies\">Oblique Strategies</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0607-ryan-episode.jpg",
+		"guests": [
+			{
+				"name": "Ryan Kahn",
+				"bio": "<p>Ryan loves solving the human and technical problems of software development, and works on both as a developer experience and productivity consultant. He lives in New York City with his partner, daughter, and dog. Outside of his work he loves Astronomy and Amateur Radio.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0607-ryan.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Julia Seidman - Embracing the Careen Over the Career",
+		"slug": "julia-seidman-embracing-the-careen-over-the-career",
+		"id": "1049",
+		"metaDescription": "Season Six, Episode Six, of the Virtual Coffee Podcast",
+		"season": 6,
+		"episode": 6,
+		"buzzsproutId": "11351419",
+		"publishDate": "2022-09-20T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Julia about learning how to learn as a Technical Writer, the importance of teaching as a tool for learning, and her approach to writing about new technologies.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Julia Seidman, a technical marketing consultant and developer in the Seattle area, and talked about her work writing about different technologies, learning by teaching, and embracing the careen over the career. She talks about her career journey from studying anthropology to financial analysis to teaching high school English, ESL and Debate, before landing her current role as a technical writer.</p><h3>Links</h3><ul><li><p><a href=\"https://en.wikipedia.org/wiki/Krugerrand\">Krugerrand</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Doubloon\">Gold Doubloons</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Rhodium\">Rhodium</a></p></li><li><p><a href=\"https://flutter.dev/\">Flutter</a></p></li><li><p><a href=\"https://www.amazon.com/Developer-Marketing-Does-Not-Exist-ebook/dp/B091NK954H\">Developer Marketing Does Not Exist</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0606-julia-episode.jpg",
+		"guests": [
+			{
+				"name": "Julia Seidman",
+				"bio": "<p>Julia Seidman is a technical marketing consultant and developer in the Seattle area. She has 2 terrific kids and a wonderful partner, and her family cos-plays as a “normal” family.</p><p class=\"text-left\">Julia is a believer in the careen, rather than the career.</p><p class=\"text-left\">After studying anthropology and writing a senior thesis on the ethics of museum collections of human skeletal remains, she took the job she could get, which was fundraising for a hospital.</p><p class=\"text-left\">From there, she became a financial analyst and employee educator for 401(k) and pension plans. After that, she got a Master’s in Teaching, and taught high school English, ESL and Debate for most of a decade.</p><p class=\"text-left\">Now, she works as a freelance technical writer and software developer, specializing in technical content marketing.</p><p class=\"text-left\">Along the way, she has learned a lot about a lot of things, including the Python ecosystem.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0606-juila.JPG"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Chad Stewart - OSS and #TechisHiring",
+		"slug": "chad-stewart-oss-and-techishiring",
+		"id": "1026",
+		"metaDescription": "Season 6, Episode 5 of the Virtual Coffee Podcast",
+		"season": 6,
+		"episode": 5,
+		"buzzsproutId": "11269316",
+		"publishDate": "2022-09-06T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk with Chad Stewart about getting started in open source, finding a project with a supportive community, and his project #TechIsHiring.</p>",
+		"showNotes": "<p>In today's episode, Bekah and Dan talk to Chad Stewart, a Software Engineer from Kingston, Jamaica, about his journey into contributing to Open Source projects like Open Sauced and how to find your way to your first contribution. He shares the inspiration behind his <a href=\"https://www.getrevue.co/profile/techishiring\">#TechIsHiring project</a>, which helps to identify tech jobs and resources, but more importantly, to connect people in the wider tech community.</p><h3>Links</h3><ul><li><p><a href=\"https://www.amazon.com/Side-Mountain-Jean-Craighead-George/dp/0141312424\">My Side of the Mountain</a></p></li><li><p><a href=\"https://twitter.com/bdougieYO\">Brian Douglas, aka Bdougie</a></p></li><li><p><a href=\"https://opensauced.pizza/\">Open Sauced</a></p></li><li><p><a href=\"https://github.com/yangshun/tech-interview-handbook\">Tech Interview Handbook</a></p></li><li><p><a href=\"https://github.com/TheAlgorithms\">The Algorithms</a></p></li><li><p><a href=\"https://twitter.com/AdiatiAyu\">Ayu</a></p></li><li><p><a href=\"https://twitter.com/TechIsHiring\">Tech is Hiring</a></p></li><li><p><a href=\"https://github.com/Virtual-Coffee/virtualcoffee.io/blob/main/CONTRIBUTING.md\">Virtual Coffee Contributors Guide</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0605-chad-episode.jpg",
+		"guests": [
+			{
+				"name": "Chad Stewart",
+				"bio": "<p>Software Engineer from Kingston, Jamaica. Founder of <a href=\"https://www.getrevue.co/profile/techishiring\">TechIsHiring</a>.</p><ul><li><p><a href=\"https://twitter.com/Chad_R_Stewart\">@Chad_R_Stewart on Twitter</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0605-chad.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Sadie Jay - Technical Interviews for Bootcamp Grads",
+		"slug": "sadie-jay-technical-interview-for-bootcamp-grads",
+		"id": "990",
+		"metaDescription": "Season 6, Episode 4 of the Virtual Coffee Podcast",
+		"season": 6,
+		"episode": 4,
+		"buzzsproutId": "11204579",
+		"publishDate": "2022-08-30T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Sadie about technical interviewing after bootcamp. She shares her tips for landing interviews, prepping, and interviewing your interviewers.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Sadie a frontend developer for a federal agency, to chat about her experience navigating the interview process and how she found success after giving tech a second shot. She shares tips on how to avoid burnout both during the interview process and while you're working in tech.</p><h3>Links:</h3><ul><li><p><a href=\"https://18f.gsa.gov/\">18f</a></p></li><li><p><a href=\"https://skillcrush.com/\">Skill Crush</a></p></li><li><p><a href=\"https://leetcode.com/explore/challenge/\">Leet Code Challenge</a></p></li><li><p><a href=\"https://github.com/jmkoni/interview-questions\"><u>Jennifer's List of Interview Questions</u></a></p></li><li><p><a href=\"https://skillcrush.com/blog/technical-test-preparation-advice/\">Technical Test Preparation Advice</a> post by Sadie</p></li><li><p><a href=\"https://www.wordsofmouth.org/\">Words of Mouth job email</a></p></li><li><p><a href=\"https://designsystem.digital.gov/\">US Web Design Standards</a></p></li><li><p><a href=\"https://jekyllrb.com/\">Jekyll</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0604-sadie-episode.png",
+		"guests": [
+			{
+				"name": "Sadie Jay",
+				"bio": "<p>Sadie is a Front-end Developer and bootcamp alum. In 2016, Sadie started her journey into tech with web design courses. Along the way, she graduated with a Masters specializing in Web Design and Online Communication, taught yoga, searched for cheap flights at a travel startup, volunteered as a writer and proofreader for various non-profits, and contributed to a number of open source projects. Outside of coding and writing, Sadie can be found petting her cat Maxie, hanging out with her mom, or looking up the next vegan restaurant to check out.</p><ul><li><p><a href=\"https://sadiejay.github.io/portfolio/\">Sadie's Portfolio Site</a></p></li><li><p><a href=\"https://github.com/sadiejay\">@sadiejay on GitHub</a></p></li><li><p><a href=\"https://www.linkedin.com/in/sadiej/\">@sadiej on LinkedIn</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0604-sadie.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "50th Episode Special - Live at KCDC 2022",
+		"slug": "50th-episode-special-live-at-kcdc-2022",
+		"id": "987",
+		"metaDescription": "Season Six Special Edition",
+		"season": 6,
+		"episode": 999,
+		"buzzsproutId": "11127313",
+		"publishDate": "2022-08-12T04:00:00+00:00",
+		"shortDescription": "<p>For the 50th episode of the podcast, Dan and Bekah are live at KCDC 2022 answering listener questions and practicing their accents.</p>",
+		"showNotes": "<p>For the 50th episode of the podcast, Dan and Bekah are live at the Kansas City Developer Conference 2022 answering listener questions and practicing their accents.</p><p><a href=\"https://www.youtube.com/watch?v=_fqFv1joZ3A\"><strong>Check out the video version on YouTube!</strong></a></p><h4>Listener questions:</h4><ul><li><p>What time do you go to sleep? (2:19)</p></li><li><p>How does a computer get drunk? (12:42)</p></li><li><p>What's the hardest part of community? (22:20)</p></li><li><p>Ayu would like to hear the history of how Virtual Coffee was founded. (31:57)</p></li><li><p>What does community mean to you? (38:01)</p></li><li><p>At in-person events, what are some techniques or tactics you used for starting a conversation with a stranger? (41:00)</p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/06-special.png",
+		"guests": [],
+		"sponsors": []
+	},
+	{
+		"title": "Seth Hall - From Film Production to Technical Product Owner: A Career Changer's Story",
+		"slug": "seth-hall-from-film-production-to-technical-product-owner-a-career-changers-story",
+		"id": "954",
+		"metaDescription": "Season 6, Episode 3 of the Virtual Coffee Podcast",
+		"season": 6,
+		"episode": 3,
+		"buzzsproutId": "11103329",
+		"publishDate": "2022-08-09T04:00:00+00:00",
+		"shortDescription": "<p>Bekah and Dan talk to Seth Hall, a Technical Product Owner at Uniform. He talks about the importance of fostering authentic company culture, as well as how his search to find a challenging, fun, and flexible job led him from Film Production, to Frontend Developer, to his current role.</p>",
+		"showNotes": "<p>In today's episode, Dan and Bekah talk with Seth Hall about the importance of intimate collaboration, advocating for yourself, and transferable skills as part of his job as a Technical Product Owner at <a href=\"https://uniform.dev/\">Uniform</a>. He shares how his background as a creative producer informs how he guides demo initiatives, creates roadmaps, and collaborates with other departments.</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0603-seth-hall-episode.jpg",
+		"guests": [
+			{
+				"name": "Seth Hall",
+				"bio": "<p>Seth is a Technical Product Owner at <a href=\"https://uniform.dev/\">Uniform</a></p><ul><li><p>Website: <a href=\"https://sethhall.dev/\">sethhall.dev</a></p></li><li><p>Dev.to: <a href=\"https://dev.to/sethburtonhall\"><u>dev.to/sethburtonhall</u></a></p></li><li><p>Polywork: <a href=\"https://www.polywork.com/sethhall\"><u>polywork.com/sethhall</u></a></p></li><li><p>Twitter: <a href=\"https://twitter.com/sethburtonhall\">@sethburtonhall</a></p></li><li><p>GitHub: <a href=\"https://github.com/sethburtonhall\">@sethburtonhall</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0603-seth-hall.png"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Bogdan Covrig - Navigating Tech Career Paths",
+		"slug": "bogdan-covrig-navigating-tech-career-paths",
+		"id": "933",
+		"metaDescription": "Season Six, Episode Two of the Virtual Coffee Podcast",
+		"season": 6,
+		"episode": 2,
+		"buzzsproutId": "11044164",
+		"publishDate": "2022-07-28T04:00:00+00:00",
+		"shortDescription": "<p>In this episode, Dan and Bekah talk to Bogdan Covrig about finding the right career path within tech and searching for what gets you excited.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Bogdan Covrig, a Software Engineer in the Netherlands who's into Typescript, React and Node, about navigating different learning and career paths in tech before landing a job that fulfills his interests to see the changes he's making and provides a dynamic work environment. He also drops his tips on the most important things you can do if you're starting your journey into tech.</p><h3>Links</h3><ul><li><p><a href=\"https://p5js.org/\">p5.js</a></p></li><li><p><a href=\"https://www.arduino.cc/\">Arduino</a></p></li><li><p><a href=\"https://www.twitch.tv/virtualcoffeeio/schedule\">Twitch TypeScript Tuesdays</a></p></li><li><p>Nick and Bekah's Lunch & Learn <a href=\"https://youtu.be/DVqtr3iwkwQ\">Coding questions: Problem-solving and working through challenges</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0602-bogdan-episode.png",
+		"guests": [
+			{
+				"name": "Bogdan Covrig",
+				"bio": "<p>Bogdan is a Software Engineer in the Netherlands. He’s passionate about privacy, automation and infrastructure. He’s into Typescript, React and Node, currently building and working with CMS. He’s usually busy with movies, concerts or sitting in the park for no reason.</p><ul><li><p><a href=\"https://github.com/BogDAAAMN\">@BogDAAAMN</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/BogdanCovrig\">@BogdanCovrig</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/BogdanCovrig\">@BogdanCovrig</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0602-bogdan.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "David Alpert - On pairing and providing support",
+		"slug": "david-alpert-on-pairing-and-providing-support",
+		"id": "913",
+		"metaDescription": "Season 6, Episode 1 of the Virtual Coffee Podcast",
+		"season": 6,
+		"episode": 1,
+		"buzzsproutId": "10964411",
+		"publishDate": "2022-07-15T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to David Alpert about supporting others in their tech journey, asking the right questions, and leading with empathy.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with David Alpert, Director of Engineering at Northfield IT, about taking a personalized approach to helping others as they ask coding questions and navigate career paths. David shares the importance of bringing empathy to every situation and gives tips on how to handle challenging situations.</p><h3>Links:</h3><ul><li><p><a href=\"https://en.wikipedia.org/wiki/Logo_(programming_language)\">Logo (the programming turtle)</a></p></li><li><p><a href=\"https://dev.to/virtualcoffee/how-the-virtual-coffee-coworking-room-works-2a89\">Virtual Coffee Co-Working Room</a></p></li><li><p><a href=\"https://agilemanifesto.org/\">The Agile Manifesto</a></p></li><li><p><a href=\"https://www.twitch.tv/virtualcoffeeio\">Typescript Tuesdays</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0601-david-episode.jpg",
+		"guests": [
+			{
+				"name": "David Alpert",
+				"bio": "<p>David Alpert is a collaborative leader and agile coach striving to reduce friction between people and software. Based in Winnipeg, Manitoba, David has over 20 years of professional IT experience in software development, system design, and project and people management spanning the finance, manufacturing, and sports entertainment industries. David is passionate about test-driven development, refactoring, pair programming, and helping people become better developers.</p><ul><li><p>Website: <a href=\"https://blog.spinthemoose.com\">Spin the Moose</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/davidalpert\">@davidalpert</a></p></li><li><p>GitHub: <a href=\"https://github.com/davidalpert\">davidalpert</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0601-david.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Season 5 Wrap-Up: Working to Empower the Virtual Coffee Community",
+		"slug": "season-5-wrap-up-working-to-empower-the-virtual-coffee-community",
+		"id": "876",
+		"metaDescription": "Season 5 Finale of the Virtual Coffee Podcast",
+		"season": 5,
+		"episode": 9,
+		"buzzsproutId": "10720878",
+		"publishDate": "2022-06-01T04:00:00+00:00",
+		"shortDescription": "<p>In this season finale of the podcast, Dan, Kirk, and Bekah come together to talk about making hard decisions to ensure community support and stability. They also share how they're navigating technical and community challenges as the community grows.</p>",
+		"showNotes": "<p>In this episode of the podcast, Bekah, Kirk, and Dan discuss the decision to pause new membership and what the maintainers are doing to progress towards opening the community up again. We share what we think makes our community special, how we're working to preserve that, and some of the challenges we're figuring out as we take steps towards reopening membership. What goes into the long-term strategy of making Virtual Coffee <em>an intimate group of devs, optimized for you</em>? You'll find out in this episode.</p><h3>Links:</h3><ul><li><p><a href=\"https://gamesnostalgia.com/game/dx-ball\" rel=\"noopener noreferrer\" target=\"_blank\">DX Ball</a></p></li><li><p><a href=\"https://boardgamegeek.com/boardgame/3086/omega-virus\" rel=\"noopener noreferrer\" target=\"_blank\">Omega Virus</a></p></li><li><p><a href=\"https://www.ultraboardgames.com/othello/game-rules.php\" rel=\"noopener noreferrer\" target=\"_blank\">Othello</a></p></li><li><p><a href=\"http://virtualcoffee.io/members\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee Members</a></p></li><li><p><a href=\"https://virtualcoffee.io/resources/virtual-coffee/get-involved/paths-to-leadership\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee Paths to Leadership</a></p></li><li><p><a href=\"https://twitter.com/SuzeShardlow\" rel=\"noopener noreferrer\" target=\"_blank\">Suze Shardlow</a></p></li><li><p><a href=\"https://www.bbc.com/future/article/20191001-dunbars-number-why-we-can-only-maintain-150-relationships\" rel=\"noopener noreferrer\" target=\"_blank\">Dunbar's Number</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0509-finale-episode.jpg",
+		"guests": [
+			{
+				"name": "Kirk Shillingford",
+				"bio": "<p>Software Developer, and Community Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://github.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-kirk.jpg"
+			},
+			{
+				"name": "Bekah Hawrot Weigel",
+				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dev.to/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/bekahhw</a></p></li><li><p><a href=\"https://twitter.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">@bekahhw</a> on Twitter</p></li><li><p><a href=\"https://www.instagram.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">bekahhw</a> on Instagram</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/T014AAKN3KP-U014HT3RNCU-f7cccf369940-512.png"
+			},
+			{
+				"name": "Dan Ott",
+				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dtott.com/\" rel=\"noopener noreferrer\" target=\"_blank\">dtott.com</a></p></li><li><p><a href=\"https://twitter.com/danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">@danieltott</a> on Twitter</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-dan.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Matt McInnis - Go Make Stuff!",
+		"slug": "matt-mcinnis-go-make-stuff",
+		"id": "860",
+		"metaDescription": "Season 5, Episode 8 of the Virtual Coffee Podcast",
+		"season": 5,
+		"episode": 8,
+		"buzzsproutId": "10680520",
+		"publishDate": "2022-05-25T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Matt McInnis about his incredible journey through tech from math professor, to self-taught data-scientist working with IBM and Microsoft, to founder.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Matt McInnis a former Math Professor, and current data scientist, full-stack engineer, and founder, about his journey through tech as a self-taught engineer. He shares his insight into building personal projects and creating value in the projects you work on, even if those projects are just for you.</p><h3>Links</h3><ul><li><p><a href=\"https://typistapp.ca/\">Typist</a></p></li><li><p><a href=\"https://www.littlebrown.com/titles/malcolm-gladwell/the-tipping-point/9780759574731/\">Malcolm Gladwell's Tipping Point</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Kidstreet\" rel=\"noopener noreferrer\" target=\"_blank\">Kidstreet</a></p></li><li><p><a href=\"https://www.hackerparadise.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Hacker Paradise</a></p></li><li><p><a href=\"https://ologicinc.com/portfolio/star-wars-science-force-trainer/\" rel=\"noopener noreferrer\" target=\"_blank\">Star Wars Force Trainer</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0508-matt-episode.jpg",
+		"guests": [
+			{
+				"name": "Matt McInnis",
+				"bio": "<p>Matt is a full-stack developer (Rails+React) at <a href=\"https://typistapp.ca/\">Typist</a> based in Toronto, Canada. Former artificial intelligence lead at IBM and Microsoft, mathematics professor at Centennial College and Saskatchewan Polytechnic. Matt really loves brunch.</p><ul><li><p><a href=\"https://github.com/MattyMc\">MattyMc on GitHub</a></p></li><li><p><a href=\"https://twitter.com/MattLovesMath\">MattLovesMath on Twitter</a></p></li><li><p><a href=\"http://linkedin.com/in/mattmcinnis\">mattmcinnis on LinkedIn</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0508-matt.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Meg Gutshall - Building accountability into Community",
+		"slug": "meg-gutshall-building-accountability-into-community",
+		"id": "840",
+		"metaDescription": "Season 5, Episode 7 of the Virtual Coffee Podcast",
+		"season": 5,
+		"episode": 7,
+		"buzzsproutId": "10613498",
+		"publishDate": "2022-05-13T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk with Meg Gutshall about accountability and how to bring that to your community. She shares some of her memorable experiences with community and she does it all with Philly flair.</p>",
+		"showNotes": "<p>In today's episode, Bekah and Dan talk to Meg Gutshall, a Ruby on Rails Developer, and community volunteer at Virtual Coffee. She shared all things Philly and some memorable stories of how she's supported others--including Bekah--in their journeys into tech. Meg talks about her Accountabilibuddies group at Virtual Coffee and how she chose Ruby after graduating from a full stack bootcamp.</p><p></p><img src=\"http://storage.googleapis.com/virtualcoffeeio-assets/images/_podcastShowNotesImage/gritty.jpg\" alt=\"Gritty, the Fliers Mascot\" title=\"Gritty, the Fliers Mascot\"><p></p><h3>Links</h3><ul><li><p><a href=\"https://en.wikipedia.org/wiki/Gritty\" rel=\"noopener noreferrer\" target=\"_blank\">Gritty</a></p></li><li><p><a href=\"https://freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">freeCodeCamp</a></p></li><li><p><a href=\"https://www.pennmedicine.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Penn medicine</a></p></li><li><p><a href=\"https://www.urbandictionary.com/define.php?term=Jawn\" rel=\"noopener noreferrer\" target=\"_blank\">jawn</a></p></li><li><p>Meg's blog post on code and Spanish: <a href=\"https://meghangutshall.com/2018/07/21/the_little_things_matter/\" rel=\"noopener noreferrer\" target=\"_blank\">The Little Things Matter</a></p></li><li><p><a href=\"https://rubyforgood.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Ruby for Good</a></p></li><li><p><a href=\"https://humanessentials.app/\" rel=\"noopener noreferrer\" target=\"_blank\">HumanEssentials.app</a></p></li><li><p><a href=\"https://nationalcasagal.org/\" rel=\"noopener noreferrer\" target=\"_blank\">CASA</a></p></li><li><p><a href=\"https://2022.phillytechweek.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Philly Tech Week</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0507-meg-episode.jpg",
+		"guests": [
+			{
+				"name": "Meg Gutshall",
+				"bio": "<p>Meg is a Ruby on Rails developer with a passion for open source and tech for good. She's always smiling, continuously learning, and quick to strike up a conversation. She takes her advice with a grain of salt & a shot of tequila.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0507-meg.png"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Andrew Bush - Mobile Development and Giving Back to Community",
+		"slug": "andrew-bush-mobile-development-and-giving-back-to-community",
+		"id": "828",
+		"metaDescription": "Season 5, Episode 6 of the Virtual Coffee Podcast",
+		"season": 5,
+		"episode": 6,
+		"buzzsproutId": "10565670",
+		"publishDate": "2022-05-05T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Andrew Bush about his experiences with mobile development, and his thoughts on community and what it means to give back.</p>",
+		"showNotes": "<p>In today's episode, Dan and Bekah talk to Andrew Bush, a Mobile Engineer Specializing in React Native. One of the updates we've made to our site is to have tags on our <a href=\"https://virtualcoffee.io/members\">members page</a> to indicate what volunteer roles they have. Andrew is one of our Monthly Challenge team leads, and he shared with us his experiences helping to facilitate the challenges, keeping our community motivated, and the processes we go through. We also go into what it's like to be a mobile developer, and the learning path he's been on throughout his career.</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0506-andrew-episode.jpg",
+		"guests": [
+			{
+				"name": "Andrew Bush",
+				"bio": "<p>Andrew is a mobile developer specializing in React Native based out of Wisconsin in the US. He has been developing professionally for 3 years and has really found his passion in mobile apps and accessibility. Being legally blind himself, he recognizes the need for inclusion in software development so that EVERYONE can use the applications we create.</p><p>Outside of his professional life, Andrew is a dedicated amateur runner with a love for the sport that rivals his love of Swedish Fish candy. You can also find him participating as a co-lead of the Virtual Coffee monthly challenges where he strives to create engagement and growth combined with the feeling of an intimate community.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0506-andrew.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Special Kirk Day Bonus Episode (Live)",
+		"slug": "special-kirk-day-bonus-episode",
+		"id": "825",
+		"metaDescription": "Happy Kirk Day!",
+		"season": 5,
+		"episode": 999,
+		"buzzsproutId": "10509803",
+		"publishDate": "2022-04-26T04:00:00+00:00",
+		"shortDescription": "<p>A special live episode of the Virtual Coffee Podcast - Bekah and Dan meet for the first time in real life, and get to hang out with Kirk on Kirk Day!</p>",
+		"showNotes": "<p>A special live episode of the Virtual Coffee Podcast - Bekah and Dan meet for the first time in real life, and get to hang out with Kirk on Kirk Day! Also Dan fires Bekah (for the first time).</p><p><a href=\"https://youtu.be/uh-oA8czBVo\">Watch the stream on YouTube!</a></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/05-bonus-kirk-day.jpg",
+		"guests": [],
+		"sponsors": []
+	},
+	{
+		"title": "Roger Gentry - Perseverance and  Problem Solving",
+		"slug": "roger-gentry-perseverance-and-problem-solving",
+		"id": "814",
+		"metaDescription": "Season 5, Episode 5 of the Virtual Coffee Podcast",
+		"season": 5,
+		"episode": 5,
+		"buzzsproutId": "10480828",
+		"publishDate": "2022-04-21T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Roger Gentry about his love of solving problems and how he's brought that with him into tech.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Roger Gentry, who has spent a lot of his career managing security and compliance for clients across the United States, about his passion for problem-solving and what to do when you get stuck. We're all going to run into frustrations during our tech journeys, but knowing how to navigate through them is one of the key skills you'll need.</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0505-roger-episode.jpg",
+		"guests": [
+			{
+				"name": "Roger Gentry",
+				"bio": "<p>Roger has managed the security and compliance for clients across the United States. Providing CTO/CSO level consulting to a variety of industries, Roger has worked with customers to achieve successful compliance certifications from PCI, ISO, SOC, and more.</p><p><a href=\"http://r-o-g-e-r.com/\" rel=\"noopener noreferrer\" target=\"_blank\">http://r-o-g-e-r.com/</a></p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0505-roger.jpeg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Yolanda Haynes - Breaking into Tech: It Takes Time",
+		"slug": "yolanda-haynes-breaking-into-tech-it-takes-time",
+		"id": "790",
+		"metaDescription": "Season Five, Episode Four of the Virtual Coffee Podcast",
+		"season": 5,
+		"episode": 4,
+		"buzzsproutId": "10431216",
+		"publishDate": "2022-04-13T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Yolanda Haynes about her journey into tech and how she created her own path and experiences, including joining Virtual Coffee, 100devs, and Collab Lab.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Yolanda Haynes, a career changer who went from working as a certified occupational therapy assistant to a Software Engineer, about the importance of finding community during your learning journey, and remembering that you shouldn’t judge your journey based on anyone else’s; focus on the learning journey, absorbing what you can, and preparing yourself for your future.</p><h3>Links:</h3><ul><li><p><a href=\"https://leonnoel.com/100devs/\" rel=\"noopener noreferrer\" target=\"_blank\">100devs</a></p></li><li><p><a href=\"https://the-collab-lab.codes/\" rel=\"noopener noreferrer\" target=\"_blank\">The Collab Lab</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0504-yolanda.jpg",
+		"guests": [
+			{
+				"name": "Yolanda Haynes",
+				"bio": "<p>A career changer from working in healthcare as a COTA (certified occupational therapy assistant) to a Software Engineer.</p><ul><li><p><a href=\"https://www.yhaynes.com/\" rel=\"noopener noreferrer\" target=\"_blank\">yhaynes.com</a></p></li><li><p><a href=\"https://github.com/YolandaHaynes\" rel=\"noopener noreferrer\" target=\"_blank\">@YolandaHaynes on GitHub</a></p></li><li><p><a href=\"https://twitter.com/_YolandaHaynes\" rel=\"noopener noreferrer\" target=\"_blank\">@_YolandaHaynes on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/yolanda-haynes/\" rel=\"noopener noreferrer\" target=\"_blank\">@yolanda-haynes on LinkedIn</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/Profile.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Helen Griffin - Multi-passionate in tech",
+		"slug": "helen-griffin-multi-passionate-in-tech",
+		"id": "781",
+		"metaDescription": "Season Five, Episode Three of the Virtual Coffee Podcast",
+		"season": 5,
+		"episode": 3,
+		"buzzsproutId": "10397152",
+		"publishDate": "2022-04-07T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Helen Griffin about what she’s learned from her journey going from tech to founder and back to tech again.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Helen Griffin, a full-stack developer and founder, about how the tech industry changed during the time she was a founder, how what she’s learned as a founder has helped her to have a broader perspective about the tech industry, and what she’s doing with her companies Jovial and State of Developers to support developers in their career journeys.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://stateofdevs.com/\" rel=\"noopener noreferrer\" target=\"_blank\">The State of Developers</a></p></li><li><p><a href=\"https://jovial.work/\" rel=\"noopener noreferrer\" target=\"_blank\">Jovial</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0503-helen-episode.jpg",
+		"guests": [
+			{
+				"name": "Helen Griffin",
+				"bio": "<p>Helen started her career as a web developer. Now, as a full-stack dev & founder, she enjoys helping developers build products & a life they love. Today, she spends her time building developer tools, like State of Developers & Jovial. Helen is on a campaign to help her peers recover from burnout.</p><ul><li><p><a href=\"https://helenjr.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">HelenJr.dev</a></p></li><li><p><a href=\"https://github.com/helengriffinjr\" rel=\"noopener noreferrer\" target=\"_blank\">helengriffinjr</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/helengriffinjr\" rel=\"noopener noreferrer\" target=\"_blank\">@helengriffinjr</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/hgriffinjr\" rel=\"noopener noreferrer\" target=\"_blank\">@hgriffinjr</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0503-helen.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Amy Shackles - Finding a job you love",
+		"slug": "amy-shackles-finding-a-job-you-love",
+		"id": "767",
+		"metaDescription": "Season Five, Episode Two of the Virtual Coffee Podcast",
+		"season": 5,
+		"episode": 2,
+		"buzzsproutId": "10353204",
+		"publishDate": "2022-03-31T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Amy Shackles about the importance of good communication in finding a job you love and defining your career path.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Amy Shackles, a Senior Software Engineer at MURAL, about how she made her way from being a Psychology and Anthropology double major to being a Senior Software Engineer. She shares what’s made her experience at MURAL a great one and the importance of openness in communication.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://amyshackles.com/\" rel=\"noopener noreferrer\" target=\"_blank\">amyshackles.com</a></p></li><li><p><a href=\"https://github.com/AmyShackles/regex_parser\" rel=\"noopener noreferrer\" target=\"_blank\">Amy's regular expression parser</a></p></li><li><p><a href=\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions\" rel=\"noopener noreferrer\" target=\"_blank\">MDN article on regular expressions</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0502-amy-episode.jpg",
+		"guests": [
+			{
+				"name": "Amy Shackles",
+				"bio": "<p>Amy is a Senior Software Engineer currently working at <a href=\"https://mural.co/\" rel=\"noopener noreferrer\" target=\"_blank\">MURAL</a>. She loves information, human interaction, solving problems, helping people, and cats - not in that order. She spends most of her free time lately learning Spanish, practicing calligraphy, singing, writing parody songs, and crocheting.</p><ul><li><p><a href=\"https://amyshackles.com/\" rel=\"noopener noreferrer\" target=\"_blank\">amyshackles.com</a></p></li><li><p><a href=\"https://github.com/AmyShackles\" rel=\"noopener noreferrer\" target=\"_blank\">AmyShackles</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/AmyShackles\" rel=\"noopener noreferrer\" target=\"_blank\">@AmyShackles on Twitter</a></p></li><li><p><a href=\"https://dev.to/amyshackles\" rel=\"noopener noreferrer\" target=\"_blank\">@AmyShackles on DEV.to</a></p></li><li><p><a href=\"https://www.linkedin.com/in/AmyShackles\" rel=\"noopener noreferrer\" target=\"_blank\">@AmyShackles on LinkedIn</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0502-amy.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Brian Rinaldi - Developer Advocacy and Fostering Community",
+		"slug": "0501-brian-rinaldi",
+		"id": "180",
+		"metaDescription": "Season Five, Episode One of the Virtual Coffee Podcast",
+		"season": 5,
+		"episode": 1,
+		"buzzsproutId": "10297519",
+		"publishDate": "2022-03-22T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Brian Rinaldi about doing DevRel (Developer Relations) right and playing to your team's strengths. We also talk about the importance of connection and why we as developers need to support each other.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Brian Rinaldi, a Developer Experience Engineer at LaunchDarkly with over 20 years of experience as a developer for the web, about how Developer Relationships has changed over the years and why need not just remote community experiences but also in-person opportunities. We talk about the value of different types of communities and how each is necessary to support developers.</p><h3>Links</h3><ul><li><p><a href=\"https://launchdarkly.com/\" rel=\"noopener noreferrer\" target=\"_blank\">LaunchDarkly</a></p></li><li><p><a href=\"https://CFE.dev\" rel=\"noopener noreferrer\" target=\"_blank\">CFE.dev</a></p></li><li><p><a href=\"https://thejam.dev\" rel=\"noopener noreferrer\" target=\"_blank\">TheJam.dev</a></p></li><li><p><a href=\"https://www.manning.com/books/the-jamstack-book\" rel=\"noopener noreferrer\" target=\"_blank\">The Jamstack Book</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0501-brian-episode.jpg",
+		"guests": [
+			{
+				"name": "Brian Rinaldi",
+				"bio": "<p>Brian Rinaldi is a Developer Experience Engineer at LaunchDarkly with over 20 years experience as a developer for the web. Brian is actively involved in the community running developer meetups via CFE.dev and Orlando Devs. He's the editor of the Jamstacked newsletter and co-author of The Jamstack Book from Manning.</p><ul><li><p><a href=\"http://remotesynthesis.com\" rel=\"noopener noreferrer\" target=\"_blank\">remotesynthesis.com</a></p></li><li><p><a href=\"https://github.com/remotesynth\" rel=\"noopener noreferrer\" target=\"_blank\">remotesynth</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/remotesynth\" rel=\"noopener noreferrer\" target=\"_blank\">@remotesynth on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/brianrinaldi\" rel=\"noopener noreferrer\" target=\"_blank\">@brianrinaldi on LinkedIn</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0501-brian.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Season 4 Wrap Up - Reviewing the year and celebrating our community",
+		"slug": "0409-season-four-wrapup",
+		"id": "568",
+		"metaDescription": "Season 4 Wrap Up - Reviewing the year and celebrating our community",
+		"season": 4,
+		"episode": 9,
+		"buzzsproutId": "9650635",
+		"publishDate": "2021-12-02T05:00:00+00:00",
+		"shortDescription": "<p>In this final episode of season 4 of the podcast, Bekah and Dan bring back special guest and community maintainer, Kirk Shillingford to retro our Virtual Coffee Hacktoberfest Initiative, talk about our monthly challenges and our excitement of going into year 2 of the challenges, and we even throw in some amazing and/or awful jokes at the end.</p>",
+		"showNotes": "<p>Kirk, Dan, and Bekah are back again to wrap up Season 4 of the podcast. We talk about Hacktoberfest and how proud we are of what our community did over the month of Hacktoberfest:</p><ul><li><p>100 members signed up,</p></li><li><p>66 members merged at least 1 pr,</p></li><li><p>336 collectively we merged 336 PRs were merged by these members across 129 repos.</p></li></ul><p class=\"text-left\">On the <a href=\"https://virtualcoffee.io/\" rel=\"noopener noreferrer\" target=\"_blank\">virtualcoffee.io</a> site: 81 PRs merged, 50 were new member profiles, 31 others.</p><p class=\"text-left\">We talk about the monthly challenges, including already surpassing the monthly goal for blogging half way through <a href=\"https://virtualcoffee.io/monthlychallenges/nov-2021/\" rel=\"noopener noreferrer\" target=\"_blank\">November</a>, and what we're looking forward to doing in the next 12 months.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://hacktoberfest.digitalocean.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Digital Ocean Hacktoberfest</a></p></li><li><p><a href=\"https://virtualcoffee.io/podcast/0406-bryan-healey/\" rel=\"noopener noreferrer\" target=\"_blank\">Bryan's Episode</a></p></li><li><p><a href=\"https://github.com/colabottles/\" rel=\"noopener noreferrer\" target=\"_blank\">Todd Libby</a></p></li><li><p><a href=\"https://github.com/abbeyperini\" rel=\"noopener noreferrer\" target=\"_blank\">Abbey Perini</a></p></li><li><p><a href=\"https://github.com/MattyMc\" rel=\"noopener noreferrer\" target=\"_blank\">Matt McInnis</a></p></li><li><p><a href=\"https://prettier.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Prettier</a></p></li><li><p><a href=\"https://virtualcoffee.io/podcast/0407-jessica-wilkins/\" rel=\"noopener noreferrer\" target=\"_blank\">Jessica's Episode</a></p></li><li><p><a href=\"https://chrisbrogan.com/stories/community/audience-or-community/\" rel=\"noopener noreferrer\" target=\"_blank\">Audience or Community by Chris Brogan</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-episode.jpg",
+		"guests": [
+			{
+				"name": "Kirk Shillingford",
+				"bio": "<p>Software Developer, and Community Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://github.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-kirk.jpg"
+			},
+			{
+				"name": "Bekah Hawrot Weigel",
+				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dev.to/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/bekahhw</a></p></li><li><p><a href=\"https://twitter.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">@bekahhw</a> on Twitter</p></li><li><p><a href=\"https://www.instagram.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">bekahhw</a> on Instagram</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0209-bekah.jpg"
+			},
+			{
+				"name": "Dan Ott",
+				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dtott.com/\" rel=\"noopener noreferrer\" target=\"_blank\">dtott.com</a></p></li><li><p><a href=\"https://twitter.com/danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">@danieltott</a> on Twitter</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0409-dan.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Maeling Murphy - Transitioning to tech, and taking notes along the way",
+		"slug": "0408-maeling-murphy",
+		"id": "561",
+		"metaDescription": "Season Four, Episode Eight of the Virtual Coffee Podcast",
+		"season": 4,
+		"episode": 8,
+		"buzzsproutId": "9600325",
+		"publishDate": "2021-11-23T05:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Maeling Murphy about her journey from Material Science and Engineering to Software Engineering, including her personal documentation of her tech journey, work culture, and the big surprises when starting her job.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Dr. Maeling Murphy, a software engineer who recently transitioned into tech. Maeling shared the importance of connecting with potential employers to see if they would fit her values, how contributing to open source projects can help prepare you for your first job, and the value of developing the connection to community and being able to grow alongside others. Oh, and did we mention we talked a lot about Notion? She takes us through her notetaking journey and answers all our questions about finding the right approach.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://cs50.harvard.edu/\" rel=\"noopener noreferrer\" target=\"_blank\">Harvard's CS50</a></p></li><li><p><a href=\"https://www.100daysofcode.com/\" rel=\"noopener noreferrer\" target=\"_blank\">100 days of code</a></p></li><li><p><a href=\"https://virtualcoffee.io/monthlychallenges/july-2021/\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee Demo Monthly Challenge</a></p></li><li><p><a href=\"https://homeschool-journal.herokuapp.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Homeschool journal</a></p></li><li><p><a href=\"https://github.com/maelingmurphy\" rel=\"noopener noreferrer\" target=\"_blank\">Github</a></p></li><li><p><a href=\"https://github.com/maelingmurphy/My-Learning-Path/blob/main/log.md\" rel=\"noopener noreferrer\" target=\"_blank\">Learning Path log</a></p></li><li><p><a href=\"https://www.notion.so/templates/job-applications\" rel=\"noopener noreferrer\" target=\"_blank\">Karen's Notion for job searches</a></p></li><li><p><a href=\"https://docs.google.com/spreadsheets/d/1ZP0u5MjRiCOaYWuLoRTYr4BvB91M76ZCjkCYPuSePJc/edit?usp=sharing\" rel=\"noopener noreferrer\" target=\"_blank\">Karen's Job Application Details Spreadsheet</a></p></li><li><p><a href=\"https://www.notion.so/Thomas-Frank-s-Note-Taking-System-67924a5a25934f0fbe2f154cffcd8f97\" rel=\"noopener noreferrer\" target=\"_blank\">Frank's Notetaking System</a></p></li><li><p><a href=\"https://www.keyvalues.com/\" rel=\"noopener noreferrer\" target=\"_blank\">KeyValues: Find engineering teams that share your values</a></p></li><li><p><a href=\"https://pinboard.in/u:danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">Dan's Pinboard bookmarks</a></p></li><li><p><a href=\"https://github.com/forem/forem\" rel=\"noopener noreferrer\" target=\"_blank\">Forem</a> - Open source project that Nick Taylor helps maintain</p></li></ul><p><br></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0408-maeling-episode.jpg",
+		"guests": [
+			{
+				"name": "Maeling Murphy",
+				"bio": "<p>Dr. Maeling Murphy is a software engineer who recently transitioned into tech, coming from an 8+ year entrepreneurial journey as a digital content creator and as a Ph.D. research scientist in Materials Science & Engineering.</p><p class=\"text-left\">Maeling identifies as a multi-passionate creative soul, finding expression through gardening, programming, brush-lettering and other mediums that cross her path.</p><p class=\"text-left\">She lets her love for exploration, learning and sharing with others lead her in all aspects of life and is enjoying this journey with her husband and son.</p><ul><li><p><a href=\"https://github.com/maelingmurphy\" rel=\"noopener noreferrer\" target=\"_blank\">maelingmurphy</a> on GitHub</p></li><li><p><a href=\"https://twitter.com/maelingcodes\" rel=\"noopener noreferrer\" target=\"_blank\">@maelingcodes on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/maeling-murphy\" rel=\"noopener noreferrer\" target=\"_blank\">@maeling-murphy on LinkedIn</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0408-maeling.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Jessica Wilkins - Growing your tech career through writing",
+		"slug": "0407-jessica-wilkins",
+		"id": "554",
+		"metaDescription": "Season Four, Episode Seven of the Virtual Coffee Podcast",
+		"season": 4,
+		"episode": 7,
+		"buzzsproutId": "9566513",
+		"publishDate": "2021-11-17T05:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Jessica Wilkins about how writing can help you to grow your tech career. She gives us tips on getting started and on taking feedback.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Jessica Wilkins, a self-taught developer and a staff author for the freeCodeCamp News publication. Jessica talks about how to get started with tech writing, how to differentiate between constructive criticism and negative feedback, and how to avoid gatekeeping by eliminating assumptions from your writing, avoiding terms and phrases like \"it's so easy!\", and sometimes adding prerequisites to your posts.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://www.esm.rochester.edu/\" rel=\"noopener noreferrer\" target=\"_blank\">Eastman School of Music</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=hD6uRvCtA_0&amp;t=70s\" rel=\"noopener noreferrer\" target=\"_blank\">Jessica's Lunch & Learn: How to grow your tech career through writing</a></p></li><li><p><a href=\"https://www.freecodecamp.org/news/author/jessica-wilkins/\" rel=\"noopener noreferrer\" target=\"_blank\">Freecodecamp news</a></p></li><li><p><a href=\"https://forum.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Freecodecamp forum</a></p></li><li><p><a href=\"https://www.freecodecamp.org/news/author/quincylarson/\" rel=\"noopener noreferrer\" target=\"_blank\">Quincy Larson</a></p></li><li><p><a href=\"https://www.history.com/this-day-in-history/george-floyd-killed-by-police-officer\" rel=\"noopener noreferrer\" target=\"_blank\">George Floyd murder</a></p></li><li><p><a href=\"https://blackexcellencemusicproject.com/\" rel=\"noopener noreferrer\" target=\"_blank\">The Black Excellence Music Project</a></p></li><li><p><a href=\"https://github.com/jdwilkin4/Black_Excellence_Project\" rel=\"noopener noreferrer\" target=\"_blank\">Github for it</a></p></li><li><p><a href=\"https://virtualcoffee.io/monthlychallenges/nov-2021/\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee November Monthly Challenge</a></p></li><li><p><a href=\"https://www.gatsbyjs.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Gatsby</a></p></li><li><p><a href=\"https://www.gatsbyjs.com/blog/gatsby-voices-jessica-wilkins/\" rel=\"noopener noreferrer\" target=\"_blank\">Voices of Gatsby: Fighting Back Against Imposter Syndrome</a></p></li><li><p><a href=\"https://www.freecodecamp.org/news/how-to-use-replit/\" rel=\"noopener noreferrer\" target=\"_blank\">How to Use Repl.it: a beginner's guide</a></p></li><li><p><a href=\"https://www.freecodecamp.org/news/how-to-use-codepen/\" rel=\"noopener noreferrer\" target=\"_blank\">How to Use Codepen: a beginner's guide</a></p></li><li><p><a href=\"https://dev.to/codergirl1991/how-to-create-a-node-bot-that-sends-happy-emails-throughout-the-year-25nj\" rel=\"noopener noreferrer\" target=\"_blank\">NodeMailer</a></p></li></ul><p><br></p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0407-jessica-episode.jpg",
+		"guests": [
+			{
+				"name": "Jessica Wilkins",
+				"bio": "<p>Jessica Wilkins is a self taught developer and technical writer from Los Angeles, California.</p><p class=\"text-left\">In her previous career, she was a professional oboist, educator and owner of JDW Sheet Music.</p><p class=\"text-left\">Jessica's interest in programming came during the pandemic when she wanted to build the Black Excellence Music Project which celebrates black artists from the jazz and classical fields.</p><p class=\"text-left\">She now works part-time as a junior developer for a small tech company and is a staff author for the freeCodeCamp News publication.</p><ul><li><p><a href=\"https://dev.to/codergirl1991\" rel=\"noopener noreferrer\" target=\"_blank\">Dev.to profile</a></p></li><li><p><a href=\"https://twitter.com/codergirl1991\" rel=\"noopener noreferrer\" target=\"_blank\">@codergirl1991 on Twitter</a></p></li><li><p><a href=\"https://www.linkedin.com/in/jessica-wilkins-developer\" rel=\"noopener noreferrer\" target=\"_blank\">@jessica-wilkins-developer on LinkedIn</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0407-jessica.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Bryan Healey - The Entrepreneurial Journey of a Startup Founder",
+		"slug": "0406-bryan-healey",
+		"id": "547",
+		"metaDescription": "Season Four, Episode Six of the Virtual Coffee Podcast",
+		"season": 4,
+		"episode": 6,
+		"buzzsproutId": "9522643",
+		"publishDate": "2021-11-10T05:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Bryan Healey about how to kickoff your career as a start-up founder and the lessons he's learned along the way.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Bryan Healey, an entrepreneur, tech leader, data scientist / ML engineer, and biz developer. Bryan talks about gaining experience as an entrepreneur, how to get started in the start-up life, and how the entrepreneurial spirit has always been in his blood.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a></p></li><li><p><a href=\"https://virtualcoffee.io/podcast/0401-jessi-shakarian/\" rel=\"noopener noreferrer\" target=\"_blank\">Jessi's VC Podcast episode</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0406-bryan-episode.jpg",
+		"guests": [
+			{
+				"name": "Bryan Healey",
+				"bio": "<p>Bryan Healey is an entrepreneur, tech leader, data scientist / ML engineer, and biz developer. He's helped create or grow several start-ups, raised money, and built/managed teams of varying sizes, small to large. Currently co-founder and CTO at <a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a>.</p><ul><li><p><a href=\"https://twitter.com/Bryan_Healey\" rel=\"noopener noreferrer\" target=\"_blank\">@Bryan_Healey</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/bryanhealey\" rel=\"noopener noreferrer\" target=\"_blank\">bryanhealey</a> on LinkedIn</p></li><li><p><a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0406-bryan.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Suze Shardlow - Creating welcoming spaces in dev communities",
+		"slug": "0405-suze-shardlow",
+		"id": "540",
+		"metaDescription": "Season Four, Episode Five of the Virtual Coffee Podcast",
+		"season": 4,
+		"episode": 5,
+		"buzzsproutId": "9487228",
+		"publishDate": "2021-11-03T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Suze Shardlow about how she approaches creating welcoming spaces in dev communities.</p>",
+		"showNotes": "<p>This week Bekah and Dan sat down with Suze Shardlow. Suze is an award winning community manager, coder, tech writer and tech event MC and she currently leads the developer community at <a href=\"https://redis.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Redis</a>. We had a really interesting conversation with Suze! She's done a million different things throughout her life and her career and she shared with us how her experiences have informed her time as a software developer and a community leader.</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://www.goodreads.com/book/show/56638386-30-second-coding?from_search=true&amp;from_srp=true&amp;qid=kCeXU2k1Tx&amp;rank=1\" rel=\"noopener noreferrer\" target=\"_blank\">30-second-coding</a></p></li><li><p><a href=\"https://twitter.com/SuzeShardlow/status/1445413709891973121?s=20\" rel=\"noopener noreferrer\" target=\"_blank\">On being a published author</a></p></li><li><p><a href=\"https://www.twitch.tv/redislabs\" rel=\"noopener noreferrer\" target=\"_blank\">redislabs on Twitch</a></p></li><li><p><a href=\"https://suze.dev/blog/im-a-techwomen100-2020-winner/\" rel=\"noopener noreferrer\" target=\"_blank\">One of the top 100 women in tech in 2020</a></p></li><li><p><a href=\"https://university.redis.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Redis University</a></p></li><li><p><a href=\"https://hacktoberfest.digitalocean.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Hacktoberfest</a></p></li><li><p><a href=\"https://codelandconf.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Codeland</a></p></li><li><p><a href=\"https://t.co/G0RN3vx2Gd?amp=1\" rel=\"noopener noreferrer\" target=\"_blank\">global diversity CFP day</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0405-suze-episode.jpg",
+		"guests": [
+			{
+				"name": "Suze Shardlow",
+				"bio": "<p>Suze Shardlow is a published tech author, developer community manager and event MC. Before retraining as a software engineer, she worked in marketing and management for 20 years in the engineering, technology, law enforcement, education and economic development sectors. Currently the head of developer community at Redis, Suze has won numerous awards including Rising Star In Tech 2021, TechWomen100 2020, Women In Software Power List 2020 and is a finalist in the Women In Tech Excellence Awards 2021.</p><ul><li><p><a href=\"https://suze.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">suze.dev</a></p></li><li><p><a href=\"https://twitter.com/SuzeShardlow\" rel=\"noopener noreferrer\" target=\"_blank\">@SuzeShardlow</a> on Twitter</p></li><li><p><a href=\"https://github.com/SuzeShardlow\" rel=\"noopener noreferrer\" target=\"_blank\">@SuzeShardlow</a> on GitHub</p></li><li><p><a href=\"https://www.linkedin.com/in/SuzeShardlow\" rel=\"noopener noreferrer\" target=\"_blank\">SuzeShardlow</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0405-suze.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Mark Noonan - Civic tech, accessibility, holding the door open for other career changers",
+		"slug": "0404-mark-noonan",
+		"id": "531",
+		"metaDescription": "Season Four, Episode Four of the Virtual Coffee Podcast",
+		"season": 4,
+		"episode": 4,
+		"buzzsproutId": "9442638",
+		"publishDate": "2021-10-27T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Mark Noonan about how we can make space for career changers through Civic Tech while we make an impact on our communities.</p>",
+		"showNotes": "<p>This week we welcome Mark Noonan to the show to talk about how becoming a part of Civic Tech initiatives can help career changers to grow and help existing developers create opportunities for mentorship, support, and connection for those coming into tech.</p><p class=\"text-left\">Mark talks about his experience with <a href=\"https://www.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">FreeCodeCamp</a> as well as <a href=\"https://www.codeforatlanta.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Code for Atlanta</a>, and the $40,000 Hackathon his group won and donated to charity! He brings his experience as a career transitioner to the conversation and we look at how participating in Civic Tech can help you develop skills to be a better communicator and programmer. And you might hear a little bit about how we prefer our breakfast foods too 🥞</p><h3><strong>Links</strong></h3><ul><li><p><a href=\"https://www.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">FreeCodeCamp</a></p></li><li><p><a href=\"https://www.codeforatlanta.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Code for Atlanta</a></p></li><li><p><a href=\"https://www.codeforamerica.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Code for America</a></p></li><li><p><a href=\"https://medium.com/paratransit-pal/paratransit-pal-won-40-000-at-at-ts-atlanta-civic-coding-challenge-and-gave-it-all-to-charity-30bba157d92d\" rel=\"noopener noreferrer\" target=\"_blank\">Marta Hackathon</a></p></li><li><p><a href=\"https://brigade.codeforamerica.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Code for America Brigades</a></p></li><li><p><a href=\"http://peoplemakingprogress.org/\" rel=\"noopener noreferrer\" target=\"_blank\">People Making Progress</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0404-mark-episode.jpg",
+		"guests": [
+			{
+				"name": "Mark Noonan",
+				"bio": "<p>Mark is a senior engineer at Cypress.io and is a co-organizer at Code for Atlanta. He also works as a program developer for People Making Progress, an Atlanta-based nonprofit serving adults with developmental disabilities at home, work, and in the community.</p><ul><li><p><a href=\"https://twitter.com/marktnoonan\" rel=\"noopener noreferrer\" target=\"_blank\">@marktnoonan</a> on Twitter</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0404-mark.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Jennifer Konikowski - Hot Takes on Being a Woman in Tech",
+		"slug": "0403-jennifer-konikowski",
+		"id": "524",
+		"metaDescription": "Season Four, Episode Three of the Virtual Coffee Podcast",
+		"season": 4,
+		"episode": 3,
+		"buzzsproutId": "9396120",
+		"publishDate": "2021-10-19T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Jennifer Konikowski about building community for women in tech and her own experience as a woman in tech. She gives us some of her hot takes, and we are here for it 🔥</p>",
+		"showNotes": "<p>This week we welcome Jennifer Konikowski to the show to talk about being a woman in tech and building community for women in tech!</p><p class=\"text-left\">Jennifer brings her experience creating communities like <a href=\"http://www.meetup.com/pyladies-boston/\" rel=\"noopener noreferrer\" target=\"_blank\">Py Ladies Boston</a> and <a href=\"https://www.meetup.com/Boston-Ruby-Women/\" rel=\"noopener noreferrer\" target=\"_blank\">Boston Ruby Women</a> to the podcast, and talks about the value of learning to code even if you don't want to be a developer. She also talks about getting through toxic work environments, moving forward, and her hot takes on community and being a woman in tech.</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0403-jennifer-episode.jpg",
+		"guests": [
+			{
+				"name": "Jennifer Konikowski",
+				"bio": "<p>Jennifer has 10 years of experience as a software engineer, working in Ruby and Rails, Go, Swift, Scala, Rust, PHP, Javascript, Java, Perl, and Python. She was the founder and organizer of PyLadies Boston and a founding member of Boston Ruby Women. She currently resides in Pittsburgh and works remotely at Splice. She also really loves Negronis.</p><ul><li><p><a href=\"https://jenniferkonikowski.com/\" rel=\"noopener noreferrer\" target=\"_blank\">jenniferkonikowski.com</a></p></li><li><p><a href=\"https://twitter.com/jenkoni\" rel=\"noopener noreferrer\" target=\"_blank\">@jenkoni</a> on Twitter</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0403-jennifer.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Todd Libby - Making the web equal and accessible",
+		"slug": "0402-todd-libby",
+		"id": "517",
+		"metaDescription": "Season Four, Episode Two of the Virtual Coffee Podcast",
+		"season": 4,
+		"episode": 2,
+		"buzzsproutId": "9355176",
+		"publishDate": "2021-10-12T04:00:00+00:00",
+		"shortDescription": "<p>This week on the podcast, we have Todd Libby talking about his work making the web equal and accessible for everyone. He drops a ton of resources (check the show notes!) tips on how to get started, and talks about how he's continually learning on the job.</p>",
+		"showNotes": "<p>We're welcoming Todd Libby to give us an intro to accessibility and what it means to make the web equal. Todd, a professional web developer, designer, and accessibility advocate for 22 years, provides a plethora of resources that can help everyone to get started and talks about how to advocate for accessibility and equality on projects.</p><h3><strong>Show Notes:</strong></h3><h4 class=\"text-left\"><strong>Things/People mentioned in the episode:</strong></h4><ul><li><p><a href=\"https://www.smashingmagazine.com/2021/07/strong-case-for-accessibility/\" rel=\"noopener noreferrer\" target=\"_blank\">Making A Strong Case for Accessibility</a> by Todd Libby</p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Microsoft_FrontPage\" rel=\"noopener noreferrer\" target=\"_blank\">Front Page Express</a></p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Designing_with_Web_Standards\" rel=\"noopener noreferrer\" target=\"_blank\">Designing with Web Standards</a></p></li><li><p><a href=\"https://www.w3.org/WAI/standards-guidelines/wcag/\" rel=\"noopener noreferrer\" target=\"_blank\">Web Content Accessibility Guidelines (WCAG)</a></p></li><li><p><a href=\"https://twitter.com/cassandrafaris\" rel=\"noopener noreferrer\" target=\"_blank\">Cass Faris</a></p></li><li><p><a href=\"https://twitter.com/saltnburnem\" rel=\"noopener noreferrer\" target=\"_blank\">Chris DeMars</a></p></li></ul><h4 class=\"text-left\"><strong>A11y Learning Resources:</strong></h4><ul><li><p><a href=\"https://www.edx.org/course/web-accessibility-introduction\" rel=\"noopener noreferrer\" target=\"_blank\">Introduction to Web Accessibility</a> on edX</p></li><li><p><a href=\"https://webaim.org/\" rel=\"noopener noreferrer\" target=\"_blank\">WebAIM</a></p></li><li><p><a href=\"https://www.tpgi.com/\" rel=\"noopener noreferrer\" target=\"_blank\">TPGi</a></p></li></ul><h4 class=\"text-left\"><strong>Tools:</strong></h4><ul><li><p><a href=\"https://wave.webaim.org/extension/\" rel=\"noopener noreferrer\" target=\"_blank\">WAVE Web Accessibility Evaluation Tool</a></p></li><li><p><a href=\"https://www.deque.com/axe/\" rel=\"noopener noreferrer\" target=\"_blank\">axe accessibility toolkit</a></p></li><li><p><a href=\"https://pa11y.org/\" rel=\"noopener noreferrer\" target=\"_blank\">pa11y command line</a></p></li><li><p><a href=\"https://pauljadam.com/bookmarklets/tables.html\" rel=\"noopener noreferrer\" target=\"_blank\">Bookmarklets by Ian Loyyd and Paul J Adams</a></p></li><li><p><a href=\"https://github.com/microsoft/accessibility-insights-web\" rel=\"noopener noreferrer\" target=\"_blank\">Microsoft a11y insights</a></p></li><li><p><a href=\"https://developer.mozilla.org/en-US/docs/Tools/Accessibility_inspector\" rel=\"noopener noreferrer\" target=\"_blank\">Firefox a11y devtools</a></p></li><li><p><a href=\"https://developers.google.com/web/tools/lighthouse\" rel=\"noopener noreferrer\" target=\"_blank\">Lighthouse automated testing</a></p></li><li><p><a href=\"https://contrast-ratio.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Contrast Ratio tool by Lea Verou</a></p></li><li><p><a href=\"https://www.tpgi.com/color-contrast-checker/\" rel=\"noopener noreferrer\" target=\"_blank\">Colour Contrast Analyser</a></p></li></ul><h4 class=\"text-left\"><strong>Todd's steps for manual testing:</strong></h4><ol start=\"1\"><li><p>Mouse only</p></li><li><p>Keyboard only</p></li><li><p>Squint test</p></li><li><p><a href=\"https://www.afb.org/blindness-and-low-vision/using-technology/assistive-technology-products/screen-readers\" rel=\"noopener noreferrer\" target=\"_blank\">Screen readers</a></p></li><li><p><a href=\"https://webaim.org/articles/voiceover/\" rel=\"noopener noreferrer\" target=\"_blank\">Voice over in Safari</a></p></li><li><p><a href=\"https://www.nvaccess.org/\" rel=\"noopener noreferrer\" target=\"_blank\">NVDA</a> and <a href=\"https://www.freedomscientific.com/products/software/jaws/\" rel=\"noopener noreferrer\" target=\"_blank\">JAWS</a> on Windows</p></li><li><p><a href=\"https://help.gnome.org/users/orca/stable/introduction.html.en\" rel=\"noopener noreferrer\" target=\"_blank\">Orca</a> on Linux</p></li></ol>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0402-todd-episode.jpg",
+		"guests": [
+			{
+				"name": "Todd Libby",
+				"bio": "<p>Todd is a professional web developer, designer, and accessibility advocate for 22 years under many different technologies starting with HTML/CSS, Perl, and PHP, Todd has been an avid learner of web technologies for over 40 years starting with many flavors of BASIC all the way to React/Vue. Todd is also a member of the W3C working with groups on WCAG Silver (3.0). When not coding or advocating accessibility, you'll usually find Todd tweeting about (or eating) lobster rolls and accessibility.</p><ul><li><p><a href=\"https://toddl.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">toddl.dev</a></p></li><li><p><a href=\"https://twitter.com/toddlibby\" rel=\"noopener noreferrer\" target=\"_blank\">@toddlibby</a> on Twitter</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0402-todd.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Jessi Shakarian - You aren't your tech stack: sharing your passion",
+		"slug": "0401-jessi-shakarian",
+		"id": "510",
+		"metaDescription": "Season Four, Episode One of the Virtual Coffee Podcast",
+		"season": 4,
+		"episode": 1,
+		"buzzsproutId": "9322612",
+		"publishDate": "2021-10-06T04:00:00+00:00",
+		"shortDescription": "<p>In today's episode, Dan and Bekah talk to Jessi Shakarian about her journey into UX/UI and how that lead to the big energy she needed to find her place in tech.</p>",
+		"showNotes": "<p>We welcome Jessi Shakarian to the show today to talk about her journey into UX/UI!</p><p class=\"text-left\">Jessi talks about how passion can be your motivation, and how valuable it is to be able to share what you're excited about: you aren't your tech stack. Sometimes finding that passion can lead you to new and interesting places like Jessi's change in focus from web dev to design.</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0401-jessi-episode.png",
+		"guests": [
+			{
+				"name": "Jessi Shakarian",
+				"bio": "<p>Jessi Shakarian got her start in tech as a developer, but also she loved everything that happened before it was time to build a website. She is currently a UX designer at DIA Design Guild in Los Angeles and a python developer interested in machine learning.</p><ul><li><p><a href=\"https://www.jessishakarian.com/\" rel=\"noopener noreferrer\" target=\"_blank\">jessishakarian.com</a></p></li><li><p><a href=\"https://twitter.com/jessishakarian\" rel=\"noopener noreferrer\" target=\"_blank\">@jessishakarian</a> on Twitter</p></li><li><p><a href=\"https://www.polywork.com/jessishakarian\" rel=\"noopener noreferrer\" target=\"_blank\">jessishakarian</a> on PolyWork</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0401-jessi.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Season 3 Wrap Up: Hacktoberfest is Coming!",
+		"slug": "0309-season-three-wrap-up",
+		"id": "503",
+		"metaDescription": "Season Three, Episode Nine of the Virtual Coffee Podcast",
+		"season": 3,
+		"episode": 9,
+		"buzzsproutId": "9124000",
+		"publishDate": "2021-09-01T04:00:00+00:00",
+		"shortDescription": "<p>Community Maintainer Kirk joins us (again) for our Season 3 wrap up and Hacktoberfest preview!</p>",
+		"showNotes": "<p>Community Maintainer Kirk joins us (again) for our Season 3 wrap up! We review what Virtual Coffee did last year for Hacktoberfest, and talk about a lot of the exciting things we have coming up this year! We also shared some fun things from the last year at Virtual Coffee, like our Virtual Coffee Co-Working Room!</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p><a href=\"https://apps.apple.com/us/app/classic-sudoku/id1488838275\" rel=\"noopener noreferrer\" target=\"_blank\">Classic Sudoku</a></p></li><li><p><a href=\"https://www.youtube.com/channel/UCC-UOdK8-mIjxBQm_ot1T-Q\" rel=\"noopener noreferrer\" target=\"_blank\">Cracking the Cryptic</a></p></li><li><p><a href=\"https://twitter.com/MarieAntons\" rel=\"noopener noreferrer\" target=\"_blank\">@MarieAntons</a></p></li><li><p>Tatiana Mac - <a href=\"https://github.com/selfdefined\" rel=\"noopener noreferrer\" target=\"_blank\">selfdefined</a></p></li><li><p><a href=\"https://github.com/dominicduffin1/Quarto\" rel=\"noopener noreferrer\" target=\"_blank\">Quarto by Dominic Duffin</a></p></li><li><p><a href=\"https://github.com/BekahHW/postpartum-wellness-app\" rel=\"noopener noreferrer\" target=\"_blank\">Bekah's postpartum wellness app</a></p></li><li><p><a href=\"https://github.com/Virtual-Coffee/virtualcoffee.io\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee's GitHub Org</a></p></li><li><p><a href=\"https://hacktoberfest.digitalocean.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Hacktoberfest on Digital Ocean</a></p></li><li><p>shoutout to our Monthly Challenge team: Adam, Andrew, Aurelie, Chris, Courtney, Dominic, Kevin, Luis, Vanessa, and Yolanda!</p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0309-hacktoberfest.jpg",
+		"guests": [
+			{
+				"name": "Kirk Shillingford",
+				"bio": "<p>Software Developer, and Community Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://twitter.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0108-kirk.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Aurelie Verrot - Learning and Working Remotely",
+		"slug": "0308-aurelie-verrot",
+		"id": "494",
+		"metaDescription": "Season Three, Episode Eight of the Virtual Coffee Podcast",
+		"season": 3,
+		"episode": 8,
+		"buzzsproutId": "9080882",
+		"publishDate": "2021-08-24T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah are joined by Aurelie Verrot to talk about working through bootcamp during the pandemic, remote work, and how to \"just be cool\" when you're dealing with challenges like the pandemic, virtual school, and remote work.</p>",
+		"showNotes": "<p>In this episode, Dan and Bekah talk to Aurelie Verrot, a Software Engineer from the San Francisco Bay Area, who's originally from France, about the importance of relationships in team-building--whether as part of the learning process or in a work environment--and the benefits of being able to work from home. She talks about the importance of clear communication, creating boundaries, and maintaining flexibility as key habits to build.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Twitter: <a href=\"https://twitter.com/LiliVerrot\" rel=\"noopener noreferrer\" target=\"_blank\">LiliVerrot</a></p></li><li><p>GitHub: <a href=\"https://github.com/aurelieverrot\" rel=\"noopener noreferrer\" target=\"_blank\">aurelieverrot</a></p></li><li><p>LinkedIn: <a href=\"https://www.linkedin.com/in/aurelieverrot/\" rel=\"noopener noreferrer\" target=\"_blank\">aurelieverrot</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0308-aurelie-episode.jpg",
+		"guests": [
+			{
+				"name": "Aurelie Verrot",
+				"bio": "<p>Aurelie Verrot is a software engineer from the San Francisco Bay Area, originally from France. After moving to the US and taking care of her children for 4 years, she decided to make a career change in 2019 to work in tech. She started her first dev job in May as a Software Engineer working mostly with Ruby on Rails.</p><ul><li><p>Twitter: <a href=\"https://twitter.com/LiliVerrot\" rel=\"noopener noreferrer\" target=\"_blank\">LiliVerrot</a></p></li><li><p>GitHub: <a href=\"https://github.com/aurelieverrot\" rel=\"noopener noreferrer\" target=\"_blank\">aurelieverrot</a></p></li><li><p>LinkedIn: <a href=\"https://www.linkedin.com/in/aurelieverrot/\" rel=\"noopener noreferrer\" target=\"_blank\">aurelieverrot</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0308-aurelie.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Mike Rogers - Tend Your Career like a Garden",
+		"slug": "0307-mike-rogers",
+		"id": "486",
+		"metaDescription": "Season Three, Episode Seven of the Virtual Coffee Podcast",
+		"season": 3,
+		"episode": 7,
+		"buzzsproutId": "9044559",
+		"publishDate": "2021-08-17T04:00:00+00:00",
+		"shortDescription": "<p>In this episode, Dan and Bekah are joined by Mike Rogers, to talk about changing course as a dev, and tending careers like gardens.</p>",
+		"showNotes": "<p>In this episode, Dan and Bekah are joined by Mike Rogers. Mike has had a long and successful career, but at one point he realized he no longer felt good or satisfied with where he was as a developer. He shared with us what he did to change course, and how he has learned to approach tending his career almost like a garden.</p><h5 class=\"text-left\"><strong>Links to things mentioned in the episode:</strong></h5><ul><li><p>Mike's YouTube: <a href=\"https://www.youtube.com/c/MikeRogers0\" rel=\"noopener noreferrer\" target=\"_blank\">MikeRogers0</a></p></li><li><p><a href=\"http://www.slate.com/articles/technology/technology/2012/03/ruby_ruby_on_rails_and__why_the_disappearance_of_one_of_the_world_s_most_beloved_computer_programmers_.html\" rel=\"noopener noreferrer\" target=\"_blank\">Where’s _why?</a> - What happened when one of the world’s most unusual, and beloved, computer programmers disappeared.</p></li><li><p>Meditation Minis podcast: <a href=\"https://www.meditationminis.com/\" rel=\"noopener noreferrer\" target=\"_blank\">meditationminis.com</a></p></li><li><p>Mike's Business Times cover:</p></li><li><p></p><img src=\"https://optimise2.assets-servd.host/virtual-coffee/production/images/0307-mike-bt-cover.jpg?w=378&amp;auto=compress%2Cformat&amp;fit=crop&amp;dm=1648577051&amp;s=3b73d41bc861dfe62cff7d45baac177b\" alt=\"Mike&#039;s cover on the Business Times\" title=\"\"></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0307-mike-episode.jpg",
+		"guests": [
+			{
+				"name": "Mike Rogers",
+				"bio": "<p>Mike Rogers is a Ruby developer from the UK. He made the chat bots for Virtual Coffee, has an awesome Ruby Event Calendar, and loves Docker.</p><ul><li><p><a href=\"https://mikerogers.io/\" rel=\"noopener noreferrer\" target=\"_blank\">mikerogers.io</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/mikerogers0\" rel=\"noopener noreferrer\" target=\"_blank\">mikerogers0</a></p></li><li><p>GitHub: <a href=\"https://github.com/MikeRogers0\" rel=\"noopener noreferrer\" target=\"_blank\">MikeRogers0</a></p></li><li><p>YouTube: <a href=\"https://www.youtube.com/c/MikeRogers0\" rel=\"noopener noreferrer\" target=\"_blank\">MikeRogers0</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0307-mike.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Ray Deck - Rubber-Ducking your Life",
+		"slug": "0306-ray-deck",
+		"id": "479",
+		"metaDescription": "Season Three, Episode Six of the Virtual Coffee Podcast",
+		"season": 3,
+		"episode": 6,
+		"buzzsproutId": "9007249",
+		"publishDate": "2021-08-10T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk to Ray Deck about rubber ducking your career path, the importance of trust and relationships, and accepting that we're probably wrong more than we're right.</p>",
+		"showNotes": "<p>In this episode, Dan and Bekah talk to Ray Deck, a trained data scientist, occasional angel investor, and software entrepreneur, about finding the right career path through growth, learning, and motivation. We talk about the importance of trust and listening, and Ray drops a bunch of great resources to help everyone find their own path.</p><h5 class=\"text-left\"><strong>Favorite nonfiction books:</strong></h5><ul><li><p>Bekah's pick: <a href=\"https://allisonpataki.com/books/beauty-in-the-broken-places/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Beauty in the Broken Places</em></a><a href=\"https://allisonpataki.com/books/beauty-in-the-broken-places/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Allison Pataki</a></p></li><li><p>Bekah's second pick: <a href=\"https://drgabormate.com/book/scattered-minds/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Scattered Minds</em></a><a href=\"https://drgabormate.com/book/scattered-minds/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Dr. Gabor Maté</a></p></li><li><p>Dan's pick: <a href=\"https://www.hachettebooks.com/titles/lindy-west/shit-actually/9780316449847/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Shit, Actually</em></a><a href=\"https://www.hachettebooks.com/titles/lindy-west/shit-actually/9780316449847/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Lindy West</a></p></li><li><p>Ray's pick: <a href=\"https://www.edwardtufte.com/tufte/books_vdqi\" rel=\"noopener noreferrer\" target=\"_blank\"><em>The Visual Display of Quantitative Information</em></a><a href=\"https://www.edwardtufte.com/tufte/books_vdqi\" rel=\"noopener noreferrer\" target=\"_blank\"> by Edwarde Tufte</a></p></li></ul><h5 class=\"text-left\"><strong>Links to things mentioned in the episode:</strong></h5><ul><li><p><a href=\"https://simonsinek.com/product/start-with-why/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Start With Why</em></a><a href=\"https://simonsinek.com/product/start-with-why/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Simon Sinek</a></p></li><li><p><a href=\"https://www.franklincovey.com/the-7-habits/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>The 7 Habits of Highly Effective People</em></a><a href=\"https://www.franklincovey.com/the-7-habits/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Stephen R. Covey</a></p></li><li><p><a href=\"https://www.amazon.com/8th-Habit-Effectiveness-Greatness-Paperback/dp/B00GOHDKRI/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>The 8th Habit: From Effectiveness to Greatness</em></a><a href=\"https://www.amazon.com/8th-Habit-Effectiveness-Greatness-Paperback/dp/B00GOHDKRI/\" rel=\"noopener noreferrer\" target=\"_blank\"> by Stephen R. Covey</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0306-ray-episode.jpg",
+		"guests": [
+			{
+				"name": "Ray Deck",
+				"bio": "<p>Ray is a trained data scientist, occasional angel investor, and software entrepreneur. His 25-year career spans industries from law to finance. Most recently, Ray is the founder of Sustained Ventures, a software product studio where he also publishes essays on technology and markets.</p><p class=\"text-left\">Ray's thoughts can be followed at <a href=\"https://sustainedventures.com/essays\" rel=\"noopener noreferrer\" target=\"_blank\">sustainedventures.com/essays</a>, and his less-thoughtful self is on Twitter <a href=\"https://twitter.com/ray_deck\" rel=\"noopener noreferrer\" target=\"_blank\">@ray_deck</a>.</p><ul><li><p><a href=\"https://sustainedventures.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Sustained Ventures</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/ray_deck\" rel=\"noopener noreferrer\" target=\"_blank\">@ray_deck</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0306-ray.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Kevin Truong - Tech Career Coaching",
+		"slug": "0305-kevin-truong",
+		"id": "472",
+		"metaDescription": "Season Three, Episode Five of the Virtual Coffee Podcast",
+		"season": 3,
+		"episode": 5,
+		"buzzsproutId": "8967149",
+		"publishDate": "2021-08-03T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk to Kevin, a senior software consultant at Test Double and a coding career coach at his company Tap into Tech, about his approach to interviewing and how to navigate some of the biggest challenges early-career devs face when trying to break into the industry.</p>",
+		"showNotes": "<p>In this episode of the podcast, Dan and Bekah talk to Kevin, a senior software consultant at Test Double and a coding career coach at his company Tap into Tech, about some of the most common challenges early-career developers face getting into tech and offers practical advice for working through those problems. We dive into visualization, personal support, and ways to change the interview process in tech.</p><h5 class=\"text-left\"><strong>Links:</strong></h5><ul><li><p>Kevin's Twitter: <a href=\"https://twitter.com/TheKevinTruong\" rel=\"noopener noreferrer\" target=\"_blank\">@TheKevinTruong</a></p></li><li><p>Kevin's LinkedIn: <a href=\"https://www.linkedin.com/in/thekevintruong/\" rel=\"noopener noreferrer\" target=\"_blank\">thekevintruong</a></p></li><li><p><a href=\"https://tapintotech.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Tap into Tech</a></p></li><li><p><a href=\"https://testdouble.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Test Double</a></p></li><li><p><a href=\"http://thekevintruong.com/\" rel=\"noopener noreferrer\" target=\"_blank\">thekevintruong.com</a></p></li><li><p><a href=\"https://www.loom.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Loom</a></p></li><li><p><a href=\"https://twitter.com/terribledustin/status/1405903173684850695?s=19\" rel=\"noopener noreferrer\" target=\"_blank\">Dustin McCaffree Upwork/Loom Tweet</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0305-kevin-episode.jpg",
+		"guests": [
+			{
+				"name": "Kevin Truong",
+				"bio": "<p>Kevin Truong is a senior software consultant at Test Double and a coding career coach at his company Tap into Tech. Previously a coding boot camp instructor and mentor, Kevin realized that boot camps were missing a lot of information when it came to the final steps of getting hired. With his years of experience, he has developed a program where he has coached dozens of early career devs on how to improve their results on getting a tech job.</p><ul><li><p>Twitter: <a href=\"https://twitter.com/TheKevinTruong\" rel=\"noopener noreferrer\" target=\"_blank\">@TheKevinTruong</a></p></li><li><p>LinkedIn: <a href=\"https://www.linkedin.com/in/thekevintruong/\" rel=\"noopener noreferrer\" target=\"_blank\">thekevintruong</a></p></li><li><p><a href=\"https://tapintotech.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Tap into Tech</a></p></li><li><p><a href=\"http://thekevintruong.com/\" rel=\"noopener noreferrer\" target=\"_blank\">thekevintruong.com</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0305-kevin.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Joan Marie Verba - Keeping hope through decades of challenges",
+		"slug": "0304-joan-marie-verba",
+		"id": "465",
+		"metaDescription": "Season Three, Episode Four of the Virtual Coffee Podcast",
+		"season": 3,
+		"episode": 4,
+		"buzzsproutId": "8929061",
+		"publishDate": "2021-07-27T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk to Joan Marie Verba about her early days in tech using Fortran, and how refusal to accommodate her allergies has prevented her from having a lifelong career in tech. She talks about pushing forward and not taking no for an answer as she continues her decades-long journey into tech.</p>",
+		"showNotes": "<p>In this episode of the podcast, Dan and Bekah talk to Joan Marie Verba, a web developer, former astronomy teacher, and prolific science fiction writer, about her early days in tech using Fortran, and how refusal to accommodate her allergies has prevented her from having a lifelong career in tech. She shares the story of her recent job offer that actually turned out to be a scam that's being investigated by the FBI. But she's not done searching for her next place in tech. She's pushing past the challenges until she finds that next job.</p><h5 class=\"text-left\"><strong>Links:</strong></h5><ul><li><p><a href=\"https://www.ada.gov/\" rel=\"noopener noreferrer\" target=\"_blank\">Americans with Disabilities Act</a></p></li><li><p>Website: <a href=\"http://joanmarieverba.com/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.com</a></p></li><li><p>Blog: <a href=\"http://joanmarieverba.info/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.info</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/joanmarieverba\" rel=\"noopener noreferrer\" target=\"_blank\">@joanmarieverba</a></p></li><li><p>Web developer portfolio: <a href=\"http://joanmarieverba.co.technology/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.co.technology</a></p></li><li><p>Projects page: <a href=\"http://joanmarieverba.name/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.name</a></p></li><li><p>UX page: <a href=\"http://joanmarieverba.net/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.net</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0304-joan-episode.jpg",
+		"guests": [
+			{
+				"name": "Joan Marie Verba",
+				"bio": "<p>Joan Marie Verba earned a bachelor of physics degree from the University of Minnesota and attended the graduate school of astronomy at Indiana University, where she was an associate instructor of astronomy for one year. She has worked as a computer programmer and as an editor. She currently works as a writer, a publisher, and a web developer.</p><ul><li><p>Website: <a href=\"http://joanmarieverba.com/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.com</a></p></li><li><p>Blog: <a href=\"http://joanmarieverba.info/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.info</a></p></li><li><p>Twitter: <a href=\"https://twitter.com/joanmarieverba\" rel=\"noopener noreferrer\" target=\"_blank\">@joanmarieverba</a></p></li><li><p>Web developer portfolio: <a href=\"http://joanmarieverba.co.technology/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.co.technology</a></p></li><li><p>Projects page: <a href=\"http://joanmarieverba.name/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.name</a></p></li><li><p>UX page: <a href=\"http://joanmarieverba.net/\" rel=\"noopener noreferrer\" target=\"_blank\">joanmarieverba.net</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0304-joan.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Ayu Adiati - Working through burnout as a self-taught developer",
+		"slug": "0303-ayu-adiati",
+		"id": "458",
+		"metaDescription": "Season Three, Episode Three of the Virtual Coffee Podcast",
+		"season": 3,
+		"episode": 3,
+		"buzzsproutId": "8893503",
+		"publishDate": "2021-07-20T04:00:00+00:00",
+		"shortDescription": "<p>In this episode, Dan and Bekah talk to Ayu about the impact of community, being a prolific blogger, and the very real challenge of burnout.</p>",
+		"showNotes": "<p>In this episode, Dan and Bekah talk to Ayu about the impact of community, being a prolific blogger, and the very real challenge of burnout. Ayu's openness about the challenges of being a mom on the self-taught track into tech, isolation, and fears of not being good enough are the stories that we don't share enough of. Because when we share, we can all work through them together. Thank you, Ayu, for reminding us that it's ok to not be ok.</p><h4 class=\"text-left\"><strong>Links mentioned in the episode:</strong></h4><ul><li><p><a href=\"https://community.codenewbie.org/adiatiayu/lesson-learned-massive-burnout-in-learning-web-development-3b5g?signin=true\" rel=\"noopener noreferrer\" target=\"_blank\">Lesson Learned: Massive Burnout In Learning Web Development</a></p></li><li><p><a href=\"https://twitter.com/AdiatiAyu/status/1400833965293019138?s=19\" rel=\"noopener noreferrer\" target=\"_blank\">Ayu's twitter thread about struggling with learning to code</a></p></li><li><p><a href=\"https://www.freecodecamp.org/learn/responsive-web-design/\" rel=\"noopener noreferrer\" target=\"_blank\">Free Code Camp - web responsive design certification</a></p></li><li><p><a href=\"https://community.codenewbie.org/codenewbie/ayu-polyglot-latte-lover-codenewbie-149m\" rel=\"noopener noreferrer\" target=\"_blank\">Ayu's CodeNewbie Community Spotlight</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0303-ayu-episode.jpg",
+		"guests": [
+			{
+				"name": "Ayu Adiati",
+				"bio": "<p>Originally from Indonesia and now based in The Netherlands, Ayu Adiati is a self-taught Frontend Developer & Technical Blogger. She’s on her way to break into tech from being a stay-at-home-mom of now a 4 years old daughter.</p><p class=\"text-left\">When Ayu is not coding, you can find her with the DLSR camera on her hands, cuddling with her daughter, or enjoying her iced macchiato latte.</p><ul><li><p><a href=\"https://virtualcoffee.io/podcast/0303-ayu-adiati/@AdiatiAyu%20(https://twitter.com/AdiatiAyu)\" rel=\"noopener noreferrer\" target=\"_blank\">Twitter</a></p></li><li><p><a href=\"https://adiati.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Blog</a></p></li><li><p><a href=\"https://dev.to/adiatiayu\" rel=\"noopener noreferrer\" target=\"_blank\">DEV</a></p></li><li><p><a href=\"https://community.codenewbie.org/adiatiayu\" rel=\"noopener noreferrer\" target=\"_blank\">CodeNewbie</a></p></li><li><p><a href=\"https://hashnode.com/@ayuadiati\" rel=\"noopener noreferrer\" target=\"_blank\">Hashnode</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0303-ayu.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Abbey Perini - Finding Confidence and Opportunities",
+		"slug": "0302-abbey-perini",
+		"id": "451",
+		"metaDescription": "Season Three, Episode Two of the Virtual Coffee Podcast",
+		"season": 3,
+		"episode": 2,
+		"buzzsproutId": "8858957",
+		"publishDate": "2021-07-13T04:00:00+00:00",
+		"shortDescription": "<p>On this episode of the podcast, we talk to Abbey Perini, a full-stack web developer, about the importance of practice, building in public, and sending thank you notes when you're interviewing for your first tech job.</p>",
+		"showNotes": "<p>On this episode of the podcast, we talk to Abbey Perini, a full-stack web developer, about the impact building in public has had on her developer journey, what her experience as a recruiting admin taught her as she sent out 160 applications before landing her dev role, and how rehearsing before an interview can make a big impact.</p><h4 class=\"text-left\"><strong>Links mentioned in the episode:</strong></h4><ul><li><p>Github: <a href=\"https://github.com/abbeyperini\" rel=\"noopener noreferrer\" target=\"_blank\">https://github.com/abbeyperini</a></p></li><li><p><a href=\"https://www.indeed.com/career/salaries\" rel=\"noopener noreferrer\" target=\"_blank\">Indeed job rate checker</a></p></li><li><p>Abbey's posts mentioned:</p><ul><li><p><a href=\"https://dev.to/abbeyperini/css-animated-button-with-offset-border-1ibi\" rel=\"noopener noreferrer\" target=\"_blank\">CSS Animated Button with Offset Border</a></p></li><li><p><a href=\"https://javascript.plainenglish.io/react-redux-reload-a-page-when-a-user-makes-a-change-7661a3e1b8ed\" rel=\"noopener noreferrer\" target=\"_blank\">Sheba Counter: How To Reload a Page Whenever a User Makes a Change with React/Redux</a></p></li><li><p><a href=\"https://dev.to/abbeyperini/toggle-dark-mode-in-react-28c9\" rel=\"noopener noreferrer\" target=\"_blank\">Toggle Dark Mode in React</a></p></li><li><p><a href=\"https://dev.to/abbeyperini/knitting-as-programming-3e5\" rel=\"noopener noreferrer\" target=\"_blank\">Knitting as Programming</a></p></li><li><p><a href=\"https://dev.to/abbeyperini/practicing-confidence-for-the-job-search-38nj\" rel=\"noopener noreferrer\" target=\"_blank\">Practicing Confidence for the Job Search</a></p></li></ul></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0302-abbey-episode.jpg",
+		"guests": [
+			{
+				"name": "Abbey Perini",
+				"bio": "<p>Abbey Perini is many things - a metro Atlanta native, a person of many hobbies, and a full-stack web developer. Currently ramping up in her first development role, she loves blogging about stupid Discord bots, animated CSS buttons, and other fun and useful things about programming. You can find her work and ways to connect with her at <a href=\"https://abbeyperini.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">abbeyperini.dev</a>.</p><ul><li><p><a href=\"https://abbeyperini.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">abbeyperini.dev</a></p></li><li><p><a href=\"https://twitter.com/AbbeyPerini\" rel=\"noopener noreferrer\" target=\"_blank\">@AbbeyPerini</a> on Twitter</p></li><li><p><a href=\"https://github.com/abbeyperini\" rel=\"noopener noreferrer\" target=\"_blank\">@abbeyperini</a> on GitHub</p></li><li><p><a href=\"https://dev.to/abbeyperini\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/abbeyperini</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0302-abbey.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Jono Yeong - Digital Gardening and Tim Tams",
+		"slug": "0301-jono-yeong",
+		"id": "444",
+		"metaDescription": "Season Three, Episode One of the Virtual Coffee Podcast",
+		"season": 3,
+		"episode": 1,
+		"buzzsproutId": "8821435",
+		"publishDate": "2021-07-06T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast Bekah and Dan talk to Jono Yeong about digital gardening, learning Elixir, and how he brings learning new things to what he's doing with Rails. And for a bonus, he even walks us through how to do a proper Tim Tam slam.</p>",
+		"showNotes": "<p>In this episode of the podcast Bekah and Dan talk to Jono Yeong, a senior software engineer originally from Australia, but currently based in Seattle, USA, about how digital gardening leaves room for growth, allows you to develop what you enjoy, and is an investment in communication skills. We also talk about learning Elixir, the process he goes through as he's learning something new, and how he brings learning new things to what he's doing with Rails. Bonus: he even walks us through how to do a proper Tim Tam slam.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p><a href=\"https://www.jonathanyeong.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Jono's website</a></p></li><li><p><a href=\"https://www.descript.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Descript</a></p></li><li><p><a href=\"https://maggieappleton.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Maggie Appleton</a></p></li><li><p><a href=\"https://www.jonathanyeong.com/garden/using-github-and-notion-to-organise-side-projects\" rel=\"noopener noreferrer\" target=\"_blank\">Github and notion blogpost</a></p></li><li><p><a href=\"https://twitter.com/VicVijayakumar\" rel=\"noopener noreferrer\" target=\"_blank\">Vic Vijayakumar</a></p></li><li><p><a href=\"https://twitter.com/nickytonline\" rel=\"noopener noreferrer\" target=\"_blank\">NickyT</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=jhXJCqQBz04\" rel=\"noopener noreferrer\" target=\"_blank\">Building a social network for puppies</a></p></li><li><p><a href=\"https://www.youtube.com/watch?v=k8hEo4N8Nhs\" rel=\"noopener noreferrer\" target=\"_blank\">TimTams slams</a></p></li><li><p><a href=\"https://www.arnotts.com/products/tim-tam\" rel=\"noopener noreferrer\" target=\"_blank\">TimTams</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0301-jono-episode.jpg",
+		"guests": [
+			{
+				"name": "Jonathan Yeong",
+				"bio": "<p>Jonathan Yeong is a senior developer at Shopify. Being from Australia, he often goes by Jono. A Rubyist at heart, he blogs and produces videos about all things programming. He’s passionate about the human connections in technology. And believes that being part of a community, a mentor, and a teacher is one of the most rewarding things you can do.</p><ul><li><p><a href=\"https://twitter.com/JonoYeong\" rel=\"noopener noreferrer\" target=\"_blank\">Twitter</a></p></li><li><p><a href=\"https://www.jonathanyeong.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Website</a></p></li><li><p><a href=\"https://www.youtube.com/c/jonathanyeong\" rel=\"noopener noreferrer\" target=\"_blank\">YouTube</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0301-jono.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Season Two Wrap-Up: Code and Community",
+		"slug": "0209-season-two-wrapup",
+		"id": "427",
+		"metaDescription": "Season Two, Episode Nine of the Virtual Coffee Podcast",
+		"season": 2,
+		"episode": 9,
+		"buzzsproutId": "8625475",
+		"publishDate": "2021-06-01T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah wrap up season two by talking about what they've learned about community, supporting members, and trying to find the right tools to make it happen.</p>",
+		"showNotes": "<p>In this episode of the podcast, Dan and Bekah wrap up season two by talking about what they've learned about community building over the last year and some lessons they've learned along the way. They talk about Virtual Coffee's mission to support its members, and how Virtual Coffee's unique approach presents both challenges and opportunities when it comes to finding tools and guidance as the community grows.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p><a href=\"https://magnoliajs.com/\" rel=\"noopener noreferrer\" target=\"_blank\">MagnoliaJS</a></p></li><li><p><a href=\"https://www.radicalcandor.com/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Radical Candor</em></a> by Kim Scott</p></li><li><p><a href=\"https://twitter.com/kldickenson\" rel=\"noopener noreferrer\" target=\"_blank\">Karen Dickinson</a></p></li><li><p><a href=\"https://orbit.love/\" rel=\"noopener noreferrer\" target=\"_blank\">Orbit model</a></p></li><li><p><a href=\"https://twitter.com/MarieAntons\" rel=\"noopener noreferrer\" target=\"_blank\">Marie Antons</a></p></li><li><p><a href=\"https://twitter.com/ray_deck\" rel=\"noopener noreferrer\" target=\"_blank\">Ray Deck</a></p></li><li><p><a href=\"https://twitter.com/CerchieLucia\" rel=\"noopener noreferrer\" target=\"_blank\">Lucia Cerchie</a></p></li><li><p><a href=\"https://twitter.com/CerchieLucia/status/1397937325464723458\" rel=\"noopener noreferrer\" target=\"_blank\">Lucia's tweet about Hacktoberfest</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0209-season-2-wrapup.jpg",
+		"guests": [
+			{
+				"name": "Bekah Hawrot Weigel",
+				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dev.to/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/bekahhw</a></p></li><li><p><a href=\"https://twitter.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">@bekahhw</a> on Twitter</p></li><li><p><a href=\"https://www.instagram.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">bekahhw</a> on Instagram</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0209-bekah.jpg"
+			},
+			{
+				"name": "Dan Ott",
+				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dtott.com/\" rel=\"noopener noreferrer\" target=\"_blank\">dtott.com</a></p></li><li><p><a href=\"https://twitter.com/danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">@danieltott</a> on Twitter</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0209-dan.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Sara McCombs - Learning to leverage your past experience and embrace your whole self",
+		"slug": "0208-sara-mccombs",
+		"id": "420",
+		"metaDescription": "Season Two, Episode Eight of the Virtual Coffee Podcast",
+		"season": 2,
+		"episode": 8,
+		"buzzsproutId": "8584928",
+		"publishDate": "2021-05-25T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast we talk to Sara McCombs, a software engineer, team lead, and Community Maintainer at Virtual Coffee, about how to leverage your past experience, talk about transferable skills, and owning your wins as an early career developer.</p>",
+		"showNotes": "<p>In this episode of the podcast, Dan and Bekah talk with Sara McCombs. Sara is a software engineer and team lead at <a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a>, and also one of the original organizers, and a current Community Maintainer, at Virtual Coffee. Sara shared her thoughts on how to think and talk about transferable skills, leveraging past experience to differentiate yourself, and the importance of embracing that past experience as part of your journey and strengths. She also talked about the impact of career changes, promotions, and overcoming self-doubt.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Sara McCombs: <a href=\"https://twitter.com/dino_momma\" rel=\"noopener noreferrer\" target=\"_blank\">@dino_momma</a> on Twitter, <a href=\"https://dev.to/saramccombs/\" rel=\"noopener noreferrer\" target=\"_blank\">saramccombs</a> on DEV, <a href=\"https://github.com/saramccombs\" rel=\"noopener noreferrer\" target=\"_blank\">saramccombs</a> on GitHub</p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0208-sara-episode.jpg",
+		"guests": [
+			{
+				"name": "Sara McCombs",
+				"bio": "<p>Sara is a published former research director turned software engineer and team lead at <a href=\"https://www.aiera.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Aiera</a>, as well as a community engagement leader at <a href=\"https://www.projectalloy.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Project Alloy</a>. She is also one of the original organizers, and a current community maintainer, at <a href=\"https://virtualcoffee.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee</a>. Sara is passionate about diversity and inclusion, and has written frequently about her journey into tech. She has an M.Ag and a B.S.Ag from West Virginia University, and is a 2020 graduate of Flatiron School.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0208-sara.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Nerando Johnson - Keeping Momentum, Community, and Socialization as a Service",
+		"slug": "0207-nerando-johnson",
+		"id": "413",
+		"metaDescription": "Season Two, Episode Seven of the Virtual Coffee Podcast",
+		"season": 2,
+		"episode": 7,
+		"buzzsproutId": "8542053",
+		"publishDate": "2021-05-18T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast we talk to Nerando Johnson, a full stack developer, about running freeCodeCamp meetups in Atlanta, learning through hackathons, and how his next endeavor should be socialization as a service for tech events.</p>",
+		"showNotes": "<p>In this episode of the podcast, Dan and Bekah talk with Nerando Johnson, a full stack developer looking for his next job, about running freeCodeCamp meetups in Atlanta, learning through hackathons (including that one time his team won the hackathon and donated the $40,000 in winnings to charity) and how his next endeavor should be socialization as a service for tech events. We also talk about the importance of having a solid support system and we laugh...a lot.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Nerando Johnson: <a href=\"https://twitter.com/nerajno\" rel=\"noopener noreferrer\" target=\"_blank\">@nerajno</a> on Twitter, <a href=\"https://dev.to/nerajno/\" rel=\"noopener noreferrer\" target=\"_blank\">nerajno</a> on DEV, <a href=\"https://github.com/Nerajno\" rel=\"noopener noreferrer\" target=\"_blank\">Nerajno</a> on GitHub</p></li></ul><h5 class=\"text-left\"><strong>Mentioned in the Episode:</strong></h5><ul><li><p><a href=\"https://www.itsmarta.com/marta-hackathon.aspx\" rel=\"noopener noreferrer\" target=\"_blank\">MARTA Hackathon</a></p></li><li><p>freeCodeCamp Atlanta - <a href=\"https://www.facebook.com/groups/free.code.camp.atlanta/\" rel=\"noopener noreferrer\" target=\"_blank\">Facebook</a> - <a href=\"https://study-group-directory.freecodecamp.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Find your FCC Meetup</a>:</p></li><li><p>Reactadelphia - <a href=\"https://twitter.com/reactadelphia\" rel=\"noopener noreferrer\" target=\"_blank\">@reactadelphia</a></p></li><li><p><a href=\"https://connect.tech/\" rel=\"noopener noreferrer\" target=\"_blank\">Connect.Tech</a></p></li><li><p><a href=\"https://twitter.com/garyvee\" rel=\"noopener noreferrer\" target=\"_blank\">Gary Vee</a></p></li><li><p><a href=\"https://twitter.com/xirclebox\" rel=\"noopener noreferrer\" target=\"_blank\">Homer Gaines</a></p></li><li><p><a href=\"https://twitter.com/techieEliot\" rel=\"noopener noreferrer\" target=\"_blank\">Eliot Sanford</a></p></li><li><p><a href=\"https://twitter.com/DThompsonDev\" rel=\"noopener noreferrer\" target=\"_blank\">Danny Thompson</a></p></li><li><p><a href=\"https://twitter.com/Career_Karma\" rel=\"noopener noreferrer\" target=\"_blank\">Career Karma</a></p></li><li><p><a href=\"https://www.jim-butcher.com/books/Dresden\" rel=\"noopener noreferrer\" target=\"_blank\">Dresden Files</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/27213329-grit\" rel=\"noopener noreferrer\" target=\"_blank\">Grit: The Power of Passion and Perseverance</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0207-nerando-episode.jpg",
+		"guests": [
+			{
+				"name": "Nerando Johnson",
+				"bio": "<p>This is Nerando, he likes to use programming to solve problems, (Yup, he is a developer). Nerando has been a community organizer for <a href=\"https://www.facebook.com/groups/free.code.camp.atlanta/\" rel=\"noopener noreferrer\" target=\"_blank\">freeCodeCamp Atlanta</a> for over the last two years. He has been to a <a href=\"https://medium.com/paratransit-pal/paratransit-pal-won-40-000-at-at-ts-atlanta-civic-coding-challenge-and-gave-it-all-to-charity-30bba157d92d\" rel=\"noopener noreferrer\" target=\"_blank\">few hackathons</a> and is <a href=\"https://dev.to/nerajno\" rel=\"noopener noreferrer\" target=\"_blank\">an infrequent blogger</a>. When not coding, Nerando enjoys coding cooking, reading, the act of creating something from nothing and consuming the odd blog or podcast about the human mind (<a href=\"https://www.npr.org/programs/\" rel=\"noopener noreferrer\" target=\"_blank\">Hi, NPR</a>).</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0207-nerando.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Courtney Landau - On being quiet in a loud tech world",
+		"slug": "0206-courtney-landau",
+		"id": "406",
+		"metaDescription": "Season Two, Episode Six of the Virtual Coffee Podcast",
+		"season": 2,
+		"episode": 6,
+		"buzzsproutId": "8499055",
+		"publishDate": "2021-05-11T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, we talk to Courtney Landau about how the trend of constant self-marketing in tech has impacted her career, her experience as a developer, and what's it's been like to take on a variety of roles as a Virtual Coffee contributor.</p>",
+		"showNotes": "<p>In this episode of the podcast, we talk to Courtney Landau, a software engineer currently working at an early-stage startup in the Education Technology space. We talked about her experience with being quiet in tech with the constant push for self-marketing and how she learns new things. We also dive into her experience as a mentor, speaker, lightning talk team member, and the other roles she's played as part of Virtual Coffee.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Courtney Landau: <a href=\"https://twitter.com/sosuperc\" rel=\"noopener noreferrer\" target=\"_blank\">@sosuperc</a> on Twitter, <a href=\"http://www.celandau.com/\" rel=\"noopener noreferrer\" target=\"_blank\">celandau.com</a></p></li></ul><h5 class=\"text-left\"><strong>Mentioned in the Episode:</strong></h5><ul><li><p><a href=\"https://twitter.com/sosuperc/status/1372529647947288588?s=20\" rel=\"noopener noreferrer\" target=\"_blank\">Quiet & soft-spoken =/= inexperienced.</a></p></li><li><p>Courtney's Lightning Talk from 2021: <a href=\"https://www.youtube.com/watch?v=ghFNiCMy67M\" rel=\"noopener noreferrer\" target=\"_blank\">Breaking down coding problems in interviews</a></p></li><li><p><a href=\"https://chrome.google.com/webstore/detail/learnics-teacher-link/nhdacjmkhimeohpnahfmdmcknaneeffk\" rel=\"noopener noreferrer\" target=\"_blank\">Learnics Teacher Link Chrome Extension</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0206-courtney-episode.jpg",
+		"guests": [
+			{
+				"name": "Courtney Landau",
+				"bio": "<p>Courtney is a software engineer currently working at an early-stage startup in the Education Technology space. Previously in the medical imaging field, she’s been working in the industry since 2019 after obtaining her Master’s in Information Sciences. She works on full-stack web applications using primarily TypeScript and JavaScript, built on a cloud platform. For fun she likes to run, play board games with her family, and patronize local independent restaurants and breweries.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0206-courtney.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Tom Cudd - Psychological Safety and DevOps",
+		"slug": "0205-tom-cudd",
+		"id": "399",
+		"metaDescription": "Season Two, Episode Five of the Virtual Coffee Podcast",
+		"season": 2,
+		"episode": 5,
+		"buzzsproutId": "8456725",
+		"publishDate": "2021-05-04T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, we talk to Tom Cudd about his experiences with DevOps, the importance of building psychological safety in to your team building and workflows.</p>",
+		"showNotes": "<p>In this episode of the podcast, we talk to Tom Cudd, a systems architect and 20-year veteran in technology. We talked about his experiences with DevOps and how it has changed over the years, about psychological safety: what it means to Tom, and how important it is to build in to your team and workflows, and about the dangers of \"hero culture\" in the workplace.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Tom Cudd: <a href=\"https://twitter.com/tomcudd\" rel=\"noopener noreferrer\" target=\"_blank\">@tomcudd</a> on Twitter, <a href=\"https://tomcudd.com/\" rel=\"noopener noreferrer\" target=\"_blank\">tomcudd.com</a></p></li></ul><h5 class=\"text-left\"><strong>Mentioned in the Episode:</strong></h5><ul><li><p><a href=\"https://www.goodreads.com/book/show/17255186-the-phoenix-project\" rel=\"noopener noreferrer\" target=\"_blank\">The Phoenix Project</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/44333183-the-unicorn-project\" rel=\"noopener noreferrer\" target=\"_blank\">the Unicorn Project</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/18167218-lean-enterprise\" rel=\"noopener noreferrer\" target=\"_blank\">Lean Enterprise</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/35747076-accelerate\" rel=\"noopener noreferrer\" target=\"_blank\">Accelerate</a></p></li><li><p><a href=\"https://www.goodreads.com/book/show/29939161-radical-candor\" rel=\"noopener noreferrer\" target=\"_blank\">Radical Candor</a></p></li><li><p><a href=\"https://softwaresocial.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Software Social Podcast</a></p></li><li><p><a href=\"https://www.manager-tools.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Manager Tools</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0205-tomcudd-episode.jpg",
+		"guests": [
+			{
+				"name": "Tom Cudd",
+				"bio": "<p>Tom Cudd is a Systems Architect and a reformed Systems Administrator for an ad agency in the Kansas City area. He has been employed in technology for nearly 20 years, but has been using computers and the internet for most of his life. Tom is a huge fan of DevOps, lean processes, learning mindsets, and empathy with action. He also rabidly follows Husker football and the Chiefs.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0205-tomcudd.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Debra-Kaye Elliott: The Self-Taught Developer Journey",
+		"slug": "0204-debra-kaye",
+		"id": "391",
+		"metaDescription": "Season Two, Episode Four of the Virtual Coffee Podcast",
+		"season": 2,
+		"episode": 4,
+		"buzzsproutId": "8413543",
+		"publishDate": "2021-04-27T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, we talk to Debra-Kaye Elliott about what it's like to be on the self-taught developer journey, imposter syndrome, and some of the key things she's learned along the way.</p>",
+		"showNotes": "<p>In this episode of the podcast, we talk to Debra-Kaye Elliott, a self-taught frontend developer making her way through Frontend Masters Web Development Bootcamp, about what it's like to be on the self-taught developer journey, how she navigates imposter syndrome, and the lessons she's learned a long the way. She talks about the impact of being able to learn with support, choosing the resources that work best for you, and how blogging has been a part of her journey.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Debra-Kaye: <a href=\"https://twitter.com/debrakayelliott\" rel=\"noopener noreferrer\" target=\"_blank\">@debrakayelliott</a> on Twitter, <a href=\"https://www.linkedin.com/in/debrakayeelliott\" rel=\"noopener noreferrer\" target=\"_blank\">@debrakayeelliott</a> on LinkedIn, and <a href=\"https://dev.to/debrakayeelliott\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/debrakayeelliott</a>.</p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0204-debra-kaye-episode.jpg",
+		"guests": [
+			{
+				"name": "Debra-Kaye Elliott",
+				"bio": "<p>Debra-Kaye Elliott is a Front End Developer going through a bootcamp, who's adding community-learning to her learning process. She's a career changer from the administrative field and always wanted to be in tech.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0204-debra-kaye.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Glen McCallum: From IC to Engineering Manager, and the lessons learned along the way",
+		"slug": "0203-glen",
+		"id": "384",
+		"metaDescription": "Season Two, Episode Three of the Virtual Coffee Podcast",
+		"season": 2,
+		"episode": 3,
+		"buzzsproutId": "8370318",
+		"publishDate": "2021-04-20T04:00:00+00:00",
+		"shortDescription": "<p>In this episode, Dan and Bekah talk to Glen McCallum, a Software engineer and manager from Victoria, Canada, about his unexpected career journey, the hard decisions he's had to make, and using open-source software with his artificial pancreas.</p>",
+		"showNotes": "<p>In this episode, Dan and Bekah talk to Glen McCallum, a Software engineer from Victoria, Canada who manages a team of 8 engineers for the 2nd largest independent book distributor in the US, about his unexpected career journey, the hard decisions he's had to make, and using open-source software with his artificial pancreas. Glen also talks about his near-death experience in his first IT job and the decision to move from Independent Contributor to Management.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Glen: <a href=\"https://glenmccallum.com/\" rel=\"noopener noreferrer\" target=\"_blank\">glenmccallum.com</a>, <a href=\"https://twitter.com/glenmccallumcan\" rel=\"noopener noreferrer\" target=\"_blank\">@glenmccallumcan</a> on Twitter,</p></li><li><p>Glen's Lightning Talk: <a href=\"https://youtu.be/2hIBz5Ogi3o\" rel=\"noopener noreferrer\" target=\"_blank\">From independent contributor to engineering manager</a></p></li><li><p><a href=\"https://www.healthline.com/health/diabetesmine/innovation/we-are-not-waiting#About-the-#WeAreNotWaiting-Movement\" rel=\"noopener noreferrer\" target=\"_blank\">We are not waiting movement</a></p></li><li><p><a href=\"https://openaps.org/\" rel=\"noopener noreferrer\" target=\"_blank\">OpenAPS</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0203-glen-episode.jpg",
+		"guests": [
+			{
+				"name": "Glen McCallum",
+				"bio": "<p>Glen McCallum is a Software engineer from Victoria, Canada. For the past 7 years he's been doing backend development in C# and SQL. Earlier, he did projects in Java and Rails. He's always learning, currently exploring big data with hadoop, python, and spark. Day-to-day he manages a team of 8 engineers for the 2nd largest independent book distributor in the United States.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0203-glen.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Lucia Cerchie: Mom life and finding your confidence",
+		"slug": "0202-lucia",
+		"id": "377",
+		"metaDescription": "Season Two, Episode Two of the Virtual Coffee Podcast",
+		"season": 2,
+		"episode": 2,
+		"buzzsproutId": "8315337",
+		"publishDate": "2021-04-11T04:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah talk with Lucia Cercie, a Software Engineer, about the importance of having a growth-mindset, asking questions, and pair programming.</p>",
+		"showNotes": "<p>In this episode of the podcast, Dan and Bekah talk with Lucia Cercie, a Software Engineer at <a href=\"https://stepzen.com/\" rel=\"noopener noreferrer\" target=\"_blank\">StepZen</a>, mom, and Arizona transplant, about the importance of having a growth-mindset, asking questions, and pair programming. We also talk about the power of community and feeling comfortable asking questions and asking for help. When she's not coding, Lucia likes to make her baby laugh.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Lucia: <a href=\"https://luciacerchie.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">luciacerchie.dev</a>, <a href=\"https://twitter.com/CerchieLucia\" rel=\"noopener noreferrer\" target=\"_blank\">@CerchieLucia</a> on Twitter, <a href=\"https://dev.to/cerchie\" rel=\"noopener noreferrer\" target=\"_blank\">cerchi</a> on DEV</p></li><li><p><a href=\"https://stepzen.com/\" rel=\"noopener noreferrer\" target=\"_blank\">StepZen</a></p></li><li><p><a href=\"https://hbr.org/2016/01/what-having-a-growth-mindset-actually-means\" rel=\"noopener noreferrer\" target=\"_blank\"><em>What Having a “Growth Mindset” Actually Means</em></a><a href=\"https://hbr.org/2016/01/what-having-a-growth-mindset-actually-means\" rel=\"noopener noreferrer\" target=\"_blank\"> </a>by Carol Dweck</p></li><li><p><a href=\"https://martinfowler.com/articles/on-pair-programming.html\" rel=\"noopener noreferrer\" target=\"_blank\"><em>On Pair Programming</em></a> by Martin Fowler</p></li><li><p><a href=\"https://www.youtube.com/watch?v=u8qgehH3kEQ\" rel=\"noopener noreferrer\" target=\"_blank\">NCIS \"pair programming\"</a></p></li><li><p><a href=\"https://lindastone.net/2014/11/24/are-you-breathing-do-you-have-email-apnea/\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Are You Breathing? Do You Have Email Apnea?</em></a> by Linda Stone</p></li><li><p><a href=\"https://oisinmoran.com/quinetweet\" rel=\"noopener noreferrer\" target=\"_blank\"><em>How I Made a Self-Quoting Tweet</em></a><a href=\"https://oisinmoran.com/quinetweet\" rel=\"noopener noreferrer\" target=\"_blank\"> </a>by Oisín Moran</p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0202-lucia-episode.jpg",
+		"guests": [
+			{
+				"name": "Lucia Cerchie",
+				"bio": "<p>Lucia Cerchie is a software engineer from Phoenix, AZ. She spends a lot of time orbiting outside her comfort zone and when she's not coding, she likes to make her baby laugh.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0202-lucia.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Gant Laborde: Finding your Voice",
+		"slug": "0201-gant",
+		"id": "370",
+		"metaDescription": "Season Two, Episode One of the Virtual Coffee Podcast",
+		"season": 2,
+		"episode": 1,
+		"buzzsproutId": "8281596",
+		"publishDate": "2021-04-06T04:00:00+00:00",
+		"shortDescription": "<p>We're back! In this episode of the Virtual Coffee podcast, Dan and Bekah talk to Gant Laborde, an owner of Infinite Red, mentor, adjunct professor, published author, and award-winning speaker, about overcoming challenges, being authentic, and finding your voice.</p>",
+		"showNotes": "<p>In this episode of the Virtual Coffee podcast, Dan and Bekah talk to Gant Laborde, an owner of Infinite Red, mentor, adjunct professor, published author, and award-winning speaker, about overcoming challenges, being authentic, and finding your voice. They share some of the struggles they've faced, talk about how practice can lead to growth, and the importance of recognizing your body's signals in the process.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Gant: <a href=\"https://gantlaborde.com/\" rel=\"noopener noreferrer\" target=\"_blank\">gantlaborde.com</a>, <a href=\"https://twitter.com/GantLaborde\" rel=\"noopener noreferrer\" target=\"_blank\">@GantLaborde</a></p></li><li><p>Some blog posts about public speaking by Gant:</p><ul><li><p><a href=\"https://gantlaborde.medium.com/open-your-speech-and-make-it-marvelous-e031cfa18858\" rel=\"noopener noreferrer\" target=\"_blank\">Open your speech, and make it marvelous</a></p></li><li><p><a href=\"https://medium.com/hackernoon/5-conference-speaking-tips-from-tech-gurus-2f7d1a250af3\" rel=\"noopener noreferrer\" target=\"_blank\">5 Conference Speaking Tips from Tech Gurus</a></p></li><li><p><a href=\"https://shift.infinite.red/the-road-to-distinguished-c9e458da091c\" rel=\"noopener noreferrer\" target=\"_blank\">The Road to Distinguished: From Afraid to Awarded — The path to public speaking success</a></p></li></ul></li><li><p><a href=\"https://cryptozombies.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Cryptozombies</a></p></li><li><p><a href=\"https://geddski.teachable.com/p/flexbox-zombies\" rel=\"noopener noreferrer\" target=\"_blank\">Flexbox zombies</a></p></li><li><p><a href=\"https://infinite.red/\" rel=\"noopener noreferrer\" target=\"_blank\">Infinite Red</a></p></li><li><p><a href=\"https://www.toastmasters.org/\" rel=\"noopener noreferrer\" target=\"_blank\">Toastmasters</a></p></li><li><p><a href=\"https://www.amazon.com/gp/product/1492090794/ref=as_li_qf_asin_il_tl?ie=UTF8&amp;tag=gant0d-20&amp;creative=9325&amp;linkCode=as2&amp;creativeASIN=1492090794&amp;linkId=9b7b356b7b13efdaf9d34bfa47f7a6ee\" rel=\"noopener noreferrer\" target=\"_blank\">Learning TensorFlow.js: Powerful Machine Learning in JavaScript by Gant Laborde</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0201-gant-episode.jpg",
+		"guests": [
+			{
+				"name": "Gant Laborde",
+				"bio": "<p>Gant Laborde is an owner of Infinite Red, mentor, adjunct professor, published author, and award-winning speaker. For 20 years, he has been involved in software development and continues strong today. He is recognized as a Google Developer Expert in Web and Machine Learning, but informally he is an “open sourcerer” and aspires to one day become a mad scientist. He blogs, videos, and maintains popular repositories for the community. Follow Gant’s adventures at <a href=\"https://gantlaborde.com/\" rel=\"noopener noreferrer\" target=\"_blank\">gantlaborde.com</a>.</p>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0201-gant.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Dan and Bekah: Season One Wrap-Up",
+		"slug": "0109-bekah-dan",
+		"id": "353",
+		"metaDescription": "Season One, Episode Nine of the Virtual Coffee Podcast",
+		"season": 1,
+		"episode": 9,
+		"buzzsproutId": "8096247",
+		"publishDate": "2021-03-07T05:00:00+00:00",
+		"shortDescription": "<p>In this episode of the podcast, Dan and Bekah switch things up. Since it's last episode of season one, they share a bit about their origin stories, when their paths connected, and how that led to where Virtual Coffee is today.</p>",
+		"showNotes": "<p>In this episode of the podcast, Dan and Bekah switch things up. Since it's last episode of season one, they share a bit about their origin stories, when their paths connected, and how that led to where Virtual Coffee is today. They talk about the challenges of the last year, how Virtual Coffee has been a light during dark times, and how growing can be painful, but also the process that allows you to become more than you could've imagined. And they also drop some of their favorite Virtual Coffee moments of the last year.</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0109-bekahdan-episode.jpg",
+		"guests": [
+			{
+				"name": "Bekah Hawrot Weigel",
+				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dev.to/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/bekahhw</a></p></li><li><p><a href=\"https://twitter.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">@bekahhw</a> on Twitter</p></li><li><p><a href=\"https://www.instagram.com/bekahhw\" rel=\"noopener noreferrer\" target=\"_blank\">bekahhw</a> on Instagram</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0109-bekah.jpg"
+			},
+			{
+				"name": "Dan Ott",
+				"bio": "<p>Front-end developer, and Org Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://dtott.com/\" rel=\"noopener noreferrer\" target=\"_blank\">dtott.com</a></p></li><li><p><a href=\"https://twitter.com/danieltott\" rel=\"noopener noreferrer\" target=\"_blank\">@danieltott</a> on Twitter</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0109-dan.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Kirk Shillingford: On Making Mistakes, Growth, and the Importance of Community",
+		"slug": "0108-kirk",
+		"id": "344",
+		"metaDescription": "Season One, Episode Eight of the Virtual Coffee Podcast",
+		"season": 1,
+		"episode": 8,
+		"buzzsproutId": "8052553",
+		"publishDate": "2021-03-01T05:00:00+00:00",
+		"shortDescription": "<p>In this episode, Dan and Bekah talk to Kirk Shillingford, a software developer (and Community Maintainer at Virtual Coffee), about the importance of making mistakes and the growth that comes with it.</p>",
+		"showNotes": "<p>In this episode, Dan and Bekah talk to Kirk Shillingford, a software developer (and Community Maintainer at Virtual Coffee), who has been \"haphazardly writing code for about seven years,\" about the importance of making mistakes and the growth that comes with it. We also talk about empathy being a key indicator of a senior developer and the importance of having a supportive community.</p><h5 class=\"text-left\"><strong>Links:</strong></h5><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://twitter.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li><li><p><a href=\"https://en.wikipedia.org/wiki/Neverwinter_Nights\" rel=\"noopener noreferrer\" target=\"_blank\">Never Winter Nights</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0108-kirk-episode.jpg",
+		"guests": [
+			{
+				"name": "Kirk Shillingford",
+				"bio": "<p>Software Developer, and Community Maintainer at Virtual Coffee.</p><ul><li><p><a href=\"https://twitter.com/KirkCodes\" rel=\"noopener noreferrer\" target=\"_blank\">@KirkCodes</a> on Twitter</p></li><li><p><a href=\"https://twitter.com/tkshill\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshill</a> on GitHub</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0108-kirk.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Colleen Schnettler -- Tech: It's hard, but it's worth it",
+		"slug": "0107-colleen",
+		"id": "337",
+		"metaDescription": "Season One, Episode Seven of the Virtual Coffee Podcast",
+		"season": 1,
+		"episode": 7,
+		"buzzsproutId": "8007425",
+		"publishDate": "2021-02-22T05:00:00+00:00",
+		"shortDescription": "<p>In this episode, Bekah and Dan are joined by Colleen Schnettler to talk about the challenges women face in the workplace, the benefits of working for yourself, and growing her SaaS business.</p>",
+		"showNotes": "<p>In this episode, we talk to Colleen Schnettler about the challenges of being a woman in the workplace, the benefits of working for yourself, and building her own SaaS business. Colleen is a Ruby on Rails consultant, who recently launched her <a href=\"https://www.simplefileupload.com/\" rel=\"noopener noreferrer\" target=\"_blank\">first product</a>, a career changer, and a mom. Colleen talks about how difficult it is to learn to code; it will take time and commitment, but when you get there, it will all be worth it.</p><h5 class=\"text-left\"><strong>Colleen:</strong></h5><ul><li><p><a href=\"https://twitter.com/leenyburger\" rel=\"noopener noreferrer\" target=\"_blank\">@leenyburger</a> on Twitter</p></li><li><p><a href=\"http://www.bitmappeddesigns.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Bitmapped Designs</a></p></li><li><p><a href=\"https://www.simplefileupload.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Simple File Upload</a></p></li><li><p><a href=\"https://twitter.com/softwaresocpod\" rel=\"noopener noreferrer\" target=\"_blank\">@softwaresocpod</a> - Software Social Podcast</p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0107-colleen-episode.jpg",
+		"guests": [
+			{
+				"name": "Colleen Schnettler",
+				"bio": "<p>Ruby on Rails consultant at <a href=\"http://www.bitmappeddesigns.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Bitmapped Designs</a>.</p><ul><li><p><a href=\"https://twitter.com/leenyburger\" rel=\"noopener noreferrer\" target=\"_blank\">@leenyburger</a> on Twitter</p></li><li><p><a href=\"http://www.bitmappeddesigns.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Bitmapped Designs</a></p></li><li><p><a href=\"https://www.simplefileupload.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Simple File Upload</a></p></li><li><p><a href=\"https://twitter.com/softwaresocpod\" rel=\"noopener noreferrer\" target=\"_blank\">@softwaresocpod</a> - Software Social Podcast</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0107-colleen.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Drew Clements: Building a career and community",
+		"slug": "0106-drew",
+		"id": "329",
+		"metaDescription": "Season One, Episode Six of the Virtual Coffee Podcast",
+		"season": 1,
+		"episode": 6,
+		"buzzsproutId": "7867681",
+		"publishDate": "2021-02-15T05:00:00+00:00",
+		"shortDescription": "<p>In this episode, Bekah and Dan are joined by Drew Clements to talk about the struggles of junior-level job searching, the importance of supportive company culture, and learning in public while building <a href=\"https://protege.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Protege.dev</a>.</p>",
+		"showNotes": "<p>In this episode, we talk to Drew Clements about the challenges junior developers face, learning through building Protege.dev, and the importance of community support. Drew is a career transitioner, father of two, and full-time developer who spends his spare time building Protege.dev, the platform curated with remote jobs for junior developers. We also talk about approaches to problem-solving, when to ask questions, and using live-streaming as an accountability tool.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><h5 class=\"text-left\"><strong>Drew:</strong></h5><ul><li><p><a href=\"https://twitter.com/drewclemcr8\" rel=\"noopener noreferrer\" target=\"_blank\">@drewclemcr8</a> on Twitter</p></li><li><p><a href=\"https://protege.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Protege.dev</a></p></li><li><p><a href=\"https://github.com/drewclem/\" rel=\"noopener noreferrer\" target=\"_blank\">drewclem</a> on GitHub</p></li><li><p><a href=\"https://dev.to/drewclem/\" rel=\"noopener noreferrer\" target=\"_blank\">drewclem</a> on DEV</p></li></ul><h5 class=\"text-left\"><strong>Stu the Rubber Duck!</strong></h5><p class=\"text-left\"></p><img src=\"http://storage.googleapis.com/virtualcoffeeio-assets/images/_podcastShowNotesImage/0106-drew-duck.jpg\" alt=\"Drew holding Stu the Rubber Duck!\" title=\"\">",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0106-drew-episode.jpg",
+		"guests": [
+			{
+				"name": "Drew Clements",
+				"bio": "<p>Frontend Engineer at <a href=\"https://www.fostercommerce.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Foster Commerce</a>, co-founder of <a href=\"https://protege.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Protege.dev</a></p><ul><li><p><a href=\"https://twitter.com/drewclemcr8\" rel=\"noopener noreferrer\" target=\"_blank\">@drewclemcr8</a> on Twitter</p></li><li><p><a href=\"https://protege.dev/\" rel=\"noopener noreferrer\" target=\"_blank\">Protege.dev</a></p></li><li><p><a href=\"https://github.com/drewclem/\" rel=\"noopener noreferrer\" target=\"_blank\">drewclem</a> on GitHub</p></li><li><p><a href=\"https://dev.to/drewclem/\" rel=\"noopener noreferrer\" target=\"_blank\">drewclem</a> on DEV</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0106-drew.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Cameron Bardell and Rahat Chowdhury: Mental Health & Tech",
+		"slug": "0105-cameron-rahat",
+		"id": "312",
+		"metaDescription": "Season One, Episode Five of the Virtual Coffee Podcast",
+		"season": 1,
+		"episode": 5,
+		"buzzsproutId": "7741411",
+		"publishDate": "2021-02-08T05:00:00+00:00",
+		"shortDescription": "<p>In this episode, Bekah and Dan talk about mental health with Cameron Bardell, an iOS developer in the healthcare industry, and Rahat Chowdhury, a mental health start-up founder.</p>",
+		"showNotes": "<p>In this episode, Bekah and Dan talk about mental health with Cameron Bardell, an iOS developer in the healthcare industry, and Rahat Chowdhury, a mental health start-up founder. We talk about how sometimes building a product to meet our own needs is a great place to start and the importance of prioritizing mental health, especially in a fast-paced industry like tech. We walk through our own experiences, how mental health recovery isn't linear, and how different approaches to mental health technology create support for more people.</p><p class=\"text-left\">If you or someone else is suffering from mental health issues, you aren't alone. Below are some links to help you find resources or to seek help:</p><ul><li><p><a href=\"https://suicidepreventionlifeline.org/\" rel=\"noopener noreferrer\" target=\"_blank\">National Suicide Prevention Lifeline</a> - 1-800-273-8255</p></li><li><p><a href=\"https://www.samhsa.gov/find-help/national-helpline\" rel=\"noopener noreferrer\" target=\"_blank\">SAMHSA’s National Helpline</a> - 1-800-662-HELP (4357)</p></li><li><p><a href=\"https://cmha.ca/\" rel=\"noopener noreferrer\" target=\"_blank\">CMHA National</a></p></li></ul><h4 class=\"text-left\"><strong>Links:</strong></h4><h5 class=\"text-left\"><strong>Cameron:</strong></h5><ul><li><p><a href=\"https://cambardell.github.io/\" rel=\"noopener noreferrer\" target=\"_blank\">cambardell.github.io</a></p></li><li><p><a href=\"https://twitter.com/cameronbardell\" rel=\"noopener noreferrer\" target=\"_blank\">@cameronbardell</a> on Twitter</p></li></ul><h5 class=\"text-left\"><strong>Rahat:</strong></h5><ul><li><p><a href=\"https://www.rahatcodes.com/\" rel=\"noopener noreferrer\" target=\"_blank\">rahatcodes.com</a></p></li><li><p><a href=\"https://twitter.com/Rahatcodes\" rel=\"noopener noreferrer\" target=\"_blank\">@Rahatcodes</a> on Twitter</p></li><li><p><a href=\"https://whimser.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Whimser</a></p></li><li><p>Open source mental health resources database: <a href=\"https://www.sylarproject.com/\" rel=\"noopener noreferrer\" target=\"_blank\">The Sylar Project</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0105-camrahat-episode.jpg",
+		"guests": [
+			{
+				"name": "Cameron Bardell",
+				"bio": "<p>iOS developer in the healthcare industry</p><ul><li><p><a href=\"https://cambardell.github.io/\" rel=\"noopener noreferrer\" target=\"_blank\">cambardell.github.io</a></p></li><li><p><a href=\"https://twitter.com/cameronbardell\" rel=\"noopener noreferrer\" target=\"_blank\">@cameronbardell</a> on Twitter</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0105-cameron.jpg"
+			},
+			{
+				"name": "Rahat Chowdhury",
+				"bio": "<p>Mental health start-up founder</p><ul><li><p><a href=\"https://www.rahatcodes.com/\" rel=\"noopener noreferrer\" target=\"_blank\">rahatcodes.com</a></p></li><li><p><a href=\"https://twitter.com/Rahatcodes\" rel=\"noopener noreferrer\" target=\"_blank\">@Rahatcodes</a> on Twitter</p></li><li><p><a href=\"https://whimser.io/\" rel=\"noopener noreferrer\" target=\"_blank\">Whimser</a></p></li><li><p><a href=\"https://www.sylarproject.com/\" rel=\"noopener noreferrer\" target=\"_blank\">The Sylar Project</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0105-rahat.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Vic Vijayakumar: Indie Hacking",
+		"slug": "0104-vic-vijayakumar",
+		"id": "305",
+		"metaDescription": "Season One, Episode Four of the Virtual Coffee Podcast",
+		"season": 1,
+		"episode": 4,
+		"buzzsproutId": "7564483",
+		"publishDate": "2021-02-01T05:00:00+00:00",
+		"shortDescription": "<p>In this episode, Vic talks about Indie Hacking and gives us his take on when to ship, what to focus on, and the value of diverse opinions in your community.</p>",
+		"showNotes": "<p>In this episode, Vic talks about Indie Hacking and gives us his take on when to ship, what to focus on, and the value of diverse opinions in your community. He also talks about treating life as a lot of drafts and about building things that you're passionate about as well as things that others find valuable. He cautions against the danger of survivorship bias, recognizing that it's difficult to find a path in indie hacking and that many of the popular voices have worked through challenges and no longer effectively represent how difficult it is to create a product that's successful.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><h5 class=\"text-left\"><strong>Vic:</strong></h5><ul><li><p><a href=\"https://vicvijayakumar.com/\" rel=\"noopener noreferrer\" target=\"_blank\">vicvijayakumar.com</a></p></li><li><p><a href=\"https://twitter.com/vicvijayakumar\" rel=\"noopener noreferrer\" target=\"_blank\">@vicvijayakumar</a> on Twitter</p></li></ul><h5 class=\"text-left\"><strong>Vic's Projects:</strong></h5><ul><li><p><a href=\"https://www.everyoak.com/\" rel=\"noopener noreferrer\" target=\"_blank\">EveryOak</a></p></li><li><p><a href=\"https://meetsweats.com/\" rel=\"noopener noreferrer\" target=\"_blank\">MeetSweats.com</a></p></li><li><p><a href=\"https://dogears.xyz/\" rel=\"noopener noreferrer\" target=\"_blank\">Dog Ears</a></p></li></ul><h5 class=\"text-left\"><strong>Low-Code Tools:</strong></h5><ul><li><p><a href=\"https://carrd.co/\" rel=\"noopener noreferrer\" target=\"_blank\">Carrd</a></p></li><li><p><a href=\"https://zapier.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Zapier</a></p></li><li><p><a href=\"https://airtable.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Airtable</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0104-vic-episode.jpg",
+		"guests": [
+			{
+				"name": "Vic Vijayakumar",
+				"bio": "<p>Principal software engineer at <a href=\"https://www.researchsquare.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Research Square</a>, a preprint platform</p><ul><li><p><a href=\"https://vicvijayakumar.com/\" rel=\"noopener noreferrer\" target=\"_blank\">vicvijayakumar.com</a></p></li><li><p><a href=\"https://twitter.com/vicvijayakumar\" rel=\"noopener noreferrer\" target=\"_blank\">@vicvijayakumar</a> on Twitter</p></li><li><p><a href=\"https://www.everyoak.com/\" rel=\"noopener noreferrer\" target=\"_blank\">EveryOak</a></p></li><li><p><a href=\"https://meetsweats.com/\" rel=\"noopener noreferrer\" target=\"_blank\">MeetSweats.com</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0104-vic.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Tori Crawford: Interviewing — If it's broke, fix it",
+		"slug": "0103-tori-crawford",
+		"id": "298",
+		"metaDescription": "Season One, Episode Three of the Virtual Coffee Podcast",
+		"season": 1,
+		"episode": 3,
+		"buzzsproutId": "7474594",
+		"publishDate": "2021-01-25T05:00:00+00:00",
+		"shortDescription": "<p>In this episode, Dan and Bekah welcome Tori Crawford to talk about her journey through the interview process that included about 53 interviews, 430 applications, and a pandemic offer that ultimately led to her being ghosted by the company.</p>",
+		"showNotes": "<p>In this episode, Dan and Bekah welcome Tori to talk about her journey through the interview process that included about 53 interviews, 430 applications, and a pandemic offer that ultimately led to her being ghosted by the company. She gives her tips and tricks, including recognizing that interviews are a two-way street; you should also be interviewing the companies that are interviewing you. She talks about the problems of technical interviewing, how she's hopeful that the industry can make changes, and how the job she ultimately landed has been a great experience, starting with the interview.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Tori: <a href=\"https://dev.to/torianne02\" rel=\"noopener noreferrer\" target=\"_blank\">DEV</a>, <a href=\"https://twitter.com/_torrborr\" rel=\"noopener noreferrer\" target=\"_blank\">Twitter</a></p></li><li><p>Article Tori wrote detailing her interview journey: <a href=\"https://dev.to/torianne02/444-days-later-tori-hit-the-jackpot-3o4p\" rel=\"noopener noreferrer\" target=\"_blank\">444 Days Later, Tori Hit the Jackpot</a></p></li><li><p>Udemy course mentioned: <a href=\"https://www.udemy.com/course/master-the-coding-interview-data-structures-algorithms/\" rel=\"noopener noreferrer\" target=\"_blank\">Master the Coding Interview: Data Structures + Algorithms</a></p></li><li><p><a href=\"https://flatironschool.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Flatiron School</a></p></li><li><p><a href=\"https://firehydrant.io/\" rel=\"noopener noreferrer\" target=\"_blank\">FireHydrant</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0103-tori-episode.jpg",
+		"guests": [
+			{
+				"name": "Tori Crawford",
+				"bio": "<p>Software Engineer at <a href=\"https://firehydrant.io/\" rel=\"noopener noreferrer\" target=\"_blank\">FireHydrant</a>.</p><ul><li><p><a href=\"https://twitter.com/_torrborr\" rel=\"noopener noreferrer\" target=\"_blank\">@_torrborr</a> on Twitter</p></li><li><p><a href=\"https://dev.to/torianne02\" rel=\"noopener noreferrer\" target=\"_blank\">torianne02</a> on DEV</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0103-tori.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Marie Antons: From Chef to Tech",
+		"slug": "0102-marieantons",
+		"id": "291",
+		"metaDescription": "Season One, Episode Two of the Virtual Coffee Podcast",
+		"season": 1,
+		"episode": 2,
+		"buzzsproutId": "7323430",
+		"publishDate": "2021-01-18T05:00:00+00:00",
+		"shortDescription": "<p>In this episode, Marie Antons talks with Dan, Bekah, and Kirk about how she went from being a chef to a junior developer.</p>",
+		"showNotes": "<p>In this episode, Marie Antons talks with Dan, Bekah, and Kirk about how she went from being a chef to a junior developer. With more and more developers coming into tech from non-traditional backgrounds, Marie shares her own unique story and how taking her past experience as a chef allowed her to understand coding in her own way. There are ingredients and steps to follow with recipes, and similarly, as you learn to code, you'll find what you need to get your code to work and the process you need to take to get there. She also talks about the challenges of coming into her first job from a bootcamp, and what she wishes she would've known before starting that job.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p><a href=\"https://www.deltavcodeschool.com/\" rel=\"noopener noreferrer\" target=\"_blank\">DeltaV Code School</a></p></li><li><p><a href=\"https://stratafolio.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Stratafolio</a></p></li><li><p><a href=\"https://d3js.org/\" rel=\"noopener noreferrer\" target=\"_blank\">D3 javascript library</a></p></li><li><p><a href=\"https://wattenberger.com/blog/css-percents\" rel=\"noopener noreferrer\" target=\"_blank\">Amy Wattenberger</a> (the blogger Dan couldn't remember!)</p></li><li><p><a href=\"https://twitter.com/MarieAntons\" rel=\"noopener noreferrer\" target=\"_blank\">@MarieAntons</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/marie\" rel=\"noopener noreferrer\" target=\"_blank\">Marie Antons</a> on LinkedIn</p></li><li><p>Kirk: <a href=\"https://twitter.com/tkshillinz\" rel=\"noopener noreferrer\" target=\"_blank\">@tkshillinz</a> on Twitter</p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0102-marie-episode.jpg",
+		"guests": [
+			{
+				"name": "Marie Antons",
+				"bio": "<p>Marie is a C#/.NET developer working for a small start-up called Stratafolio.</p><ul><li><p><a href=\"https://twitter.com/MarieAntons\" rel=\"noopener noreferrer\" target=\"_blank\">@MarieAntons</a> on Twitter</p></li><li><p><a href=\"https://www.linkedin.com/in/marie\" rel=\"noopener noreferrer\" target=\"_blank\">Marie Antons</a> on LinkedIn</p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0102-marie.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Nick Taylor: Open Source, Live Streaming, and Structured YOLO",
+		"slug": "0101-nickyt",
+		"id": "284",
+		"metaDescription": "Season One, Episode One of the Virtual Coffee Podcast",
+		"season": 1,
+		"episode": 1,
+		"buzzsproutId": "7238548",
+		"publishDate": "2021-01-11T05:00:00+00:00",
+		"shortDescription": "<p>Dan and Bekah welcome Nick Taylor (Senior Software Engineer at Forem/DEV) to talk about his journey into tech, open source, and the importance of community</p>",
+		"showNotes": "<p>Dan and Bekah welcome Nick Taylor (Senior Software Engineer at Forem/DEV) to talk about his journey into tech, open source, and the importance of community. Nick talks about his journey through University and into tech, how the landscape of tech has changed with increased resources and community, and how his idea of \"structured YOLO\" has lead him to this point in his career. He talks about how his job at Forem and how the pandemic led to his livestreaming, where he tries to make coding as realistic as possible. His hour and a half livestreams focus on one issue, but realistically those issues won't be solved during that time. And that's ok, because coding takes time, and working through issues won't always be a simple solution. His approach to teaching includes learning as you go, which made him an amazing contributor, mentor, and maintainer for the Virtual Coffee Hacktoberfest Initiative. Every conversation with Nick is an interesting one, and this one isn't an exception.</p><h4 class=\"text-left\"><strong>Links:</strong></h4><ul><li><p>Nick: <a href=\"https://dev.to/nickytonline\" rel=\"noopener noreferrer\" target=\"_blank\">https://dev.to/nickytonline</a></p></li><li><p>Forem: <a href=\"https://www.forem.com/\" rel=\"noopener noreferrer\" target=\"_blank\">https://www.forem.com/</a></p></li></ul>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/0101-nickyt-episode.jpg",
+		"guests": [
+			{
+				"name": "Nick Taylor",
+				"bio": "<p>Senior Software Engineer at <a href=\"https://www.forem.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Forem</a>, the software that powers <a href=\"https://dev.to/\" rel=\"noopener noreferrer\" target=\"_blank\">DEV</a>, working on all things Forem.</p><ul><li><p><a href=\"https://iamdeveloper.com/\" rel=\"noopener noreferrer\" target=\"_blank\">iamdeveloper.com</a></p></li><li><p><a href=\"https://livecoding.ca/\" rel=\"noopener noreferrer\" target=\"_blank\">livecoding.ca</a></p></li><li><p><a href=\"https://twitter.com/nickytonline\" rel=\"noopener noreferrer\" target=\"_blank\">twitter.com/nickytonline</a></p></li><li><p><a href=\"https://dev.to/nickytonline\" rel=\"noopener noreferrer\" target=\"_blank\">dev.to/nickytonline</a></p></li><li><p><a href=\"https://iamdeveloper.com/hacktoberfest2020\" rel=\"noopener noreferrer\" target=\"_blank\">Getting the Most Out of Open Source</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/0101-nickyt.jpg"
+			}
+		],
+		"sponsors": []
+	},
+	{
+		"title": "Virtual Coffee Podcast Trailer",
+		"slug": "0000-trailer",
+		"id": "271",
+		"metaDescription": "Welcome to the Virtual Coffee Podcast!",
+		"season": 1,
+		"episode": 0,
+		"buzzsproutId": "7119532",
+		"publishDate": "2021-01-04T05:00:00+00:00",
+		"shortDescription": "<p>Welcome to the Virtual Coffee Podcast!</p>",
+		"showNotes": "<p>This is the Virtual Coffee Podcast, hosted by Bekah Hawrot Weigel and Dan Ott. You'll find interviews with members of our community to learn more about their stories, who they are, how they found Virtual Coffee, and how it has influenced their lives as developers. We want to bring everything that's special about Virtual Coffee, the intimacy and the friendships we’ve built, and share that with everyone through the podcast. We’re always growing and learning together as a group, and there’s something really special about being able to do that knowing that you’ll have the full support of the community around you. And that’s what this podcast is about too.</p>",
+		"episodeCard": "https://virtualcoffeeio-cms.imgix.net/podcast/virtual-coffee-mug-square.png",
+		"guests": [
+			{
+				"name": "Virtual Coffee IO",
+				"bio": "<ul><li><p><a href=\"https://virtualcoffee.io/podcast\" rel=\"noopener noreferrer\" target=\"_blank\">Virtual Coffee Podcast</a></p></li></ul>",
+				"headshot": "https://virtualcoffeeio-cms.imgix.net/podcast/virtual-coffee-mug-square.png"
+			}
+		],
 		"sponsors": []
 	}
 ]


### PR DESCRIPTION
## Summary

Replaces Craft CMS GraphQL queries with a fetch from `vc-data` (our own GitHub repo). This is the core change needed to stop paying for Craft CMS Pro.

**What changed:**
- `src/data/podcast.ts` no longer imports `graphql-request` or uses `CMS_URL`/`CMS_TOKEN`
- - Episode data is now fetched from `https://raw.githubusercontent.com/Virtual-Coffee/vc-data/main/podcast/episodes.json`
- - All 86 episodes are cached for 24 hours (same as before)
- - The same TypeScript interfaces are preserved — no changes needed in any page components
- - `getEpisodeQueryParams` is kept as a no-op stub for backwards compatibility
- - Transcript fetching from `feeds.virtualcoffee.io` is unchanged
**After merging this PR:**
1. Remove `CMS_URL` and `CMS_TOKEN` env vars from Vercel (confirm `events.ts` doesn't use them first — it does use `CMS_URL`, so remove only after events migration)
2. 2. Can uninstall `graphql-request` dep: `npm uninstall graphql-request`
3. 3. Cancel Craft CMS Pro subscription
## Related

Part of migrating off Craft CMS. See https://github.com/Virtual-Coffee/vc-data for the data repo and MIGRATION.md for the full plan.