### PR TITLE
Fix null user-agent crash in block-bots edge function

### DIFF
--- a/netlify/edge-functions/block-bots.js
+++ b/netlify/edge-functions/block-bots.js
@@ -45,7 +45,7 @@ const botUas = [
 ];
 
 export default async (request, context) => {
-	const ua = request.headers.get('user-agent');
+	const ua = request.headers.get('user-agent') ?? '';
 
 	let isBot = false;
 


### PR DESCRIPTION
## Linked Issue

N/A

## Description

Fixes a crash in the `block-bots` Netlify edge function that was taking down the entire site homepage with an \"edge function invocation failed\" error.

The function runs on every request (`/*`) and checks the `User-Agent` header against a list of known bots. When a request arrives with no `User-Agent` header, `request.headers.get('user-agent')` returns `null`. Calling `.toLowerCase()` on `null` throws an unhandled exception, crashing the edge function for all visitors.

**Fix:** Added a `?? ''` nullish coalescing fallback so a missing `User-Agent` is treated as an empty string (not a bot) rather than causing a crash.

## Methodology

The root cause was a missing null guard on the `user-agent` header value. Requests without a `User-Agent` are not bots in the traditional sense, so falling back to an empty string (which matches no bot patterns) is the correct behavior.

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)