### PR TITLE
feat: replace Dependabot with Renovate via shared org config preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["github>Virtual-Coffee/renovate-config"]
+}


### PR DESCRIPTION
## Linked Issue

_None._

## Description

Adds a `renovate.json` that opts this repo into [Renovate](https://docs.renovatebot.com/), extending the org's new shared preset repo, [`Virtual-Coffee/renovate-config`](https://github.com/Virtual-Coffee/renovate-config):

```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["github>Virtual-Coffee/renovate-config"]
}
```

That's the whole file — all dependency-update policy lives in the preset repo, so changing the schedule or grouping later is one PR there rather than one PR per repo.

**What the preset does:**

- Updates npm dependencies, GitHub Actions, and `.nvmrc`/`engines.node`.
- Runs **weekly** (Monday before 6am, America/New_York). Security fixes ignore the schedule and open immediately.
- **Major updates do not open PRs.** They're listed on a Dependency Dashboard issue with a checkbox, so breaking upgrades (`bootstrap` 4→5, the `unified`/`remark-*`/`rehype-*` ESM majors) get picked up deliberately instead of rotting as permanently-open PRs.
- **Groups** updates to keep PR count low: one PR for non-major devDependencies, one for all GitHub Actions, one for Node.
- **Monthly lockfile maintenance** to refresh transitive dependencies in `pnpm-lock.yaml`.
- **No automerge.** The preset repo offers an opt-in `:automerge` preset, but this repo deliberately does not extend it — see Methodology.

### Follow-up steps after merge (not in this PR)

1. Install the [Renovate GitHub App](https://github.com/apps/renovate) on the org, scoped to this repo. Needs an org owner.
2. Settings → Code security → **disable Dependabot security updates**, but **leave Dependabot alerts enabled** (Renovate reads GitHub's alert data to drive its own security PRs).
3. Close the currently-open Dependabot PRs (#1519, #1524, #1527, #1530, #1531, #1532) so Renovate re-raises them under its own grouping.

This should merge *before* the app is installed — otherwise Renovate opens its own "Configure Renovate" onboarding PR instead of using this config.

## Methodology

This repo has no `.github/dependabot.yml` and never has — `git log --all` on that path is empty. Dependabot has been running purely on GitHub's UI-level defaults with automated security fixes enabled. Two problems with that:

- **Nothing is reviewable.** Schedule, grouping, ignore rules, PR limits, and labels are all invisible defaults that can't be changed in a PR or seen by contributors.
- **Coverage is narrow.** The three workflows in `.github/workflows/` are unmanaged (`actions/checkout@v3` is several majors stale), and transitive dependencies only move when a security advisory fires.

Renovate fixes both, and the shared-preset approach means the other ~9 active org repos can adopt the same policy with a three-line file instead of a copy-pasted config that drifts.

**Why no automerge here:** there is no CI on `pull_request` in this repo — the only PR workflow is Prettier formatting, and Netlify deploy previews are the de facto build check. Automerging dependency bumps with nothing verifying a build would be unsafe. Adding a real CI workflow (`pnpm typecheck` + `pnpm lint` + `pnpm build`) would be a worthwhile follow-up and is the prerequisite for enabling `:automerge` here.

All preset files were validated with `renovate-config-validator --strict`, and the preset repo runs that validator in CI on every PR, since a broken preset would break Renovate in every repo extending it.

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)