### PR TITLE
fix: decode the podcast slug so non-ASCII episodes stop 404ing

### DIFF
--- a/src/app/podcast/[slug]/page.tsx
+++ b/src/app/podcast/[slug]/page.tsx
@@ -20,9 +20,26 @@ export async function generateStaticParams() {
 	}));
 }
 
+/**
+ * Route params arrive percent-encoded, while `episodes.json` stores slugs as
+ * written — two episodes have a non-ASCII character in theirs (`jörn`,
+ * `ramón`), so an undecoded lookup misses them and the page 404s.
+ *
+ * `decodeURIComponent` throws on a malformed escape like a bare `%`, which
+ * anyone can type into the address bar; falling back to the raw slug turns that
+ * into the 404 below rather than a 500.
+ */
+function decodeSlug(slug: string) {
+	try {
+		return decodeURIComponent(slug);
+	} catch {
+		return slug;
+	}
+}
+
 async function getEpisodeData(slug: string) {
 	const episode = await getEpisode({
-		slug: slug,
+		slug: decodeSlug(slug),
 		// TODO: enable CMS previews
 		// queryParams: getEpisodeQueryParams(request),
 	});


### PR DESCRIPTION
## Linked Issue

None — found while reading a build log on #1557. Unrelated to that PR, so it is on its own branch
off `main`.

## Description

Two podcast episodes return **404 in production today**:

- `/podcast/jörn-bernhardt-becoming-a-founder`
- `/podcast/ramón-huidobro-thoughtful-learning`

They are the only two episodes in `src/data/podcast/episodes.json` whose slug contains a non-ASCII
character. Both are linked from inside the site — `src/content/newsletters/2023-03.jsx:224`,
`src/content/newsletters/2023-04.jsx:111`, and the podcast index, which builds its links from
``url: `/podcast/${e.slug}` `` — so they are reachable dead ends rather than orphans.

One decode in `getEpisodeData`, the single point both `generateMetadata` and the page component
funnel through.

## Methodology

`generateStaticParams` returns the slug as written (`jörn-…`). Next percent-encodes it into the
route path and hands `params.slug` back **encoded** (`j%C3%B6rn-…`). `getEpisode` then does an exact
compare against the raw slug in the data — `allMappedEpisodes.find((e) => e.slug === slug)`
(`src/data/podcast.ts:168`) — misses, and the route calls `notFound()`.

Nothing is wrong with the data; the mismatch is purely encoded-vs-decoded.

Decoding at the route rather than inside `getEpisode`, because the encoding is introduced by the
routing layer and the data layer should keep comparing real slugs. `generateStaticParams` keeps
returning raw slugs — that is what Next expects, and it is what gets the pages built at all.

`decodeURIComponent` throws a `URIError` on a malformed escape like a bare `%`, which anyone can put
in the address bar, and an uncaught throw here would turn a 404 into a 500 — hence the try/catch
falling back to the raw slug.

**Worth noting how long this hid.** The route calls `notFound()` instead of throwing, so the build
stays green and Netlify deploys happily. The only signal was a `console.error` in the build log:

```
Episode not found - j%C3%B6rn-bernhardt-becoming-a-founder
Episode not found - ram%C3%B3n-huidobro-thoughtful-learning
```

## Verification

`pnpm typecheck` and `pnpm build` pass, and the build log no longer contains `Episode not found` —
that string is the regression test here, since the build is green either way.

Against `pnpm dev`:

| URL | Before | After |
| --- | --- | --- |
| `/podcast/j%C3%B6rn-bernhardt-becoming-a-founder` | 404 | **200** |
| `/podcast/ram%C3%B3n-huidobro-thoughtful-learning` | 404 | **200** |
| same two, human-readable form | 404 | **200** |
| `/podcast/0101-nickyt` (control) | 200 | 200 |
| `/podcast/does-not-exist` | 404 | 404 |

Both pages render their title (`Jörn Bernhardt - Becoming a Founder`,
`Ramón Huidobro - Thoughtful Learning`), guest headshot, transcript and `og:image`.

`pnpm lint` reports the 34 warnings that exist on `main` today; this change adds none, and #1557
clears them.

## Scope

These are the only non-ASCII slugs in `episodes.json`, and no file under `src/content/resources/` or
`src/content/simple-mdx-pages/` has a non-ASCII name, so no other dynamic route is affected.
