### PR TITLE
fix(bots): actually run the edge block on deploys, and log what it refuses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ Unlike the other codegen it is **checked in**, so it is not part of `pnpm codege
 
 ### Netlify
 
-- `netlify/functions/join-coffee.ts` and `join-slack.ts` are redirect functions (env: `ZOOM_TUESDAYS`, `ZOOM_THURSDAYS`, `SLACK_JOIN_LINK`). `netlify/edge-functions/block-bots.ts` returns 403 to harvesting user agents on every path — on deploys only, since it is skipped in local dev unless `BLOCK_BOTS_LOCAL=true`, and it lets user-initiated agents through. Its list is `src/data/bots.ts` (see [The bot list](#the-bot-list-generated-but-checked-in)); it imports that with an explicit `.ts` extension because it bundles for Deno.
+- `netlify/functions/join-coffee.ts` and `join-slack.ts` are redirect functions (env: `ZOOM_TUESDAYS`, `ZOOM_THURSDAYS`, `SLACK_JOIN_LINK`). `netlify/edge-functions/block-bots.ts` returns 403 to harvesting user agents on every path — on deploys only, since it is skipped in local dev unless `BLOCK_BOTS_LOCAL=true` is set in `.env` (the CLI does not pass plain process env vars to edge functions), and it lets user-initiated agents through. It reads the deploy context from `context.deploy.context` (`Netlify.env.get('CONTEXT')` is build-scope and undefined at the edge), and logs one `[blocked]` line per refusal — `[dev bypass]` locally, where it matches but does not refuse. Its list is `src/data/bots.ts` (see [The bot list](#the-bot-list-generated-but-checked-in)); it imports that with an explicit `.ts` extension because it bundles for Deno.
 - `netlify.toml` holds the legacy 301 map, the `/join-*` rewrites, a `/bots/*` proxy to a Cloudflare Worker, and the Plausible analytics proxy. Add new URL redirects there, not in Next config.
 
 ## Content conventions

--- a/netlify/edge-functions/block-bots.ts
+++ b/netlify/edge-functions/block-bots.ts
@@ -18,16 +18,30 @@ const isBlocked = createBotMatcher(blockedUas);
 // Returning undefined bypasses the edge function, so there is nothing here to
 // await.
 const blockBots: EdgeFunction = (request, context) => {
-	const onDeploy = deployContexts.includes(context.deploy.context);
-	if (!onDeploy && Netlify.env.get('BLOCK_BOTS_LOCAL') !== 'true') return;
-
 	const ua = request.headers.get('user-agent') ?? '';
 
 	// Allowed wins. An agent fetching a page because someone asked for it is a
 	// person reading the site through a different client, and several of them
 	// name openai.com or a sibling crawler in the same string.
 	if (isAllowed(ua)) return;
-	if (!isBlocked(ua)) return;
+	const token = isBlocked(ua);
+	if (token === null) return;
+
+	// Matching runs before the deploy gate so that local dev still reports what
+	// production would refuse, just under a different tag.
+	const onDeploy = deployContexts.includes(context.deploy.context);
+	const enforce = onDeploy || Netlify.env.get('BLOCK_BOTS_LOCAL') === 'true';
+
+	// One line per refusal. The list changes weekly and the gate above once
+	// failed silently for weeks; this is the cheapest evidence the block works.
+	// The UA goes last, quoted, because it is the one free-text field.
+	const { method } = request;
+	const { pathname } = new URL(request.url);
+	console.log(
+		`[${enforce ? 'blocked' : 'dev bypass'}] ${token} ${method} ${pathname} ip=${context.ip} req=${context.requestId} ua=${JSON.stringify(ua)}`,
+	);
+
+	if (!enforce) return;
 
 	return new Response(
 		'Automated crawling of virtualcoffee.io is not permitted. See /robots.txt\n',

--- a/netlify/edge-functions/block-bots.ts
+++ b/netlify/edge-functions/block-bots.ts
@@ -2,19 +2,23 @@ import type { EdgeFunction } from '@netlify/edge-functions';
 import { allowedUas, blockedUas } from '../../src/data/bots.ts';
 import { createBotMatcher } from '../../src/data/botMatcher.ts';
 
-// Netlify sets CONTEXT to one of these on a real deploy and leaves it unset
-// under `netlify dev`. Test for a deploy positively — there is nothing to
-// protect on a laptop, and a silent 403 there reads as an auth bug.
+// Netlify reports one of these as `context.deploy.context` on a real deploy,
+// and `dev` under `netlify dev`. Test for a deploy positively — there is
+// nothing to protect on a laptop, and a silent 403 there reads as an auth bug.
+//
+// Read it from the context object, not `Netlify.env.get('CONTEXT')`: that is
+// a build-scope variable and is undefined at the edge, which made this gate
+// fail closed on every production request.
 const deployContexts = ['production', 'deploy-preview', 'branch-deploy'];
 
 // Built once at module load rather than per request.
 const isAllowed = createBotMatcher(allowedUas);
 const isBlocked = createBotMatcher(blockedUas);
 
-// Returning undefined bypasses the edge function, so there is no use for the
-// `context` argument and nothing here to await.
-const blockBots: EdgeFunction = (request) => {
-	const onDeploy = deployContexts.includes(Netlify.env.get('CONTEXT') ?? '');
+// Returning undefined bypasses the edge function, so there is nothing here to
+// await.
+const blockBots: EdgeFunction = (request, context) => {
+	const onDeploy = deployContexts.includes(context.deploy.context);
 	if (!onDeploy && Netlify.env.get('BLOCK_BOTS_LOCAL') !== 'true') return;
 
 	const ua = request.headers.get('user-agent') ?? '';

--- a/scripts/checkBotMatching.ts
+++ b/scripts/checkBotMatching.ts
@@ -22,6 +22,25 @@ function verdict(ua: string) {
 	return isBlocked(ua) ? 'block' : 'allow';
 }
 
+/**
+ * Which list entry fires. The edge function logs this, so it has to be the
+ * token as written in the list, not however the header happened to spell it.
+ */
+const tokenCases: [ua: string, expected: string, why: string][] = [
+	['Datadog/Synthetics', 'Datadog/Synthetics', 'a token containing a slash'],
+	[
+		'Mozilla/5.0 (X11; Linux x86_64; rv:155) Gecko/20100101 Firefox/155 DatadogSynthetics',
+		'DatadogSynthetics',
+		'a token at the end of a browser UA',
+	],
+	['Code/1.2.3', 'Code', 'a short token'],
+	[
+		'mozilla/5.0 (compatible; gptbot/1.1; +https://openai.com/gptbot)',
+		'GPTBot',
+		'reported in list casing, not header casing',
+	],
+];
+
 const cases: [ua: string, expected: 'allow' | 'block', why: string][] = [
 	// Training crawlers are the point of the list.
 	[
@@ -145,6 +164,16 @@ for (const [ua, expected, why] of cases) {
 	}
 }
 
+for (const [ua, expected, why] of tokenCases) {
+	const actual = isBlocked(ua);
+	if (actual !== expected) {
+		failures += 1;
+		console.error(
+			`✗ expected token ${expected}, got ${String(actual)}: ${why}\n    ${ua}`,
+		);
+	}
+}
+
 // A token in two tiers would make robots.txt both allow and disallow it.
 const tiers = new Map<string, string[]>();
 for (const [tier, list] of [
@@ -169,4 +198,6 @@ if (failures > 0) {
 	process.exit(1);
 }
 
-console.log(`Bot matching: ${cases.length} cases and ${tiers.size} tokens OK.`);
+console.log(
+	`Bot matching: ${cases.length} verdicts, ${tokenCases.length} token identities and ${tiers.size} tokens OK.`,
+);

--- a/src/data/botMatcher.ts
+++ b/src/data/botMatcher.ts
@@ -20,16 +20,23 @@ const escapeRegExp = (value: string) =>
 
 /**
  * Builds one case-insensitive pattern for the whole list. Returns a matcher
- * that is always false for an empty list, rather than a pattern that matches
- * everything.
+ * that gives back the list entry that fired — spelled as it is in the list,
+ * not as it appeared in the header — or `null` for no match. For an empty
+ * list it is always `null`, rather than a pattern that matches everything.
  */
 export function createBotMatcher(tokens: string[]) {
-	if (tokens.length === 0) return () => false;
+	if (tokens.length === 0) return () => null;
 
 	const pattern = new RegExp(
-		`(?:^|[^a-z0-9-])(?:${tokens.map(escapeRegExp).join('|')})(?:$|[^a-z0-9-])`,
+		`(?:^|[^a-z0-9-])(${tokens.map(escapeRegExp).join('|')})(?:$|[^a-z0-9-])`,
 		'i',
 	);
+	const byLowerCase = new Map(tokens.map((t) => [t.toLowerCase(), t]));
 
-	return (userAgent: string) => pattern.test(userAgent);
+	return (userAgent: string): string | null => {
+		const hit = pattern.exec(userAgent)?.[1];
+		return hit === undefined
+			? null
+			: (byLowerCase.get(hit.toLowerCase()) ?? null);
+	};
 }


### PR DESCRIPTION
## Linked Issue

No issue — follow-up to #1565 and #1566.

## Description

The edge function has never blocked anything. #1565 gated it on `Netlify.env.get('CONTEXT')`, but `CONTEXT` is a build-scope variable and is undefined at the edge, so `onDeploy` was `false` on every production request and the function returned before matching. Only `robots.txt` was ever in effect.

Two commits:

1. **Read the deploy context from `context.deploy.context`** — the second argument the function was ignoring. Netlify sets it to `production` / `deploy-preview` / `branch-deploy` on deploys and the CLI sets it to `dev` under `netlify dev`. `BLOCK_BOTS_LOCAL` stays as an env read; it's a runtime var and the CLI does inject it from `.env`.

2. **Log every refusal.** `createBotMatcher` now returns the list entry that fired (`string | null`, spelled as in the list) instead of a boolean, and the edge function matches *before* the deploy gate, so it writes one line per hit:

   ```
   [blocked] Datadog/Synthetics GET /about ip=203.0.113.9 req=01M28… ua="Datadog/Synthetics"
   [dev bypass] GPTBot GET /about ip=127.0.0.1 req=01M28… ua="Mozilla/5.0 (compatible; GPTBot/1.1; +https://openai.com/gptbot)"
   ```

   `[blocked]` when enforcing, `[dev bypass]` under `netlify dev` where it lets the request through. Token, method, path, client IP and request ID first; the raw UA last and quoted since it's the one free-text field. Every hit is logged — no sampling yet.

`scripts/checkBotMatching.ts` gains four token-identity cases (a slash token, a token at the end of a browser UA, a short token, and header-casing → list-casing), so the logged token can be trusted. `CLAUDE.md` notes the context read, the logging, and that `BLOCK_BOTS_LOCAL` must be in `.env`.

## Methodology

**How it surfaced.** #1566 merged at 12:30 with both Datadog tokens; production `robots.txt` had them within minutes. Netlify observability for 13:17–14:51 then showed 126K Datadog requests, 0.00% errors, reaching `/`, `/members` and the `/join` function. From outside:

| UA | `curl` status |
| --- | ---: |
| `Datadog/Synthetics` | 200 |
| `… Firefox/155 DatadogSynthetics` | 200 |
| `GPTBot/1.1` | 200 |

GPTBot getting a 200 is what pins it on the gate rather than the list.

**Why `context.deploy.context`.** Netlify's edge-functions environment docs: build-scope variables "are only available during the site build process and are not automatically accessible to edge functions." The `Context` type in `@netlify/types` carries `deploy: { context: string; id; published }`, and `netlify-cli/dist/lib/edge-functions/proxy.js` sets the `x-nf-deploy-context: dev` header locally. The old comment on the function said there was no use for the `context` argument; it was the argument that mattered.

**Why log, and why match before the gate.** This failed silently for weeks, and the check script can't see it — it exercises the matcher, not the Netlify runtime. One line per refusal is the cheapest evidence the block is running, and it makes Netlify's log search answer "what did we refuse today" directly. Matching before the gate means `netlify dev` reports what production would refuse instead of going quiet.

**Why the token, not a boolean.** A log line that says "blocked" without saying which entry fired is only half useful when the list is 176 tokens and regenerates weekly. Returning the list spelling (via a lowercase lookup, since the regex is case-insensitive) rather than the header's spelling keeps the log greppable by the same string that appears in `botOverrides.ts`.

**`BLOCK_BOTS_LOCAL` has to be in `.env`.** Found while verifying: the CLI only forwards env vars from `ui`, `account`, `addons`, `internal` and `.env` sources to edge functions (`edge-functions/registry.js`), so `BLOCK_BOTS_LOCAL=true pnpm dev` does nothing. `.env.example` already shows the `.env` form; `CLAUDE.md` now says so explicitly.

## Verification

`pnpm codegen && pnpm typecheck && pnpm lint && pnpm check-bot-matching` clean (22 verdicts, 4 token identities, 176 tokens).

Local, `netlify dev --offline`, `curl -A <ua> http://localhost:9000/about`:

| UA | bypass mode | `BLOCK_BOTS_LOCAL=true` in `.env` |
| --- | ---: | ---: |
| `Datadog/Synthetics` | 200, `[dev bypass] Datadog/Synthetics …` | 403, `[blocked] Datadog/Synthetics …` |
| `… Firefox/155 DatadogSynthetics` | 200, `[dev bypass] DatadogSynthetics …` | 403, `[blocked] DatadogSynthetics …` |
| `GPTBot/1.1` | 200, `[dev bypass] GPTBot …` | 403, `[blocked] GPTBot …` |
| `Claude-User/1.0` | 200, nothing logged | 200, nothing logged |
| Chrome 140 | 200, nothing logged | 200, nothing logged |

The 403 body is the plain-text refusal. (Locally each request logs five times — `/about`, `/about.html`, `/about.htm`, `/about/index.html`, `/about/index.htm` — because the dev proxy probes static-file candidates through the edge function; a real deploy runs it once.)

**Deploy preview** (`context.deploy.context === 'deploy-preview'`, the first place Netlify rather than the CLI supplies it), `curl -A <ua> https://deploy-preview-1567--virtual-coffee-io.netlify.app/about`:

| UA | status |
| --- | ---: |
| `Datadog/Synthetics` | 403 |
| `… Firefox/155 DatadogSynthetics` | 403 |
| `GPTBot/1.1` | 403 |
| `Claude-User/1.0` | 200 |
| Chrome 140 | 200 |

The 403 body is the plain-text refusal, and `/join` with the Datadog UA is 403 too — the function invocations those were driving stop. The `[blocked]` lines should be visible in the preview's edge function log in the Netlify UI.

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)
