### PR TITLE
docs: add CLAUDE.md and fix stale setup docs

### DIFF
--- a/.github/workflows/monthly-challenge-issue.yml
+++ b/.github/workflows/monthly-challenge-issue.yml
@@ -20,7 +20,7 @@ jobs:
             ## Issue Context
             *Add New Challenge to the Site*
 
-            You can use [June 2021](https://github.com/Virtual-Coffee/virtualcoffee.io/blob/main/app/routes/__frontend/monthlychallenges/june-2021.jsx) as kind of a template
+            You can use one of the existing pages in [src/app/monthlychallenges/(challenges)](https://github.com/Virtual-Coffee/virtualcoffee.io/tree/main/src/app/monthlychallenges/(challenges)) as a template
 
             ## Steps
             - [ ] Follow the instructions for [creating monthly challenge pages](https://github.com/Virtual-Coffee/virtualcoffee.io/#monthly-challenges)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+virtualcoffee.io is a Next.js 15 App Router site (React 19, TypeScript, Bootstrap 4.6 SCSS, no Tailwind) deployed on Netlify. Content is a mix of checked-in MDX/TS and build-time fetches from GitHub, a Craft CMS, and Airtable, all of which fall back to mock data when credentials are absent.
+
+## Commands
+
+pnpm is enforced (`preinstall` runs `only-allow pnpm`). Node >= 24.20 (`.nvmrc`).
+
+| Task                                       | Command                                                                                                                                |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Install                                    | `pnpm install` (copy `.env.example` to `.env` first)                                                                                   |
+| Dev server                                 | `pnpm dev` — regenerates member barrels, then runs `npm-watch` + `netlify dev` (site on http://localhost:9000, proxying Next on :3000) |
+| Next only (no Netlify functions/redirects) | `next dev`                                                                                                                             |
+| Build                                      | `pnpm build` — `prebuild` runs the member codegen first                                                                                |
+| Typecheck                                  | `pnpm typecheck` (`tsc --noEmit`)                                                                                                      |
+| Lint                                       | `pnpm lint` (ESLint flat config: `next/core-web-vitals` + `next/typescript`; `netlify/**` is ignored)                                  |
+| Format                                     | `pnpm format` (Prettier: tabs, single quotes, trailing commas; a GitHub Action auto-formats PRs; there is no husky/lint-staged hook)   |
+| Regenerate member barrels                  | `pnpm build-member-files`                                                                                                              |
+
+There is no test suite and no test runner. CI does not run lint/typecheck/build on PRs; Netlify runs `pnpm build`. Run `pnpm typecheck && pnpm lint` before finishing a change.
+
+`@/*` maps to `./src/*`.
+
+## Architecture
+
+### Data sources and the mock gate
+
+Every external data source lives in `src/data/` and degrades to mocks when its env var is missing:
+
+| Source                                         | File                              | Env var                   | Fallback                               |
+| ---------------------------------------------- | --------------------------------- | ------------------------- | -------------------------------------- |
+| Member GitHub profiles                         | `src/data/members/index.ts`       | `GITHUB_TOKEN`            | `src/data/mocks/memberData.js` (faker) |
+| GitHub Sponsors                                | `src/data/sponsors.ts`            | `GITHUB_TOKEN`            | `src/data/mocks/sponsors.ts`           |
+| Events (Craft CMS + Solspace Calendar GraphQL) | `src/data/events.ts`              | `CMS_URL`, `CMS_TOKEN`    | `src/data/mocks/events.ts`             |
+| Monthly challenge counters                     | `src/data/monthlyChallenges/*.ts` | `PUBLIC_AIRTABLE_API_KEY` | empty data                             |
+| Form submissions (server actions)              | `src/util/airtable/action.ts`     | `FORMS_AIRTABLE_API_KEY`  | error state returned to the form       |
+
+`src/data/mocks/index.ts` exports `assertMocksAllowed()`, which throws when Netlify's `CONTEXT === 'production'`. Any new external fetch should follow this pattern: try the API, fall back to a mock guarded by `assertMocksAllowed`. Fetches are wrapped in `unstable_cache` with a tag (`members`, `events`, `mdx-routes`); `/_cache?tag=…&path=…` (`src/app/%5Fcache/route.ts`) revalidates on demand and a daily GitHub Action triggers a Netlify rebuild.
+
+Podcast episodes are a checked-in JSON snapshot (`src/data/podcast/episodes.json`) copied from the `vc-data` repo; the update procedure is in the comment at the top of `src/data/podcast.ts`. Newsletters are local JSX files under `src/content/newsletters/` listed in `src/data/newsletters.ts`.
+
+### Members pipeline (generated files)
+
+- One file per member in `src/content/members/members/<github-username>.ts` (core team in `core/`), exporting a `MemberObject` (`src/content/members/types.ts`). Template: `_EXAMPLE.ts`.
+- `scripts/loadMemberFiles.ts` generates `src/data/members/core.ts` and `src/data/members/members.ts` as barrel re-exports. **These two files are gitignored and generated — never hand-edit them; run `pnpm build-member-files` after adding a member.**
+- `getMembers()` merges the local overrides with GitHub GraphQL data (batched 15 logins per query) and team membership from `src/content/members/teams.ts`.
+
+### MDX content pipeline
+
+- `next.config.mjs` configures `@next/mdx` with remark-frontmatter, a locally defined TOC plugin (replaces a `## Table of Contents` heading with a generated list), rehype-slug, rehype-autolink-headings (h2/h3), and rehype-highlight.
+- `src/util/loadMdx.server.ts` walks a content directory and reads only frontmatter (`meta.title`, `meta.description`, `hero`, `order`); the page then dynamically `import()`s the `.mdx` file itself.
+- Routes: `src/app/(simple-mdx)/[...slug]/page.tsx` serves `src/content/simple-mdx-pages/*.mdx`; `src/app/resources/[[...slug]]/page.tsx` serves the nested `src/content/resources/` tree (`index.mdx` is a directory's own page, siblings are children sorted by `order`). Both are `force-static` with `dynamicParams = false`. Adding a resource is just adding an `.mdx` file with frontmatter; index listings come from `<FileIndex />` (`src/components/content/FileIndex.tsx`).
+- `src/mdx-components.tsx` is a passthrough; MDX files import components explicitly from `@/components/content/`.
+- The site nav (`src/components/Nav.tsx`) is hand-written, not derived from content.
+
+### Layout, styling, HTML safety
+
+- `src/components/layouts/DefaultLayout.tsx` is the only page layout; every page wraps its content in it (`Hero`, `heroHeader`, `heroSubheader`, `simple` props). Root layout in `src/app/layout.tsx` imports `src/styles/main.scss`.
+- Styles are à-la-carte Bootstrap 4.6 SCSS partials plus per-feature partials in `src/styles/`; markup uses Bootstrap classes and a custom `prose` class. Legacy Sass `@import` deprecations are silenced in `next.config.mjs`.
+- All HTML from external sources goes through `src/util/sanitizeCmsData.ts` (`sanitizeHtml` / `sanitizeCmsData`); `src/util/markdown.server.ts` deliberately uses this instead of rehype-sanitize so there is one allowlist.
+- The `.server.ts` suffix marks server-only modules (a Remix holdover); it is a naming convention, not enforced.
+
+### Netlify
+
+- `netlify/functions/join-coffee.ts` and `join-slack.ts` are redirect functions (env: `ZOOM_TUESDAYS`, `ZOOM_THURSDAYS`, `SLACK_JOIN_LINK`); `netlify/edge-functions/block-bots.js` returns 401 to AI-scraper user agents on every path.
+- `netlify.toml` holds the legacy 301 map, the `/join-*` rewrites, a `/bots/*` proxy to a Cloudflare Worker, and the Plausible analytics proxy. Add new URL redirects there, not in Next config.
+
+## Content conventions
+
+- Monthly challenges: prose lives in `src/app/monthlychallenges/page.tsx` (`challengeList`) plus one static page per month under `src/app/monthlychallenges/(challenges)/<mon-year>/`. Follow the process in the VC Community Building Resources "Monthly Challenge Technical Guidelines" linked from the README.
+- Member emoji must be standard Unicode; maintainers reject PRs otherwise.
+- PRs should link an issue (`Closes #123`); the PR template asks for Description and Methodology sections.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ You can refer to our resource on [how to write an issue](https://virtualcoffee.i
 
 > ⚠️ **Heads up!** If you'd like to work on issues, please make sure you **create a new branch and work in this branch** to avoid pushing your changes directly into the `main` branch.
 
-- Follow the steps for local development [in our README](README.md#local-development).
+- Follow the steps for local development [in our README](README.md#local-development-setup).
 - Create a new branch by typing this command on the terminal:
 
   ```bash

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ cd virtualcoffee.io
 
 ### 3. Install dependencies
 
-This repo requires `node`, `pnpm`, and the [Netlify CLI](https://www.netlify.com/products/dev/) to get started.
+This repo requires `node` and `pnpm` to get started. The [Netlify CLI](https://www.netlify.com/products/dev/) is installed as a project dependency, so you don't need to install it globally.
 
 #### Installing `node`:
 
-The best way to install `node` is to [download the installer](https://nodejs.org/en/) from their site. This repo requires node version 22.20.
+The best way to install `node` is to [download the installer](https://nodejs.org/en/) from their site. This repo requires node version 24.20 (see `.nvmrc`).
 
 If you already have a different version of `node` installed, but don't want to update globally, you can install [a package called `nvm`](https://github.com/nvm-sh/nvm), which will allow you to easily switch `node` versions. Once you have `nvm` installed (or if you already have it installed), you can run `nvm use` in the main directory and it will install the proper version of `node`.
 
@@ -89,7 +89,7 @@ cp .env.example .env
 
 #### Installing package dependencies
 
-Once you have `node`, `pnpm`, and the Netlify CLI installed, you're ready to install the local dependencies! Run the following command:
+Once you have `node` and `pnpm` installed, you're ready to install the local dependencies! Run the following command:
 
 ```shell
 pnpm install
@@ -137,7 +137,7 @@ Builds a production-ready version of the site. This is what Netlify uses to buil
 pnpm format
 ```
 
-Runs [Prettier](https://prettier.io/) on all of our files. This happens automatically via [husky](https://github.com/typicode/husky) and [lint-staged](https://github.com/okonet/lint-staged), so there's usually no need to run this manually.
+Runs [Prettier](https://prettier.io/) on all of our files. A GitHub Action also formats changed files automatically on pull requests, so there's usually no need to run this manually.
 
 ### `pnpm lint`
 
@@ -146,6 +146,22 @@ pnpm lint
 ```
 
 Runs [ESLint](https://eslint.org/) on all of our files, so you can check for errors or warnings. This happens automatically at build time.
+
+### `pnpm typecheck`
+
+```shell
+pnpm typecheck
+```
+
+Runs the TypeScript compiler (`tsc --noEmit`) to check for type errors without producing output.
+
+### `pnpm build-member-files`
+
+```shell
+pnpm build-member-files
+```
+
+Regenerates `src/data/members/core.ts` and `src/data/members/members.ts` from the files in `src/content/members/`. These generated files are gitignored. `pnpm dev` and `pnpm build` run this for you, and the dev watcher re-runs it whenever a member file changes.
 
 ## Loading data
 


### PR DESCRIPTION
## Linked Issue

N/A

## Description

- Adds `CLAUDE.md` with the commonly used commands and a high-level architecture summary (data sources and mock gating, generated member barrels, MDX pipeline, layout/styling, Netlify functions and redirects) for Claude Code sessions.
- README corrections:
  - Node version is 24.20 (matches `.nvmrc` and `engines`), not 22.20.
  - The Netlify CLI is a devDependency, so it no longer needs a separate global install.
  - Prettier runs via the GitHub Action on PRs; husky and lint-staged are not in the repo.
  - Documents the existing `pnpm typecheck` and `pnpm build-member-files` scripts.
- CONTRIBUTING: fixes the README anchor (`#local-development-setup`).
- Monthly challenge issue workflow: replaces the deleted Remix-era template path with the current `src/app/monthlychallenges/(challenges)` directory.

## Methodology

While generating `CLAUDE.md`, each README claim was cross-checked against `package.json`, `.nvmrc`, `.github/workflows/`, and the source tree. The inaccuracies found are fixed here so the README and CLAUDE.md agree. All edited files pass `prettier --check`.

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)