### PR TITLE
chore: add a content team to CODEOWNERS, and fix the shadowed default owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,39 @@
 # Code Owners
-# see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# ORDER IS LOAD-BEARING. The LAST matching pattern wins outright; rules are not
+# additive. Two `*` lines do not mean "both teams own everything" — the second
+# silently replaces the first. To give a path several owners, list them all on
+# ONE line. Any one of the listed owners can then satisfy the review.
+#
+# Code-owner review is enforced by the `main (pr-merges)` ruleset, so a mistake
+# here can block every PR. Teams must be visible (not secret) AND have explicit
+# write access, or they are ignored without error.
 
-* @Virtual-Coffee/maintainers
-* @Virtual-Coffee/super-contributors
+# --- Default owners: everything not matched by a more specific rule below ---
+# This intentionally covers src/content/members/** — routine member-profile PRs
+# should not be gated on the content team.
+*                               @Virtual-Coffee/maintainers @Virtual-Coffee/super-contributors
+
+# --- Site content ---
+# Prose and editorial assets. Content Team is auto-requested here; super-contributors
+# remain listed so content is never blocked waiting on a single team.
+
+# MDX prose: resources tree, handbook, and standalone pages
+src/content/resources/          @Virtual-Coffee/content-team @Virtual-Coffee/super-contributors
+src/content/simple-mdx-pages/   @Virtual-Coffee/content-team @Virtual-Coffee/super-contributors
+
+# Newsletters. Covers today's .jsx issues, the hand-maintained import registry,
+# and any .mdx that lands in the same directory after the planned migration.
+src/content/newsletters/        @Virtual-Coffee/content-team @Virtual-Coffee/super-contributors
+src/data/newsletters.ts         @Virtual-Coffee/content-team @Virtual-Coffee/super-contributors
+
+# Monthly challenges. Currently route files under src/app/; the second path is a
+# no-op until the MDX migration moves them under src/content/.
+src/app/monthlychallenges/      @Virtual-Coffee/content-team @Virtual-Coffee/super-contributors
+src/content/monthlychallenges/  @Virtual-Coffee/content-team @Virtual-Coffee/super-contributors
+
+# Editorial assets. public/assets/svg/ is deliberately excluded: it feeds the
+# `pnpm build-undraw-ratios` codegen and is engineering-owned.
+public/assets/images/           @Virtual-Coffee/content-team @Virtual-Coffee/super-contributors
+public/assets/pdfs/             @Virtual-Coffee/content-team @Virtual-Coffee/super-contributors


### PR DESCRIPTION
## Linked Issue

None — housekeeping, raised directly.

## Description

Rewrites the root `CODEOWNERS`. Two changes:

**1. Fixes a silent bug in the default owners.** The file had two `*` lines:

```
* @Virtual-Coffee/maintainers
* @Virtual-Coffee/super-contributors
```

CODEOWNERS is **last-match-wins, not additive** — [per GitHub's docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners), "the last matching pattern takes the most precedence." So the second line *replaced* the first rather than adding to it, and `@maintainers` were not code owners of anything. #1376 ("Add Super Contributor permissions") meant to add owners and instead removed maintainers. The two lines are now collapsed into one, which is how you actually give a path multiple owners.

**2. Adds `@Virtual-Coffee/content-team` as an owner of the site's prose**, covering:

| Path | Notes |
| --- | --- |
| `src/content/resources/` | 41 MDX files — handbook + developer resources |
| `src/content/simple-mdx-pages/` | about, code-of-conduct, uses |
| `src/content/newsletters/` | today's `.jsx` issues |
| `src/data/newsletters.ts` | the hand-maintained import registry, edited with every new issue |
| `src/app/monthlychallenges/` | current per-month pages |
| `src/content/monthlychallenges/` | matches nothing yet — see below |
| `public/assets/images/`, `public/assets/pdfs/` | editorial assets |

`@super-contributors` are listed alongside the content team on every content line, so an approval from *either* team satisfies the review and content PRs never block on one small team's availability.

Two deliberate exclusions:

- **`src/content/members/**` falls through to the default owners.** These are 200+ high-volume, self-service onboarding PRs already guarded by the `vc/member-file-identity` ESLint rule and CI; routing them through an editorial team would be all cost and no benefit.
- **`public/assets/svg/` is excluded** from the content assets rule — it feeds the `pnpm build-undraw-ratios` codegen and is engineering-owned.

`src/content/monthlychallenges/` matches nothing today. It is written now so the rules stay correct after newsletters and monthly challenges convert to MDX. Patterns that match no files are harmless: GitHub only reports errors for invalid syntax and unresolvable owners, never for paths that don't exist yet.

I also documented the last-match-wins semantics in a header comment, so the next person adding a team doesn't reintroduce the same shadowing.

## Methodology

We want site prose reviewed by the people who own editorial quality, rather than only by whoever happens to hold repo write access — and we want the ownership rules to still be correct after the planned newsletter/monthly-challenge MDX migration, instead of needing a second pass then.

Investigating that surfaced the shadowing bug, which turned out to matter more than it looks. The `main (pr-merges)` ruleset is active with `require_code_owner_review: true`, so code-owner review is genuinely enforced. With maintainers shadowed out, only the four super-contributors could actually satisfy a required review; maintainers were merging on their ruleset bypass rather than as owners. Nothing surfaced this, because `GET /codeowners/errors` returns `[]` — duplicate `*` lines are valid syntax, just semantically self-defeating. It had to be found by reading.

The alternative considered was making the content team the *sole* owner of content paths, which is a stricter editorial gate. Rejected for now: with code-owner review enforced, a sole owner means content PRs stall whenever that team is unavailable, and for a volunteer org that trade lands badly. Shared ownership still auto-requests the content team on every content PR, so review-by-default is preserved without the bottleneck. Worth revisiting once the team has a track record.

> [!IMPORTANT]
> **`@Virtual-Coffee/content-team` must exist with `closed` visibility and explicit write access before this merges.** A team that is secret or lacking write access is ignored as a code owner *without an error*. Until then the content lines still work via `@super-contributors`, but the content team won't be requested.
>
> Note this means write access to the whole repo, not just content paths — GitHub has no narrower permission that satisfies CODEOWNERS. That's the real cost of the gate and worth an explicit yes.

### Verification

- All eight referenced paths confirmed to exist (`src/content/monthlychallenges/` intentionally absent).
- Prettier skips the file (`--ignore-unknown`, no parser for an extensionless file), so no format churn.
- `pnpm codegen && pnpm typecheck && pnpm lint` pass — no code changes here, so nothing else to exercise.
- After merge, `GET /repos/Virtual-Coffee/virtualcoffee.io/codeowners/errors` should stay `[]`, and a PR touching a non-content file should request *both* default teams.

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)
