### PR TITLE
fix(bots): block Datadog Synthetics again

### DIFF
--- a/scripts/checkBotMatching.ts
+++ b/scripts/checkBotMatching.ts
@@ -112,6 +112,15 @@ const cases: [ua: string, expected: 'allow' | 'block', why: string][] = [
 		'Baiduspider must not match the Spider token',
 	],
 
+	// Datadog Synthetics is hand-carried, and its two test types identify
+	// differently — the second has a `/` where the token boundary falls.
+	[
+		'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 DatadogSynthetics',
+		'block',
+		'Datadog browser test',
+	],
+	['Datadog/Synthetics', 'block', 'Datadog API test'],
+
 	// Ordinary people.
 	[
 		'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36',

--- a/src/data/botOverrides.ts
+++ b/src/data/botOverrides.ts
@@ -77,6 +77,8 @@ export const extraBlocked = [
 	'DataForSeoBot',
 	'magpie-crawler',
 	'peer39_crawler',
+	// Third-party synthetic monitoring, never asked for here and heavy enough to
+	// notice. Not upstream's remit, so it can only live here.
 	'DatadogSynthetics',
 ];
 

--- a/src/data/botOverrides.ts
+++ b/src/data/botOverrides.ts
@@ -77,6 +77,7 @@ export const extraBlocked = [
 	'DataForSeoBot',
 	'magpie-crawler',
 	'peer39_crawler',
+	'DatadogSynthetics',
 ];
 
 /**

--- a/src/data/botOverrides.ts
+++ b/src/data/botOverrides.ts
@@ -78,8 +78,11 @@ export const extraBlocked = [
 	'magpie-crawler',
 	'peer39_crawler',
 	// Third-party synthetic monitoring, never asked for here and heavy enough to
-	// notice. Not upstream's remit, so it can only live here.
+	// notice. Not upstream's remit, so it can only live here. Browser tests
+	// append `DatadogSynthetics` to a Chrome UA; API tests send
+	// `Datadog/Synthetics`, and the `/` is a token boundary, so both are named.
 	'DatadogSynthetics',
+	'Datadog/Synthetics',
 ];
 
 /**

--- a/src/data/bots.ts
+++ b/src/data/bots.ts
@@ -50,6 +50,7 @@ export const blockedUas = [
 	'Crawl4AI',
 	'Crawlspace',
 	'Cursor',
+	'DatadogSynthetics',
 	'DataForSeoBot',
 	'Datenbank Crawler',
 	'DeepSeekBot',

--- a/src/data/bots.ts
+++ b/src/data/bots.ts
@@ -50,6 +50,7 @@ export const blockedUas = [
 	'Crawl4AI',
 	'Crawlspace',
 	'Cursor',
+	'Datadog/Synthetics',
 	'DatadogSynthetics',
 	'DataForSeoBot',
 	'Datenbank Crawler',


### PR DESCRIPTION
## Linked Issue

No issue — a small follow-up to #1565.

## Description

Adds Datadog Synthetics back to the block list, as two tokens in `extraBlocked` in `src/data/botOverrides.ts`:

- `DatadogSynthetics` — browser tests append this to an ordinary Chrome UA.
- `Datadog/Synthetics` — API/HTTP tests send this on its own.

`src/data/bots.ts` is regenerated from that (`pnpm build-bot-list`), so both land in `blockedUas` — `Disallow: /` in robots.txt and a 403 from the edge function. `scripts/checkBotMatching.ts` gains a case for each.

## Methodology

#1565 dropped `DatadogSynthetics` from the old hand-written list on the grounds that it isn't an AI scraper. That's still true, but it's also not a crawler anyone here asked for: Datadog Synthetics is uptime/browser monitoring, and the traffic is someone else's account running checks against virtualcoffee.io. Netlify's top user agents for the last 24 hours:

| User agent | Requests | Bandwidth |
| --- | ---: | ---: |
| `… Firefox/155 DatadogSynthetics` | 655.8K | 7.26 GB |
| `… Chrome/152 DatadogSynthetics` | 653.6K | 7.24 GB |
| `… Chrome/152 Edg/152 DatadogSynthetics` | 652.9K | 7.23 GB |
| `Datadog/Synthetics` | 31.7K | 4.33 GB |

Roughly two million requests and 26 GB a day, all of it monitoring nobody here set up. The old list blocked it for a reason, and this restores that.

**Why two tokens.** The matcher fences tokens on `/` (it's what keeps `vscode` from tripping the `Code` token), so `DatadogSynthetics` alone matches the browser-test UA but lets `Datadog/Synthetics` straight through the edge. Verified against the matcher before adding the second one.

**Why an override.** Upstream (`ai-robots-txt/ai.robots.txt`) only tracks AI crawlers and will never carry it — same reason the Awario, DataForSeo, magpie and peer39 entries live in `extraBlocked`. Regenerating from the pinned release reproduces the committed file, so the weekly refresh workflow won't see drift.

## Verification

`pnpm build-bot-list` leaves `src/data/bots.ts` byte-identical; `pnpm check-bot-matching` passes (22 cases, 176 tokens, no token in two tiers).

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)
